### PR TITLE
v0.2-prep: rivet-delta PR check + compliance evidence + checkout v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -84,7 +84,7 @@ jobs:
     name: Rivet artifact validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install rivet-cli
@@ -96,7 +96,7 @@ jobs:
     name: AADL model (spar parse)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install spar
@@ -111,7 +111,7 @@ jobs:
     name: WIT round-trip (wasm-tools)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-tools
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: bazelbuild/setup-bazelisk@v3
       - name: Cache Bazel
         uses: actions/cache@v4
@@ -164,7 +164,7 @@ jobs:
     name: cargo-deny (licenses, advisories, bans)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-deny

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 40
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -105,6 +105,42 @@ jobs:
           done
           ls -la release-assets/
 
+      # ── Rivet compliance evidence bundle ─────────────────────────
+      #
+      # Generated via the canonical PulseEngine composite action
+      # (pulseengine/rivet/.github/actions/compliance) — same one
+      # sigil and spar use. Produces an HTML compliance report plus
+      # ReqIF / generic-yaml data formats and tarballs them as
+      # compliance-evidence-<version>.tar.gz. The tarball is added
+      # to release-assets/ so cosign signs it alongside the other
+      # release artifacts in the next step.
+
+      - name: Generate rivet compliance evidence
+        id: compliance
+        continue-on-error: true
+        uses: pulseengine/rivet/.github/actions/compliance@v0.6.0
+        with:
+          theme: dark
+          rivet-version: v0.3.0
+          single-page: false
+          include-data-formats: true
+          archive: 'true'
+          archive-name: scry-${{ env.BARE_VERSION }}-compliance-evidence
+          report-label: ${{ env.VERSION }}
+
+      - name: Stage compliance bundle
+        env:
+          ARCHIVE_PATH: ${{ steps.compliance.outputs.archive-path }}
+        run: |
+          set -euo pipefail
+          if [ -n "${ARCHIVE_PATH:-}" ] && [ -f "$ARCHIVE_PATH" ]; then
+            cp "$ARCHIVE_PATH" "release-assets/$(basename "$ARCHIVE_PATH")"
+            echo "::notice title=Compliance evidence::staged $(basename "$ARCHIVE_PATH")"
+          else
+            echo "::warning title=Compliance evidence::action emitted no archive-path; skipping"
+          fi
+          ls -la release-assets/
+
       - name: Generate SHA256SUMS.txt
         run: |
           set -euo pipefail
@@ -122,7 +158,7 @@ jobs:
         run: |
           set -euo pipefail
           cd release-assets
-          for asset in *.wasm *.cdx.json; do
+          for asset in *.wasm *.cdx.json *.tar.gz; do
             [ -f "$asset" ] || continue
             cosign sign-blob --yes \
               --output-signature "${asset}.sig" \

