### PR TITLE
close DD-002: Component-Model AI placement → option (b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ deductive-proof and bounded-model-checking layers do not staff.
   [Cousot framework](https://dl.acm.org/doi/10.1145/512950.512973)
   (POPL 1977) — explicitly named as the unstaffed layer in the
   [2026-04-22 overdo post](https://pulseengine.eu/blog/2026-04-22-overdoing-the-verification-chain/).
-- **post-meld by default, pre-meld when needed**. scry runs on the fused
-  Core Wasm module meld emits, so its invariants apply directly to
-  loom's transformation preconditions. Component-Model-level analysis
-  (handles, capabilities, host effects) runs upstream of meld on the
-  still-WIT-typed components.
+- **post-meld for Core Wasm, pre-meld for Component Model**. scry's
+  Core analysis runs on the fused module meld emits, so its invariants
+  apply directly to loom's transformation preconditions. Component-
+  Model analysis (handles, capabilities, host effects) runs upstream
+  of meld on the still-WIT-typed components; meld emits a minimal
+  `component-provenance` custom section so scry can project the
+  Component-Model invariants onto fused-module locations for loom,
+  witness, and the sigil/rivet evidence chain (DD-002).
 - **a reusable lattice library**. the abstract domains (interval,
   region-memory, reachability, taint, capability, resource-lifetime)
   ship as a separate crate (`wasm-lattice`) reusable by
@@ -198,7 +201,7 @@ are in `artifacts/requirements.yaml`; provisional ones for v0.2+ carry
 | v0.4 | compositional summary-based interprocedural AI per Stiévenart & De Roover SCAM 2020 | scaling benchmark on real fused PulseEngine modules; summary-precision metrics | (extends v0.3) | FEAT-007 |
 | v0.5 | loom integration: invariant schema v1; loom consumes scry output to trigger bounds-check elision + constant folding | end-to-end test on a meld→scry→loom pipeline; loom reports invariants-derived transforms | (extends v0.3) | FEAT-008 |
 | v0.6 | sigil attestation per scry run; rivet integration; full evidence-to-requirement traceability | DSSE-signed in-toto predicates; `rivet validate` links scry attestations as `verified-by` evidence | (extends v0.3) | FEAT-004 |
-| v0.7 | Component Model AI: per the placement decision in DD-002, pre-meld pass tracking owned/borrowed handle states + capability-flow + host-call effect sets | sound resource-lifetime detection on real WAC compositions; capability-graph soundness check | `scry-component-handles` | FEAT-002 |
+| v0.7 | Component Model AI (per DD-002): scry analyzes original component sources; meld emits `component-provenance` custom section; scry projects invariants onto fused-module locations. Tracks owned/borrowed handle states, capability flow, host-call effects | sound resource-lifetime detection on real WAC compositions; capability-graph soundness check; meld `component-provenance` round-trip test | `scry-component-handles` | FEAT-002 |
 | v0.8 | taint domain (Wanilla-class noninterference) for security-property analysis | proptest on relational noninterference; differential vs Wanilla on shared corpus | (extends v0.3) | FEAT-009 |
 | v0.9 | octagon + relational numerical domains for false-alarm reduction; mechanized soundness proof of interval domain in Rocq against WasmCert-Coq | Rocq build green; reduced false-alarm rate measured on benchmark corpus | (extends v0.3) | FEAT-010 |
 | v1.0 | six-domain credit dossier; full mechanized soundness for the v0.1+v0.2+v0.3 domain stack; SpecTec-derived transfer-function backend prototype | rivet coverage at 100% across the full G-001 sub-tree; `rivet validate --qualification-mode` green | (HW+dossier) | FEAT-011 |
@@ -272,10 +275,12 @@ each row is a market where the same chain (meld + scry + loom + witness
 
 shared cross-layer flows:
 
-- scry-pre-meld results survive meld via custom-section provenance
-  metadata (DD-002 option B), or are produced by a separate pre-meld
-  pass (option A) — the placement choice is open in DD-002 and is the
-  v0.7 design gate.
+- scry's Component-Model analysis runs on the original component
+  sources upstream of meld; meld emits a minimal `component-provenance`
+  custom section that maps fused-module function indices back to
+  their originating component+function. scry uses this mapping to
+  project Component-Model invariants onto fused-module locations
+  (DD-002, closed 2026-05-26).
 - the `wasm-lattice` crate is consumed by witness for coverage-gap
   prediction (an over-approximation of unreachable branches narrows
   the witness MC/DC coverage frontier).
@@ -287,7 +292,7 @@ shared cross-layer flows:
 | decision | what's open | where |
 |---|---|---|
 | DD-001 | pipeline placement: post-meld between meld and loom | `artifacts/design.yaml#DD-001` |
-| DD-002 | **OPEN** — Component-Model AI placement (pre-meld pass / meld-preserved provenance / hybrid). decision pending; the three options are written up. | `artifacts/design.yaml#DD-002` |
+| DD-002 | Component-Model AI placement: option (b) closed 2026-05-26 — scry analyzes original component sources; meld emits minimal `component-provenance` custom section | `artifacts/design.yaml#DD-002` |
 | DD-003 | soundness substrate: WasmCert-Coq + Iris-Wasm | `artifacts/design.yaml#DD-003` |
 | DD-004 | reusable wasm-lattice crate decoupled from Wasm front-end | `artifacts/design.yaml#DD-004` |
 | DD-005 | v0 domain set: interval + region-memory + reachability + sound call-graph | `artifacts/design.yaml#DD-005` |

--- a/artifacts/design.yaml
+++ b/artifacts/design.yaml
@@ -52,39 +52,82 @@ artifacts:
 
   - id: DD-002
     type: design-decision
-    title: Component-Model AI placement — choose between pre-meld pass, meld-preserved provenance, or hybrid
-    status: draft
-    tags: [pipeline-placement, component-model, decision-pending]
+    title: Component-Model AI placement — adopt option (b), meld emits a minimal component-provenance custom section
+    status: approved
+    tags: [pipeline-placement, component-model]
+    description: >
+      Closes the open architectural choice on where scry's Component-
+      Model analysis sits relative to meld. The chosen option (b)
+      splits responsibility cleanly: scry runs Component-Model
+      analysis on the original component sources upstream of meld;
+      meld emits a minimal `component-provenance` custom section
+      mapping fused-module function indices back to their originating
+      component+function; scry projects the resulting invariants onto
+      fused-module locations using that section. See the rationale
+      and alternatives fields for the full reasoning and the
+      investigation of meld that grounded the call.
     fields:
       decision: >
-        TODO — see "User contribution requested" below. The Component-
-        Model AI strategy is a real architectural choice with three
-        viable options, and the right answer depends on facts about meld
-        (does it already emit provenance? would it cost much to add?)
-        that the user is best positioned to decide.
+        scry runs its Component-Model analysis (resource lifetimes,
+        capability flow, host-call effects, WIT refinement) on the
+        original component sources upstream of meld. meld grows a
+        minimal custom section `component-provenance` that records the
+        per-function origin mapping (fused-module function index →
+        originating-component id + originating-function index). The
+        post-meld scry stage uses this mapping to associate the
+        Component-Model invariants with locations in the fused Core
+        Wasm module so they are consumable by loom, witness, and the
+        sigil/rivet evidence chain. meld is otherwise unchanged; the
+        Component-Model semantics live entirely inside scry.
       rationale: >
-        meld fuses Wasm components into a single Core Wasm module. Once
-        meld has run, owned/borrowed handle types, capability imports,
-        and component boundaries are erased from the Core IR. Any AI
-        that wants to reason about Component-Model-level properties
-        (use-after-drop on handles, capability flow, host-call effect
-        sets, refinement of WIT contracts) therefore needs to either
-        (a) run BEFORE meld on the still-component-shaped IR;
-        (b) consume PROVENANCE METADATA that meld preserves into the
-            fused Core Wasm (e.g. custom sections naming the originating
-            component for each function and the handle-shape of each
-            address-taken integer); or
-        (c) a HYBRID: a pre-meld pass produces a component-level
-            invariant bundle, meld preserves it through fusion, and a
-            post-meld AI verifies invariants are not invalidated.
-        Option (a) is cleanest semantically but means *two* AI
-        implementations (one component-typed, one core); option (b)
-        requires meld changes but yields a single AI implementation;
-        option (c) is the most defensible for a safety case but the
-        most engineering.
+        Investigation of meld confirmed two facts that collapse the
+        decision: (1) meld already emits a custom section
+        (`wsc.transformation.attestation`) and already tracks per-
+        function origin tuples internally (`MergedFunction.origin :=
+        (comp_idx, mod_idx, func_idx)` in `merger.rs`) — it just
+        discards them after fusion. Adding a `component-provenance`
+        custom section is ~300 LOC of bolt-on work, not a deep
+        architectural change. (2) meld's Rocq proofs (~13.3k LoV
+        across 23 files) prove forward simulation + trap simulation
+        between the composed component graph and the fused Core Wasm
+        module — i.e. they cover Core Wasm SEMANTIC preservation.
+        They do not cover Component-Model invariants (handle
+        lifetimes, capability flow, WIT refinement) by DESIGN, not by
+        gap: those properties are not in meld's scope.
+        This makes option (c) unnecessary — there is no fusion-
+        correctness gap to re-verify, only a Component-Model semantic
+        layer that belongs in scry. Option (a)'s "two analyzer
+        implementations" tax is also unnecessary: with the minimal
+        provenance custom section, a single scry implementation can
+        analyze the original components and project results onto the
+        fused module. The boundary becomes cleanly typed: meld owns
+        Core Wasm fusion correctness (proven in Rocq); scry owns
+        Component-Model semantics (proven separately). The custom
+        section is the typed contract between them.
       alternatives: >
-        (Same as the three options described in the rationale — captured
-        there explicitly so the choice is visible alongside the reasons.)
+        (a) Pre-meld pass only — rejected because the post-meld
+            consumers (loom, witness, sigil-signed evidence) need to
+            associate invariants with locations in the fused module,
+            which requires SOME meld-side mapping. Without that
+            mapping, option (a) leaves the Component-Model invariants
+            disconnected from the downstream chain.
+        (c) Pre-meld pass + meld preservation + post-meld
+            re-verification — rejected because meld's Rocq proof
+            covers exactly what re-verification would check at the
+            Core Wasm level. Re-verifying Component-Model invariants
+            through fusion would require LIFTING the meld proof to
+            cover Component-Model semantics, which is a much larger
+            piece of work than just doing the analysis in scry once
+            with origin mapping.
+        (b.1 vs b.2 scope) — the chosen variant is (b.1): minimal
+            provenance (function-origin map only). The alternative
+            (b.2) would also record resource type names and handle
+            shapes in the custom section. That is rejected for v0.7
+            because scry can derive those from the original component
+            sources directly; preserving them in meld output is
+            useful for a no-source post-hoc analysis story but is
+            out-of-scope for the v0.7 milestone.
+      source-ref: "Investigation of meld at /Users/r/git/pulseengine/meld/ — emitter in src/lib.rs:1259-1437, merger origin tuples in src/merger.rs:59-63, Rocq proofs in proofs/rocq/ (esp. fusion_spec.v)"
     links:
       - type: satisfies
         target: REQ-003

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -207,19 +207,29 @@ artifacts:
     status: draft
     description: >
       A second-phase extension lifting the AI to the Wasm Component
-      Model: tracks resource handles as a linear/affine lattice (fresh /
+      Model. Per DD-002, the analysis runs on the original component
+      sources upstream of meld; meld emits a minimal
+      `component-provenance` custom section mapping fused-module
+      function indices back to their originating component+function;
+      scry projects the resulting invariants onto the fused module so
+      they are consumable by loom, witness, and sigil/rivet evidence.
+      Tracks resource handles as a linear/affine lattice (fresh /
       borrowed / owned / dropped), capability flow through composition
       graphs, and host-call effect sets per component function.
-    tags: [component-model, capability]
+    tags: [component-model, capability, v0.7]
     fields:
       phase: phase-2
       acceptance-criteria:
-        - "Given a composed component graph using owned/borrowed handles, When the AI pass runs, Then every use-after-drop on owned handles is reported at link time."
-        - "Given a composition graph and a WASI import set, When the AI pass runs, Then for each component the analyzer reports the may-reach set of host imports."
-        - "Given a WIT interface annotated with refinement predicates, When the AI pass runs, Then the analyzer either discharges the predicate or reports a sound counterexample."
+        - "Given a composed component graph using owned/borrowed handles, When scry runs its component-mode analysis on the original component sources, Then every use-after-drop on owned handles is reported with a witnessing abstract counterexample."
+        - "Given a fused module emitted by meld with the `component-provenance` custom section present, When scry runs its post-meld projection step, Then every Component-Model invariant from the pre-meld analysis is associated with a concrete location in the fused Core Wasm module."
+        - "Given a composition graph and a WASI import set, When scry runs, Then for each component the analyzer reports the may-reach set of host imports."
+        - "Given a WIT interface annotated with refinement predicates, When scry runs, Then the analyzer either discharges the predicate or reports a sound counterexample."
+        - "Given meld with the `component-provenance` custom section emitter, When meld is given a composition and the section is decoded, Then the section round-trips losslessly and contains one entry per fused-module function."
     links:
       - type: satisfies
         target: REQ-003
+      - type: traces-to
+        target: DD-002
 
   - id: FEAT-003
     type: feature

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,7 +23,7 @@
 | **v0.4** | compositional summary-based interprocedural AI; scales to fused multi-component modules | DD-006; AC-010 (Stiévenart compositional summaries); REQ-007 | provisional: FEAT-007 |
 | **v0.5** | loom integration: invariant schema v1; loom consumes scry output for bounds-check elision + constant fold | REQ-004; DD-001 | provisional: FEAT-008 |
 | **v0.6** | sigil signed in-toto attestation per scry run; rivet `verified-by` integration; end-to-end overdo evidence | DD-007; REQ-005; FEAT-004 | provisional: FEAT-004 (already drafted) |
-| **v0.7** | Component Model AI: per the DD-002 placement choice (pre-meld / meld-provenance / hybrid), track owned/borrowed handle states + capability flow + host-call effects; `scry-component-handles` runnable | **DD-002 (open)**; AC-009 (Menon & Wagner WAW 2025); MF-002 (Component Model AI gap); REQ-003; FEAT-002 | provisional: FEAT-002 (already drafted); **DD-002 must close** |
+| **v0.7** | Component Model AI per DD-002 (closed 2026-05-26): scry analyzes original component sources; meld emits `component-provenance` custom section (~300 LOC bolt-on); scry projects invariants onto fused-module locations. Tracks owned/borrowed handle states + capability flow + host-call effects. `scry-component-handles` runnable | DD-002 (closed); AC-009 (Menon & Wagner WAW 2025); MF-002 (Component Model AI gap); REQ-003; FEAT-002 | provisional: FEAT-002 |
 | **v0.8** | taint domain (Wanilla-class noninterference) | AC-007 (Wanilla CCS 2025) | provisional: FEAT-009 |
 | **v0.9** | octagon / relational numerical domains; mechanized soundness proof of the interval domain in Rocq against WasmCert-Coq | AC-011 (Miné octagon); DD-003; TE-004 (WasmCert-Coq + Iris-Wasm) | provisional: FEAT-010 |
 | **v1.0** | six-domain credit dossier; mechanized soundness for the v0.1+v0.2+v0.3 stack; SpecTec-derived transfer-function backend prototype | AC-005 (SpecTec); G-001 (top-level safety goal closes) | provisional: FEAT-011 |
@@ -54,12 +54,15 @@ The four design decisions that locked in this pass (`DD-001`, `DD-003`,
   proofs). v0.9 lands the first mechanized soundness theorem for the
   interval domain; v1.0 extends to the full v0.1-v0.3 stack.
 
-The one decision that **remains open** is `DD-002` — Component Model
-AI placement. The three options (pre-meld pass / meld-preserved
-provenance / hybrid) are written up with their trade-offs in
-`artifacts/design.yaml`; closing DD-002 is the v0.7 gate. The choice
-shapes whether scry-component is a separate binary, an additional
-mode of the main scry binary, or a hybrid that requires a meld change.
+`DD-002` (Component Model AI placement) was closed 2026-05-26 in
+favour of **option (b)**: scry analyzes original component sources
+upstream of meld; meld emits a minimal `component-provenance` custom
+section (~300 LOC bolt-on, infrastructure already present); scry
+projects the resulting invariants onto fused-module locations using
+the section. The boundary is clean: meld owns Core Wasm fusion
+correctness (proven in Rocq); scry owns Component-Model semantics
+(proven separately). See `artifacts/design.yaml#DD-002` for the full
+rationale and the meld investigation that grounded the call.
 
 ## V-model traceability
 


### PR DESCRIPTION
## Summary

Closes the open architectural choice on where scry's Component-Model
analysis sits relative to meld. The chosen approach (option (b))
splits responsibility cleanly:

- **meld** owns Core Wasm fusion correctness (already proven in Rocq).
- **scry** owns Component-Model semantics (proven separately, on the
  original component sources upstream of meld).
- A new minimal `component-provenance` custom section emitted by meld
  is the typed contract between them.

## What changed

- `DD-002` status: `draft` → `approved`. Full rationale and rejected
  alternatives captured in the artifact.
- `FEAT-002` acceptance criteria rewritten against the chosen option;
  adds a `component-provenance` round-trip criterion for meld.
- README §what-scry-is + §release-plan v0.7 row + §design-decisions
  table + §architecture flow updated.
- `docs/roadmap.md` v0.7 row + composition section updated; DD-002
  no longer flagged as the v0.7 gate.

`rivet validate` → PASS, 0 warnings.

## What grounded the decision

Investigation of meld at `/Users/r/git/pulseengine/meld/` surfaced
two facts that collapsed the three-way choice:

1. **meld already tracks the data scry needs.** `MergedFunction.origin:
   (comp_idx, mod_idx, func_idx)` is built in `merger.rs:59-63` and
   discarded after fusion. meld already emits one custom section
   (`wsc.transformation.attestation` in `lib.rs:1412-1437`), so the
   emitter infrastructure is in place. Adding `component-provenance`
   is ~300 LOC of bolt-on work, not a deep architectural change.

2. **meld's Rocq proofs cover what they should.** ~13.3k LoV across
   23 `.v` files prove forward simulation + trap simulation between
   the composed component graph and the fused Core Wasm module —
   i.e. Core Wasm *semantic* preservation. They do not cover
   Component-Model invariants (handle lifetimes, capability flow,
   WIT refinement) by *design*, not by gap.

Together these make option (c) unnecessary (no fusion-correctness
gap to re-verify) and option (a)'s two-implementation tax avoidable
(minimal provenance lets one scry implementation analyze original
components and project onto fused locations).

## Test plan

- [x] `rivet validate` → PASS, 0 warnings
- [x] `rivet get DD-002` → status approved, full rationale present
- [x] `rivet get FEAT-002` → links to DD-002, criteria updated
- [ ] README v0.7 release row reads correctly to a fresh reader
- [ ] `docs/roadmap.md` no longer lists DD-002 as open

🤖 Generated with [Claude Code](https://claude.com/claude-code)