--- a/.github/workflows/rivet-delta.yml
+++ b/.github/workflows/rivet-delta.yml
@@ -1,0 +1,185 @@
+name: rivet-delta
+
+# Surfaces changes to the rivet artifact graph on every PR that
+# touches artifacts/, schemas/, spar/, or rivet.yaml. Posts a sticky
+# comment so reviewers see what changed without diffing YAML by hand.
+#
+# Pattern adapted from /Users/r/git/pulseengine/rivet/.github/
+# workflows/rivet-delta.yml. scry installs the rivet CLI rather
+# than building it from source.
+#
+# Informational only: every rivet command runs with
+# `continue-on-error: true`; the job never fails the PR. The value
+# is the visible diff in the PR comment, not a blocking gate.
+#
+# Workflow-injection safety: PR_NUMBER (numeric) and BASE_SHA
+# (validated git SHA) are routed through env: before any `run:`
+# block. No untrusted strings interpolated inline.
+
+on:
+  pull_request:
+    paths:
+      - 'artifacts/**'
+      - 'schemas/**'
+      - 'spar/**'
+      - 'rivet.yaml'
+      - '.github/workflows/rivet-delta.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: rivet-delta-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  delta:
+    name: Rivet artifact delta
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    steps:
+
+      - name: Checkout head
+        uses: actions/checkout@v6
+        with:
+          path: head
+          fetch-depth: 0
+
+      - name: Checkout base
+        uses: actions/checkout@v6
+        with:
+          path: base
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install rivet-cli
+        run: cargo install --locked --git https://github.com/pulseengine/rivet rivet-cli
+
+      - name: Validate head
+        working-directory: head
+        continue-on-error: true
+        run: rivet validate --format text > ../validate-head.txt 2>&1 || true
+
+      - name: Validate base
+        working-directory: base
+        continue-on-error: true
+        run: rivet validate --format text > ../validate-base.txt 2>&1 || true
+
+      - name: Diff base vs head
+        continue-on-error: true
+        run: |
+          set +e
+          rivet diff --base base --head head --format text > diff.txt 2>&1
+          rivet diff --base base --head head --format json > diff.json 2>&1 || echo '{}' > diff.json
+
+      - name: Stats head
+        working-directory: head
+        continue-on-error: true
+        run: rivet stats --format text > ../stats-head.txt 2>&1 || true
+
+      - name: Stats base
+        working-directory: base
+        continue-on-error: true
+        run: rivet stats --format text > ../stats-base.txt 2>&1 || true
+
+      - name: AADL parse (head)
+        working-directory: head
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          if [ -f spar/scry.aadl ]; then
+            cargo install --locked --git https://github.com/pulseengine/spar spar 2>/dev/null
+            spar parse spar/scry.aadl > ../aadl-head.txt 2>&1
+          else
+            echo "(no AADL model in head)" > ../aadl-head.txt
+          fi
+
+      - name: Compose PR comment body
+        id: compose
+        run: |
+          set -euo pipefail
+          {
+            echo "<!-- rivet-delta-bot -->"
+            echo "## :triangular_ruler: rivet artifact delta"
+            echo
+            echo "**PR:** #${PR_NUMBER}  **Base SHA:** \`${BASE_SHA:0:8}\`"
+            echo
+            echo "### Validation"
+            echo
+            echo "<details><summary><strong>head</strong> — \`rivet validate\` result</summary>"
+            echo
+            echo '```'
+            tail -20 validate-head.txt 2>/dev/null || echo "(no output)"
+            echo '```'
+            echo
+            echo "</details>"
+            echo
+            echo "<details><summary><strong>base</strong> — \`rivet validate\` result (for comparison)</summary>"
+            echo
+            echo '```'
+            tail -20 validate-base.txt 2>/dev/null || echo "(no output)"
+            echo '```'
+            echo
+            echo "</details>"
+            echo
+            echo "### Artifact stats"
+            echo
+            BTOT=$(grep -E "TOTAL" stats-base.txt 2>/dev/null | awk '{print $2}' || echo "n/a")
+            HTOT=$(grep -E "TOTAL" stats-head.txt 2>/dev/null | awk '{print $2}' || echo "n/a")
+            echo "| | base | head |"
+            echo "| --- | --- | --- |"
+            echo "| **Total artifacts** | $BTOT | $HTOT |"
+            echo
+            echo "<details><summary><strong>full stats — head</strong></summary>"
+            echo
+            echo '```'
+            cat stats-head.txt 2>/dev/null || echo "(no output)"
+            echo '```'
+            echo
+            echo "</details>"
+            echo
+            echo "### Diff (base → head)"
+            echo
+            echo '```'
+            tail -50 diff.txt 2>/dev/null || echo "(no diff output)"
+            echo '```'
+            echo
+            echo "### AADL model — head"
+            echo
+            echo '```'
+            cat aadl-head.txt 2>/dev/null || echo "(not run)"
+            echo '```'
+            echo
+            echo "---"
+            echo "_Posted by the \`rivet-delta\` workflow. Informational only — does not gate the PR._"
+          } > comment.md
+          echo "comment_path=comment.md" >> "$GITHUB_OUTPUT"
+
+      - name: Find previous delta comment
+        id: find_comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: '<!-- rivet-delta-bot -->'
+
+      - name: Post or update delta comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          edit-mode: replace
+          body-path: ${{ steps.compose.outputs.comment_path }}
+
+      - name: Append summary to job page
+        run: |
+          {
+            echo "## rivet artifact delta"
+            cat comment.md
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`rivet-delta.yml` PR check** — sticky comment on every PR touching
+  `artifacts/`, `schemas/`, `spar/`, or `rivet.yaml`. Reports `rivet
+  validate` head-vs-base, stats delta, full `rivet diff`, and `spar
+  parse` result for the AADL model. Pattern adapted from rivet's
+  own `rivet-delta.yml`. Informational only — does not gate the PR.
+- **Rivet compliance evidence in releases** — `release.yml` now
+  invokes the canonical `pulseengine/rivet/.github/actions/compliance@v0.6.0`
+  composite action (same one sigil and spar use) and tarballs the
+  result as `scry-<version>-compliance-evidence.tar.gz`. The bundle
+  is signed by cosign alongside the other release assets.
+
+### Changed
+
+- **`actions/checkout` upgraded from `@v4` to `@v6`** across both
+  `ci.yml` and `release.yml`. Removes the Node.js 20 deprecation
+  warning. Other Node 20 actions (`actions/cache`, `Swatinem/rust-cache`,
+  `sigstore/cosign-installer`, `bazelbuild/setup-bazelisk`,
+  `actions/attest-build-provenance`) have no Node 24-compatible
+  release yet; warnings remain for those until upstream ships.
+
 ## [0.1.0] — 2026-05-27
 
 Headline: **scaffolding ships**. The full PulseEngine Wasm-component toolchain


### PR DESCRIPTION
## Summary

Three v0.2-cycle infrastructure improvements bundled so every subsequent v0.2 feature PR benefits.

### 1. `rivet-delta.yml` — sticky PR comment on artifact changes

New workflow at `.github/workflows/rivet-delta.yml`. Fires on any PR touching `artifacts/`, `schemas/`, `spar/`, or `rivet.yaml`. Posts a sticky comment (replaces the previous one on each push) reporting:

- `rivet validate` result on head vs base
- Artifact count delta (base → head total)
- Full `rivet diff` text output
- `spar parse spar/scry.aadl` result for the AADL model

Pattern adapted from [rivet's own `rivet-delta.yml`](https://github.com/pulseengine/rivet/blob/main/.github/workflows/rivet-delta.yml). Informational only — every rivet command runs with `continue-on-error: true` and the job never gates the PR.

The value is the **visible diff in the PR conversation**, so a reviewer knows what shifted in the typed artifact graph without having to diff YAML by hand.

### 2. Rivet compliance evidence in releases

`release.yml` now invokes the canonical PulseEngine composite action `pulseengine/rivet/.github/actions/compliance@v0.6.0` (same one sigil and spar use). The action emits an HTML compliance bundle + ReqIF + generic-yaml data formats, tarballed at `outputs.archive-path`.

Staged into `release-assets/` so cosign signs it alongside the .wasm + per-crate SBOMs + SHA256SUMS. Archive name pinned to `scry-<version>-compliance-evidence.tar.gz` for clarity.

The compliance step is `continue-on-error: true` — release still ships even if the composite action upstream regresses.

### 3. `actions/checkout@v4` → `@v6` (Node 20 → Node 24)

Across both `ci.yml` and `release.yml`. Removes the Node.js 20 deprecation warning for the one action where Node 24 support exists today (rivet's own CI already runs v6).

Per a family-wide survey today, the other Node 20 actions (`actions/cache`, `Swatinem/rust-cache`, `sigstore/cosign-installer`, `bazelbuild/setup-bazelisk`, `actions/attest-build-provenance`) have no Node 24 release yet. Those warnings stay until upstream ships. Honest assessment in the survey: ~1 action fixable today, ~6 blocked on upstream.

## Test plan

- [x] `rivet validate` → PASS, 0 warnings (no rivet artifact changes here so the delta workflow won't actually post a comment until its first feature-touching PR)
- [x] All three workflows YAML-parse (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI runs green on this PR (`Format`, `Clippy`, `Test`, `Rivet artifact validation`, `AADL model (spar parse)`, `WIT round-trip`, `Bazel build`, `cargo-deny`)
- [ ] First subsequent feature PR exercises the rivet-delta comment for real
- [ ] Next release (v0.2.0 cycle) exercises the compliance-evidence step end-to-end

## Why bundled

Each piece is small and independent, but they all serve the same v0.2 cycle: making the next four feature PRs (FEAT-001 AC#1, AC#3, FEAT-005, FEAT-012 per issue #5) **observably better** for reviewers and assessors. Splitting into three PRs would triple the review overhead for one infrastructure cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)