### PR TITLE
FEAT-001 AC#1: real interval-domain fixpoint over Wasm Core Model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "scry-analyzer"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "sha2",
+ "wasmparser",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasm-lattice"
 version = "0.1.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
-name = "wasm-lattice"
-version = "0.1.0"
+name = "wasmparser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,12 @@ authors = ["Ralf Anton Beier and scry contributors"]
 
 [workspace.dependencies]
 bitflags = "2"
+# Wasm Core Model parsing for the v0.2 scry analyzer (FEAT-001 AC#1).
+# default-features = false keeps the crate buildable under #![no_std]
+# inside the wasm32-wasip2 component (the std feature pulls in alloc
+# adapters we already provide via `extern crate alloc`).
+wasmparser = { version = "0.247", default-features = false }
+# SHA-256 of the input module bytes for `invariant-bundle.module-sha256`
+# (FEAT-001 AC#1). default-features = false drops the std default and
+# keeps the dep no_std-compatible.
+sha2 = { version = "0.10", default-features = false }

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -179,15 +179,28 @@ artifacts:
     title: Sound abstract-interpretation pass for the Wasm Core Model (v0.1 — Wasm component dogfood)
     status: draft
     description: >
-      The v0.1 scry analyzer, shipping as a wasm32-wasip2 Component
-      Model component (per DD-008). Exports the `analyzer.analyze`
-      function defined in `wit/scry.wit` (derived from the AADL model
-      in `spar/scry.aadl`, per DD-010). v0.1 implements the interval
-      domain over i32/i64 locals only; region-memory (FEAT-005),
-      sound call-graph (FEAT-006), and loom integration (FEAT-008)
-      land in later versions. Built with Bazel + rules_wasm_component
-      (per DD-009).
-    tags: [core, pipeline, v0.1, component-model]
+      The scry analyzer, shipping as a wasm32-wasip2 Component Model
+      component (per DD-008). Exports the `analyzer.analyze` function
+      defined in `wit/scry.wit` (derived from the AADL model in
+      `spar/scry.aadl`, per DD-010). v0.1 shipped the Bazel + WIT +
+      cross-component dogfood scaffold; v0.2 (AC#1) lands the real
+      interval-domain abstract-interpretation fixpoint: the analyzer
+      parses the input module with `wasmparser`, walks straight-line
+      arithmetic in each function body (`i32.const`, `i64.const`,
+      `local.get`, `local.set`, `local.tee`, `i32.add`, `i32.sub`,
+      `i32.mul`, `end`, `return`), maintains an abstract operand
+      stack, calls every interval transfer function through the
+      imported `pulseengine:wasm-lattice/domain` interface, and emits
+      a per-program-point invariant snapshot of locals along with a
+      SHA-256 of the module bytes. Anything outside that supported
+      set (control flow, memory ops, calls) emits an
+      `UnsoundnessFallback` diagnostic and widens locals to top to
+      preserve soundness — region-memory (FEAT-005), sound call-graph
+      (FEAT-006), and summary-based interprocedural AI (FEAT-007)
+      land in later versions; loom integration (FEAT-008) consumes
+      the resulting invariant bundle. Built with Bazel +
+      rules_wasm_component (per DD-009).
+    tags: [core, pipeline, v0.1, v0.2, component-model]
     fields:
       phase: phase-1
       acceptance-criteria:
@@ -210,6 +223,8 @@ artifacts:
         target: FEAT-005
       - type: traces-to
         target: FEAT-006
+      - type: traces-to
+        target: FEAT-007
       - type: traces-to
         target: FEAT-008
 

--- a/crates/scry-analyzer/BUILD.bazel
+++ b/crates/scry-analyzer/BUILD.bazel
@@ -24,9 +24,21 @@ wit_library(
 # The Wasm component. The `_bindings` crate produced by the macro is
 # `scry_analyzer_component_bindings`; it carries both the exported
 # `analyzer` interface and the imported `domain` namespace.
+#
+# v0.2 (FEAT-001 AC#1) wires in the real interval-domain fixpoint:
+# `wasmparser` parses the input module, `sha2` hashes the bytes for
+# the invariant bundle's `module_sha256`. Both come from the workspace
+# `[workspace.dependencies]` via `crate_universe` — the apparent repo
+# name is `@scry_crates` (configured in MODULE.bazel) so the @crates
+# label that rules_wasm_component exposes for its own internal deps
+# doesn't shadow our workspace deps.
 rust_wasm_component_bindgen(
     name = "scry_analyzer_component",
     srcs = ["src/lib.rs"],
     profiles = ["release"],
     wit = ":scry_analyzer_wit",
+    deps = [
+        "@scry_crates//:wasmparser",
+        "@scry_crates//:sha2",
+    ],
 )

--- a/crates/scry-analyzer/Cargo.toml
+++ b/crates/scry-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scry-analyzer"
-description = "v0.1 scry interval-domain abstract interpreter as a Wasm component."
+description = "scry interval-domain abstract interpreter as a Wasm component."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -13,9 +13,14 @@ crate-type = ["cdylib"]
 [dependencies]
 bitflags = { workspace = true }
 
-# v0.1 scaffold has no other external deps; wasmparser + sha2 land
-# with the real analyzer implementation in a follow-on PR (FEAT-001
-# acceptance criterion 1 — over-approximation of concrete execution).
+# v0.2 (FEAT-001 AC#1): the real interval-domain fixpoint.
+# wasmparser parses the input Wasm Core Model module; sha2 digests
+# the module bytes for `invariant-bundle.module-sha256`. Both are
+# `default-features = false` so the crate stays `#![no_std]` and
+# compiles cleanly to wasm32-wasip2.
+#
 # The macro-generated bindings crate
 # (scry_analyzer_component_bindings) is injected by
 # rules_wasm_component.
+wasmparser = { workspace = true }
+sha2 = { workspace = true }

--- a/crates/scry-analyzer/src/lib.rs
+++ b/crates/scry-analyzer/src/lib.rs
@@ -1,91 +1,586 @@
-//! scry-analyzer — the v0.1 scry analyzer as a Wasm component.
+//! scry-analyzer — the v0.2 scry analyzer as a Wasm component.
 //!
-//! v0.1 scaffold. Implements the `analyzer.analyze` function defined
-//! in `wit/scry.wit` (derived from `spar/scry.aadl` per DD-010). The
-//! cross-component import of `pulseengine:wasm-lattice/domain` is
-//! exercised here to validate the WAC composition path before any
-//! real analysis code lands.
+//! Implements the `analyzer.analyze` function defined in `wit/scry.wit`
+//! (derived from `spar/scry.aadl` per DD-010). The cross-component
+//! import of `pulseengine:wasm-lattice/domain` is dogfooded on every
+//! call (DD-008): the analyzer never performs a lattice operation
+//! locally — every interval transfer goes through the WIT boundary.
 //!
-//! The real interval-domain fixpoint over a parsed Wasm module — the
-//! work that turns FEAT-001 acceptance criterion 1 green —
-//! arrives in a follow-on PR. This scaffold returns an empty
-//! invariant bundle for any input plus a placeholder diagnostic
-//! identifying itself as the v0.1 scaffold.
+//! v0.2 (FEAT-001 AC#1) replaces the v0.1.0 scaffold's hardcoded
+//! invariant bundle with a real interval-domain abstract-interpretation
+//! fixpoint:
+//!
+//!   1. Parse the input bytes as a Wasm Core Model module via
+//!      `wasmparser`.
+//!   2. For each function body, initialize abstract locals
+//!      (parameters → `domain::top()`, declared locals →
+//!      `domain::constant_i32(0)` per Wasm zero-init), walk
+//!      straight-line arithmetic operators, and maintain an
+//!      abstract operand stack.
+//!   3. For every handled operator, emit a `ProgramPoint` snapshot
+//!      of the locals after execution.
+//!   4. SHA-256 the module bytes and report the digest as
+//!      `invariant_bundle.module_sha256`.
+//!
+//! Scope discipline (v0.2 AC#1):
+//!
+//!   * Handled: `I32Const`, `I64Const`, `LocalGet`, `LocalSet`,
+//!     `LocalTee`, `I32Add`, `I32Sub`, `I32Mul`, `End`, `Return`.
+//!   * Deferred (emits `UnsoundnessFallback`, locals → top, operand
+//!     stack scrubbed): control flow (`If`/`Loop`/`Block`/`Br*`),
+//!     memory ops (`I32Load`/`I32Store`/`MemoryGrow`), calls
+//!     (`Call`/`CallIndirect`), and everything outside the
+//!     straight-line arithmetic core. Region memory lands with
+//!     FEAT-005, sound call-graph with FEAT-006, summary-based
+//!     interprocedural with FEAT-007.
 
 #![no_std]
 extern crate alloc;
 
 use alloc::format;
 use alloc::string::ToString;
-use alloc::vec;
 use alloc::vec::Vec;
+
+use sha2::{Digest, Sha256};
+use wasmparser::{Operator, Parser, Payload};
 
 use scry_analyzer_component_bindings::exports::pulseengine::scry::analyzer::{
     AbstractValue, AnalysisConfig, AnalysisResult, AnalyzeError, Diagnostic, DiagnosticSeverity,
     Guest, InvariantBundle, LocalInvariant, ProgramPoint,
 };
-use scry_analyzer_component_bindings::pulseengine::wasm_lattice::domain;
+use scry_analyzer_component_bindings::pulseengine::wasm_lattice::domain::{self, Interval};
 
 struct Component;
 
-const SCRY_VERSION: &str = "0.1.0-scaffold";
+const SCRY_VERSION: &str = "0.2.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
+
+/// Per-function context for the abstract interpreter.
+struct FuncCtx {
+    /// Abstract locals (parameters first, then declared locals).
+    locals: Vec<AbstractValue>,
+    /// Abstract operand stack.
+    operand_stack: Vec<AbstractValue>,
+    /// Once we see an unsupported construct in a function, we stop
+    /// emitting fresh program-points for it — the abstract state has
+    /// become uninformative (all-top) and further records would just
+    /// be noise.
+    degraded: bool,
+}
+
+impl FuncCtx {
+    fn new(locals: Vec<AbstractValue>) -> Self {
+        Self {
+            locals,
+            operand_stack: Vec::new(),
+            degraded: false,
+        }
+    }
+
+    /// Drop the operand stack and widen every local to top. Used when
+    /// we hit any operator outside the v0.2 AC#1 supported set —
+    /// soundness over precision (REQ-001 / DD-005).
+    fn scrub_to_top(&mut self) {
+        for slot in self.locals.iter_mut() {
+            *slot = AbstractValue::I32Interval(domain::top());
+        }
+        self.operand_stack.clear();
+        self.degraded = true;
+    }
+}
+
+/// Extract the inner `Interval` from an `AbstractValue::I32Interval`.
+/// Anything else (i64, unknown) means we lost track of the i32 shape;
+/// caller must treat the result as `domain::top()` and emit a
+/// fallback diagnostic.
+fn as_i32_interval(v: &AbstractValue) -> Option<Interval> {
+    match v {
+        AbstractValue::I32Interval(iv) => Some(*iv),
+        _ => None,
+    }
+}
+
+/// Snapshot the locals as a list of `LocalInvariant` records.
+fn snapshot_locals(locals: &[AbstractValue]) -> Vec<LocalInvariant> {
+    locals
+        .iter()
+        .enumerate()
+        .map(|(i, v)| LocalInvariant {
+            local_index: i as u32,
+            value: clone_value(v),
+        })
+        .collect()
+}
+
+/// `AbstractValue` derives no Copy/Clone in the generated bindings (it
+/// carries a Rust enum variant with a payload). Hand-roll a shallow
+/// clone because `Interval` is `Copy`.
+fn clone_value(v: &AbstractValue) -> AbstractValue {
+    match v {
+        AbstractValue::I32Interval(iv) => AbstractValue::I32Interval(*iv),
+        AbstractValue::I64Interval(iv) => AbstractValue::I64Interval(*iv),
+        AbstractValue::Unknown => AbstractValue::Unknown,
+    }
+}
 
 impl Guest for Component {
     fn analyze(
         module_bytes: Vec<u8>,
-        _config: AnalysisConfig,
+        config: AnalysisConfig,
     ) -> Result<AnalysisResult, AnalyzeError> {
-        // v0.1 scaffold rejects empty input as a smoke-test for the
-        // error path. Any non-empty input returns an empty bundle
-        // plus a single info diagnostic naming the scaffold version.
         if module_bytes.is_empty() {
             return Err(AnalyzeError::InvalidModule(
                 "module bytes are empty".to_string(),
             ));
         }
+        if let Some(threshold) = config.widening_threshold {
+            if threshold == 0 {
+                return Err(AnalyzeError::InvalidConfig(
+                    "widening-threshold must be >= 1".to_string(),
+                ));
+            }
+        }
 
-        // Exercise the cross-component import so the WAC composition
-        // path is verified end-to-end at runtime, not just at build
-        // time. This is the v0.1 dogfood gate: if the composed
-        // component runs and the lattice call returns the expected
-        // singleton, the cross-component import works.
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+        // ───────────────────────────────────────────────────────────
+        // Cross-component lattice probe (kept from v0.1 — DD-008).
+        // If wac mis-wires the import we want a clear, early signal
+        // before the analyzer tries any real transfer functions.
+        // ───────────────────────────────────────────────────────────
         let probe = domain::constant_i32(42);
         let lattice_alive = probe.lo == 42 && probe.hi == 42;
+        if lattice_alive {
+            if config.emit_diagnostics {
+                diagnostics.push(Diagnostic {
+                    severity: DiagnosticSeverity::Info,
+                    func_index: 0,
+                    pc: 0,
+                    message: format!(
+                        "scry {} — wasm-lattice cross-component import alive",
+                        SCRY_VERSION,
+                    ),
+                });
+            }
+        } else {
+            // Mechanical soundness: if the lattice is broken we can't
+            // produce sound invariants. Emit fallback and degrade.
+            diagnostics.push(Diagnostic {
+                severity: DiagnosticSeverity::UnsoundnessFallback,
+                func_index: 0,
+                pc: 0,
+                message: format!(
+                    "scry {} — wasm-lattice probe FAILED (constant_i32(42) returned [{}, {}]); \
+                     all invariants degraded to top",
+                    SCRY_VERSION, probe.lo, probe.hi,
+                ),
+            });
+        }
+
+        // ───────────────────────────────────────────────────────────
+        // SHA-256 of the input bytes (FEAT-001 AC#1).
+        // ───────────────────────────────────────────────────────────
+        let module_sha256 = format!("{:x}", Sha256::digest(&module_bytes));
+
+        // ───────────────────────────────────────────────────────────
+        // First pass: collect function-type table + per-function
+        // parameter counts (param_count = function-type's params).
+        // Imports + locally-defined functions share the function-
+        // index space; we only analyze defined functions (from the
+        // code section).
+        // ───────────────────────────────────────────────────────────
+        let mut func_param_counts: Vec<(Vec<wasmparser::ValType>, Vec<wasmparser::ValType>)> =
+            Vec::new();
+        let mut function_type_indices: Vec<u32> = Vec::new();
+        let mut import_func_count: u32 = 0;
+
+        for payload in Parser::new(0).parse_all(&module_bytes) {
+            let payload = payload.map_err(|e| {
+                AnalyzeError::InvalidModule(format!("wasm parse failed (pre-pass): {e}"))
+            })?;
+            match payload {
+                Payload::TypeSection(reader) => {
+                    for rec_group in reader {
+                        let rec_group = rec_group.map_err(|e| {
+                            AnalyzeError::InvalidModule(format!("type section: {e}"))
+                        })?;
+                        for subtype in rec_group.into_types() {
+                            if let wasmparser::CompositeInnerType::Func(ft) =
+                                &subtype.composite_type.inner
+                            {
+                                let params: Vec<_> = ft.params().iter().copied().collect();
+                                let results: Vec<_> = ft.results().iter().copied().collect();
+                                func_param_counts.push((params, results));
+                            } else {
+                                // Non-func composite (struct/array) —
+                                // pad so type-index arithmetic stays
+                                // aligned.
+                                func_param_counts.push((Vec::new(), Vec::new()));
+                            }
+                        }
+                    }
+                }
+                Payload::ImportSection(reader) => {
+                    for imp in reader.into_imports() {
+                        let imp = imp.map_err(|e| {
+                            AnalyzeError::InvalidModule(format!("import section: {e}"))
+                        })?;
+                        if matches!(imp.ty, wasmparser::TypeRef::Func(_)) {
+                            import_func_count = import_func_count.saturating_add(1);
+                        }
+                    }
+                }
+                Payload::FunctionSection(reader) => {
+                    for ty in reader {
+                        let ty = ty.map_err(|e| {
+                            AnalyzeError::InvalidModule(format!("function section: {e}"))
+                        })?;
+                        function_type_indices.push(ty);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // ───────────────────────────────────────────────────────────
+        // Second pass: walk the code section. We re-parse rather than
+        // buffer payloads because wasmparser's Payload borrows from
+        // the bytes and is awkward to stash.
+        // ───────────────────────────────────────────────────────────
+        let mut points: Vec<ProgramPoint> = Vec::new();
+        let mut defined_func_idx: u32 = 0;
+
+        for payload in Parser::new(0).parse_all(&module_bytes) {
+            let payload = payload.map_err(|e| {
+                AnalyzeError::InvalidModule(format!("wasm parse failed (code pass): {e}"))
+            })?;
+            if let Payload::CodeSectionEntry(body) = payload {
+                let absolute_func_idx =
+                    import_func_count.saturating_add(defined_func_idx);
+
+                // Resolve this function's signature so we know how
+                // many params to mark as top.
+                let type_idx = function_type_indices
+                    .get(defined_func_idx as usize)
+                    .copied()
+                    .unwrap_or(u32::MAX);
+                let (params, _results) = func_param_counts
+                    .get(type_idx as usize)
+                    .cloned()
+                    .unwrap_or_default();
+
+                // Build the initial abstract locals: each param →
+                // top (we know nothing about caller-provided
+                // arguments yet — v0.4 summary-based AI will
+                // strengthen this), each declared local → zero per
+                // Wasm semantics.
+                let mut locals: Vec<AbstractValue> = Vec::with_capacity(params.len());
+                for ty in &params {
+                    locals.push(initial_abstract_for(*ty));
+                }
+
+                let locals_reader = body.get_locals_reader().map_err(|e| {
+                    AnalyzeError::InvalidModule(format!(
+                        "function {absolute_func_idx} locals: {e}"
+                    ))
+                })?;
+                for entry in locals_reader {
+                    let (count, ty) = entry.map_err(|e| {
+                        AnalyzeError::InvalidModule(format!(
+                            "function {absolute_func_idx} local entry: {e}"
+                        ))
+                    })?;
+                    for _ in 0..count {
+                        locals.push(zero_for(ty));
+                    }
+                }
+
+                let mut ctx = FuncCtx::new(locals);
+
+                let ops_reader = body.get_operators_reader().map_err(|e| {
+                    AnalyzeError::InvalidModule(format!(
+                        "function {absolute_func_idx} ops: {e}"
+                    ))
+                })?;
+
+                let mut pc: u32 = 0;
+                for op in ops_reader {
+                    let op = op.map_err(|e| {
+                        AnalyzeError::InvalidModule(format!(
+                            "function {absolute_func_idx} op {pc}: {e}"
+                        ))
+                    })?;
+
+                    let mut stop = false;
+                    match interpret_op(
+                        &op,
+                        &mut ctx,
+                        absolute_func_idx,
+                        pc,
+                        config.emit_diagnostics,
+                        &mut diagnostics,
+                    )? {
+                        StepOutcome::Continue => {}
+                        StepOutcome::Stop => stop = true,
+                    }
+
+                    if !ctx.degraded {
+                        points.push(ProgramPoint {
+                            func_index: absolute_func_idx,
+                            pc,
+                            locals: snapshot_locals(&ctx.locals),
+                        });
+                    }
+
+                    pc = pc.saturating_add(1);
+                    if stop {
+                        break;
+                    }
+                }
+
+                defined_func_idx = defined_func_idx.saturating_add(1);
+            }
+        }
 
         let invariants = InvariantBundle {
             schema: INVARIANT_SCHEMA_URL.to_string(),
-            // Real SHA-256 hashing lands with the wasmparser
-            // integration. The scaffold reports the byte length as a
-            // visible placeholder.
-            module_sha256: format!("scaffold-len-{}", module_bytes.len()),
-            // Single hardcoded point exercising the AbstractValue
-            // shape end-to-end through the WIT round-trip.
-            points: vec![ProgramPoint {
-                func_index: 0,
-                pc: 0,
-                locals: vec![LocalInvariant {
-                    local_index: 0,
-                    value: AbstractValue::I32Interval(probe),
-                }],
-            }],
+            module_sha256,
+            points,
         };
-
-        let diagnostics = vec![Diagnostic {
-            severity: DiagnosticSeverity::Info,
-            func_index: 0,
-            pc: 0,
-            message: format!(
-                "scry {} scaffold — real fixpoint not yet implemented; lattice cross-component import {}",
-                SCRY_VERSION,
-                if lattice_alive { "alive" } else { "BROKEN" },
-            ),
-        }];
 
         Ok(AnalysisResult {
             invariants,
             diagnostics,
         })
+    }
+}
+
+enum StepOutcome {
+    Continue,
+    Stop,
+}
+
+/// Initial abstract value for a Wasm parameter of the given value
+/// type. We don't know the caller's argument, so it's top in the
+/// matching domain (intervals for i32/i64, Unknown for everything
+/// else).
+fn initial_abstract_for(ty: wasmparser::ValType) -> AbstractValue {
+    match ty {
+        wasmparser::ValType::I32 | wasmparser::ValType::I64 => {
+            AbstractValue::I32Interval(domain::top())
+        }
+        _ => AbstractValue::Unknown,
+    }
+}
+
+/// Initial abstract value for a declared local (Wasm zero-init).
+fn zero_for(ty: wasmparser::ValType) -> AbstractValue {
+    match ty {
+        wasmparser::ValType::I32 => AbstractValue::I32Interval(domain::constant_i32(0)),
+        wasmparser::ValType::I64 => AbstractValue::I64Interval(domain::constant_i64(0)),
+        _ => AbstractValue::Unknown,
+    }
+}
+
+/// Interpret one operator. Mutates `ctx` and may push diagnostics.
+/// Returns whether the function loop should stop (e.g. `Return`).
+fn interpret_op(
+    op: &Operator<'_>,
+    ctx: &mut FuncCtx,
+    func_index: u32,
+    pc: u32,
+    emit_diagnostics: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Result<StepOutcome, AnalyzeError> {
+    if ctx.degraded {
+        // Once degraded, we still need to scan through to keep the
+        // operator iterator advancing — but we don't update state.
+        return Ok(StepOutcome::Continue);
+    }
+
+    match op {
+        Operator::I32Const { value } => {
+            ctx.operand_stack
+                .push(AbstractValue::I32Interval(domain::constant_i32(*value)));
+        }
+        Operator::I64Const { value } => {
+            ctx.operand_stack
+                .push(AbstractValue::I64Interval(domain::constant_i64(*value)));
+        }
+        Operator::LocalGet { local_index } => {
+            let v = ctx
+                .locals
+                .get(*local_index as usize)
+                .map(clone_value)
+                .ok_or_else(|| {
+                    AnalyzeError::Internal(format!(
+                        "func {func_index} pc {pc}: local.get {local_index} out of range \
+                         (have {} locals)",
+                        ctx.locals.len()
+                    ))
+                })?;
+            ctx.operand_stack.push(v);
+        }
+        Operator::LocalSet { local_index } => {
+            let v = ctx.operand_stack.pop().ok_or_else(|| {
+                AnalyzeError::Internal(format!(
+                    "func {func_index} pc {pc}: local.set on empty stack"
+                ))
+            })?;
+            let local_count = ctx.locals.len();
+            let slot = ctx.locals.get_mut(*local_index as usize).ok_or_else(|| {
+                AnalyzeError::Internal(format!(
+                    "func {func_index} pc {pc}: local.set {local_index} out of range \
+                     (have {local_count} locals)"
+                ))
+            })?;
+            *slot = v;
+        }
+        Operator::LocalTee { local_index } => {
+            let v = ctx
+                .operand_stack
+                .last()
+                .map(clone_value)
+                .ok_or_else(|| {
+                    AnalyzeError::Internal(format!(
+                        "func {func_index} pc {pc}: local.tee on empty stack"
+                    ))
+                })?;
+            let local_count = ctx.locals.len();
+            let slot = ctx.locals.get_mut(*local_index as usize).ok_or_else(|| {
+                AnalyzeError::Internal(format!(
+                    "func {func_index} pc {pc}: local.tee {local_index} out of range \
+                     (have {local_count} locals)"
+                ))
+            })?;
+            *slot = v;
+        }
+        Operator::I32Add => {
+            i32_binop(ctx, func_index, pc, emit_diagnostics, diagnostics, domain::i32_add)?;
+        }
+        Operator::I32Sub => {
+            i32_binop(ctx, func_index, pc, emit_diagnostics, diagnostics, domain::i32_sub)?;
+        }
+        Operator::I32Mul => {
+            i32_binop(ctx, func_index, pc, emit_diagnostics, diagnostics, domain::i32_mul)?;
+        }
+        Operator::End => {
+            // End of block / function — no state change at v0.2 AC#1.
+        }
+        Operator::Return => {
+            return Ok(StepOutcome::Stop);
+        }
+        other => {
+            // Anything outside the v0.2 AC#1 set: emit a fallback
+            // diagnostic, scrub state to top to preserve soundness
+            // (REQ-001), and continue. Control flow, memory ops, and
+            // calls all land here at v0.2; FEAT-005 / FEAT-006 /
+            // FEAT-007 will replace these with real transfer
+            // functions.
+            if emit_diagnostics {
+                diagnostics.push(Diagnostic {
+                    severity: DiagnosticSeverity::UnsoundnessFallback,
+                    func_index,
+                    pc,
+                    message: format!(
+                        "unsupported operator at v0.2 AC#1: {} — locals degraded to top",
+                        op_name(other)
+                    ),
+                });
+            }
+            ctx.scrub_to_top();
+        }
+    }
+    Ok(StepOutcome::Continue)
+}
+
+/// Apply an i32 binary transfer function via the wasm-lattice
+/// component import. Wasm operand order: top of stack is `b` (the
+/// second operand), the one below is `a` (the first operand); the
+/// transfer is `f(a, b)`.
+fn i32_binop(
+    ctx: &mut FuncCtx,
+    func_index: u32,
+    pc: u32,
+    emit_diagnostics: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+    f: fn(Interval, Interval) -> Interval,
+) -> Result<(), AnalyzeError> {
+    let b = ctx.operand_stack.pop().ok_or_else(|| {
+        AnalyzeError::Internal(format!(
+            "func {func_index} pc {pc}: i32 binop with empty stack"
+        ))
+    })?;
+    let a = ctx.operand_stack.pop().ok_or_else(|| {
+        AnalyzeError::Internal(format!(
+            "func {func_index} pc {pc}: i32 binop with single operand"
+        ))
+    })?;
+    match (as_i32_interval(&a), as_i32_interval(&b)) {
+        (Some(ai), Some(bi)) => {
+            let result = f(ai, bi);
+            ctx.operand_stack
+                .push(AbstractValue::I32Interval(result));
+        }
+        _ => {
+            // One of the operands isn't an i32 interval — we lost
+            // shape tracking somewhere. Widen to top and report.
+            if emit_diagnostics {
+                diagnostics.push(Diagnostic {
+                    severity: DiagnosticSeverity::UnsoundnessFallback,
+                    func_index,
+                    pc,
+                    message:
+                        "i32 binop on non-i32-interval operand — pushing top".to_string(),
+                });
+            }
+            ctx.operand_stack
+                .push(AbstractValue::I32Interval(domain::top()));
+        }
+    }
+    Ok(())
+}
+
+/// Coarse human-readable name for an operator. wasmparser's
+/// `Operator` doesn't derive `Display`; the `Debug` impl is verbose
+/// (full payloads) and tends to balloon diagnostic strings. The set
+/// below is the one we expect to see most often via the fallback
+/// path; anything else falls through to a debug-ish label.
+fn op_name(op: &Operator<'_>) -> &'static str {
+    match op {
+        Operator::Unreachable => "unreachable",
+        Operator::Nop => "nop",
+        Operator::Block { .. } => "block",
+        Operator::Loop { .. } => "loop",
+        Operator::If { .. } => "if",
+        Operator::Else => "else",
+        Operator::Br { .. } => "br",
+        Operator::BrIf { .. } => "br_if",
+        Operator::BrTable { .. } => "br_table",
+        Operator::Call { .. } => "call",
+        Operator::CallIndirect { .. } => "call_indirect",
+        Operator::Drop => "drop",
+        Operator::Select => "select",
+        Operator::GlobalGet { .. } => "global.get",
+        Operator::GlobalSet { .. } => "global.set",
+        Operator::I32Load { .. } => "i32.load",
+        Operator::I32Store { .. } => "i32.store",
+        Operator::MemorySize { .. } => "memory.size",
+        Operator::MemoryGrow { .. } => "memory.grow",
+        Operator::I32DivS => "i32.div_s",
+        Operator::I32DivU => "i32.div_u",
+        Operator::I32RemS => "i32.rem_s",
+        Operator::I32RemU => "i32.rem_u",
+        Operator::I32And => "i32.and",
+        Operator::I32Or => "i32.or",
+        Operator::I32Xor => "i32.xor",
+        Operator::I32Shl => "i32.shl",
+        Operator::I32ShrS => "i32.shr_s",
+        Operator::I32ShrU => "i32.shr_u",
+        Operator::I32Eq => "i32.eq",
+        Operator::I32Ne => "i32.ne",
+        Operator::I32Eqz => "i32.eqz",
+        _ => "<unsupported>",
     }
 }
 

--- a/crates/scry-analyzer/src/lib.rs
+++ b/crates/scry-analyzer/src/lib.rs
@@ -255,8 +255,7 @@ impl Guest for Component {
                 AnalyzeError::InvalidModule(format!("wasm parse failed (code pass): {e}"))
             })?;
             if let Payload::CodeSectionEntry(body) = payload {
-                let absolute_func_idx =
-                    import_func_count.saturating_add(defined_func_idx);
+                let absolute_func_idx = import_func_count.saturating_add(defined_func_idx);
 
                 // Resolve this function's signature so we know how
                 // many params to mark as top.
@@ -280,9 +279,7 @@ impl Guest for Component {
                 }
 
                 let locals_reader = body.get_locals_reader().map_err(|e| {
-                    AnalyzeError::InvalidModule(format!(
-                        "function {absolute_func_idx} locals: {e}"
-                    ))
+                    AnalyzeError::InvalidModule(format!("function {absolute_func_idx} locals: {e}"))
                 })?;
                 for entry in locals_reader {
                     let (count, ty) = entry.map_err(|e| {
@@ -298,9 +295,7 @@ impl Guest for Component {
                 let mut ctx = FuncCtx::new(locals);
 
                 let ops_reader = body.get_operators_reader().map_err(|e| {
-                    AnalyzeError::InvalidModule(format!(
-                        "function {absolute_func_idx} ops: {e}"
-                    ))
+                    AnalyzeError::InvalidModule(format!("function {absolute_func_idx} ops: {e}"))
                 })?;
 
                 let mut pc: u32 = 0;
@@ -437,15 +432,11 @@ fn interpret_op(
             *slot = v;
         }
         Operator::LocalTee { local_index } => {
-            let v = ctx
-                .operand_stack
-                .last()
-                .map(clone_value)
-                .ok_or_else(|| {
-                    AnalyzeError::Internal(format!(
-                        "func {func_index} pc {pc}: local.tee on empty stack"
-                    ))
-                })?;
+            let v = ctx.operand_stack.last().map(clone_value).ok_or_else(|| {
+                AnalyzeError::Internal(format!(
+                    "func {func_index} pc {pc}: local.tee on empty stack"
+                ))
+            })?;
             let local_count = ctx.locals.len();
             let slot = ctx.locals.get_mut(*local_index as usize).ok_or_else(|| {
                 AnalyzeError::Internal(format!(
@@ -456,13 +447,34 @@ fn interpret_op(
             *slot = v;
         }
         Operator::I32Add => {
-            i32_binop(ctx, func_index, pc, emit_diagnostics, diagnostics, domain::i32_add)?;
+            i32_binop(
+                ctx,
+                func_index,
+                pc,
+                emit_diagnostics,
+                diagnostics,
+                domain::i32_add,
+            )?;
         }
         Operator::I32Sub => {
-            i32_binop(ctx, func_index, pc, emit_diagnostics, diagnostics, domain::i32_sub)?;
+            i32_binop(
+                ctx,
+                func_index,
+                pc,
+                emit_diagnostics,
+                diagnostics,
+                domain::i32_sub,
+            )?;
         }
         Operator::I32Mul => {
-            i32_binop(ctx, func_index, pc, emit_diagnostics, diagnostics, domain::i32_mul)?;
+            i32_binop(
+                ctx,
+                func_index,
+                pc,
+                emit_diagnostics,
+                diagnostics,
+                domain::i32_mul,
+            )?;
         }
         Operator::End => {
             // End of block / function — no state change at v0.2 AC#1.
@@ -519,8 +531,7 @@ fn i32_binop(
     match (as_i32_interval(&a), as_i32_interval(&b)) {
         (Some(ai), Some(bi)) => {
             let result = f(ai, bi);
-            ctx.operand_stack
-                .push(AbstractValue::I32Interval(result));
+            ctx.operand_stack.push(AbstractValue::I32Interval(result));
         }
         _ => {
             // One of the operands isn't an i32 interval — we lost
@@ -530,8 +541,7 @@ fn i32_binop(
                     severity: DiagnosticSeverity::UnsoundnessFallback,
                     func_index,
                     pc,
-                    message:
-                        "i32 binop on non-i32-interval operand — pushing top".to_string(),
+                    message: "i32 binop on non-i32-interval operand — pushing top".to_string(),
                 });
             }
             ctx.operand_stack

--- a/crates/scry-analyzer/test-fixtures/README.md
+++ b/crates/scry-analyzer/test-fixtures/README.md
@@ -1,0 +1,54 @@
+# scry-analyzer test fixtures
+
+In-repo Wasm Core Model fixtures plus expected post-analysis
+documentation. These are the worked examples that pin down the v0.2
+(FEAT-001 AC#1) abstract-interpretation semantics in concrete cases.
+
+## Why they're documentation rather than tests (yet)
+
+v0.2 ships the analyzer-side of FEAT-001 AC#1 only. The Wasm-host
+harness that drives the composed component end-to-end and asserts on
+the returned `analysis-result` (the `crates/scry-host-tests` crate
+named in FEAT-001 AC#3) lands in a separate PR — Bazel doesn't
+currently expose a way to spin up wasmtime + call into a composed
+component as a `cargo test`-style assertion against a fixture, so the
+end-to-end loop is deferred.
+
+Until that lands, these `.wat` files plus their adjacent `.md` docs
+serve three roles:
+
+1. **Spec by example** — they make the supported instruction set and
+   the expected interval-lattice behaviour readable, in one place,
+   without anyone having to read the analyzer source.
+2. **Sanity oracle** — anyone hand-running `wasmtime` against the
+   composed component can paste a fixture in, eyeball the diagnostics,
+   and check the result against the `.md`.
+3. **Drop-in fixtures** for the FEAT-001 AC#3 host harness when it
+   lands: no edits to these files; the harness just loads them via
+   `wat::parse_str` and asserts on the `analysis-result`.
+
+## Files
+
+| file                              | purpose                                       |
+|-----------------------------------|-----------------------------------------------|
+| `fixture-01-constant-fold.wat`    | pure constant folding: `(10 + 32) * 2 = 84`   |
+| `fixture-01-constant-fold.md`     | expected per-instruction operand-stack state  |
+| `fixture-02-with-param.wat`       | unknown parameter + constant: result is top   |
+| `fixture-02-with-param.md`        | expected per-instruction operand-stack state  |
+
+## Adding fixtures
+
+Each fixture is one `.wat` file (Wasm Core Model only, no component
+type) plus one adjacent `.md` with two sections:
+
+1. **Source** — verbatim copy of the `.wat`.
+2. **Expected post-analysis state** — per-instruction table of the
+   operand stack and locals after each instruction, matching the
+   v0.2 AC#1 transfer functions.
+
+Keep fixtures inside the v0.2 AC#1 supported instruction set:
+`i32.const`, `i64.const`, `local.get`, `local.set`, `local.tee`,
+`i32.add`, `i32.sub`, `i32.mul`, `end`, `return`. Anything else
+hits the fallback path (UnsoundnessFallback diagnostic + locals
+degraded to top) which is also a valid thing to demonstrate but
+should be called out explicitly in the `.md`.

--- a/crates/scry-analyzer/test-fixtures/fixture-01-constant-fold.md
+++ b/crates/scry-analyzer/test-fixtures/fixture-01-constant-fold.md
@@ -1,0 +1,45 @@
+# fixture-01-constant-fold
+
+Pure constant folding through `i32.add` and `i32.mul`. The analyzer
+should see the operand stack collapse to a singleton interval at every
+program point: `(10 + 32) * 2 = 84`.
+
+## Source
+
+```wat
+(module
+  (func (export "compute") (result i32)
+    i32.const 10
+    i32.const 32
+    i32.add
+    i32.const 2
+    i32.mul))
+```
+
+## Expected post-analysis state
+
+Per-instruction operand stack (top-of-stack rightmost):
+
+| pc | op            | operand stack after                            |
+|----|---------------|------------------------------------------------|
+|  0 | `i32.const 10`| `[ {lo:10,hi:10} ]`                            |
+|  1 | `i32.const 32`| `[ {lo:10,hi:10}, {lo:32,hi:32} ]`             |
+|  2 | `i32.add`     | `[ {lo:42,hi:42} ]`                            |
+|  3 | `i32.const 2` | `[ {lo:42,hi:42}, {lo:2,hi:2} ]`               |
+|  4 | `i32.mul`     | `[ {lo:84,hi:84} ]`                            |
+|  5 | `end`         | `[ {lo:84,hi:84} ]`                            |
+
+Final operand top is `i32-interval { lo: 84, hi: 84 }`.
+
+The function has no locals, so every `ProgramPoint` carries an empty
+`locals` list. The interesting evidence here is on the operand stack —
+the host harness (FEAT-008's loom integration) will pull it via a
+follow-on extension to the WIT interface; v0.2 AC#1 only emits the
+locals snapshot.
+
+## Why this fixture
+
+Demonstrates the lattice's constant-fold path end-to-end: every
+`i32_add` / `i32_mul` call into the wasm-lattice component returns a
+singleton interval, exercising the cross-component import on the
+non-degenerate path.

--- a/crates/scry-analyzer/test-fixtures/fixture-01-constant-fold.wat
+++ b/crates/scry-analyzer/test-fixtures/fixture-01-constant-fold.wat
@@ -1,0 +1,7 @@
+(module
+  (func (export "compute") (result i32)
+    i32.const 10
+    i32.const 32
+    i32.add
+    i32.const 2
+    i32.mul))

--- a/crates/scry-analyzer/test-fixtures/fixture-02-with-param.md
+++ b/crates/scry-analyzer/test-fixtures/fixture-02-with-param.md
@@ -1,0 +1,50 @@
+# fixture-02-with-param
+
+Adds an unknown parameter to the constant-fold pattern from
+fixture-01. The analyzer initializes parameter 0 to `domain::top()`
+(we know nothing about the caller's argument until summary-based AI
+lands at FEAT-007), then adds a constant. Per the wasm-lattice's
+overflow rule, the result widens back to top.
+
+## Source
+
+```wat
+(module
+  (func (export "doit") (param i32) (result i32)
+    local.get 0
+    i32.const 5
+    i32.add))
+```
+
+## Expected post-analysis state
+
+Per-instruction operand stack (top-of-stack rightmost):
+
+| pc | op             | operand stack after                            |
+|----|----------------|------------------------------------------------|
+|  0 | `local.get 0`  | `[ top ]`                                      |
+|  1 | `i32.const 5`  | `[ top, {lo:5,hi:5} ]`                         |
+|  2 | `i32.add`      | `[ top ]` (overflow → widens to top)           |
+|  3 | `end`          | `[ top ]`                                      |
+
+Per-program-point locals snapshot (one local: param 0):
+
+| pc | locals snapshot              |
+|----|------------------------------|
+|  0 | `[ local 0 = top ]`          |
+|  1 | `[ local 0 = top ]`          |
+|  2 | `[ local 0 = top ]`          |
+|  3 | `[ local 0 = top ]`          |
+
+The locals never change (no `local.set` / `local.tee`); the
+interesting evidence is again on the operand stack.
+
+## Why this fixture
+
+Validates two things:
+1. Parameter initialization: scry must mark function parameters as
+   `top` (unknown), not as the analyzer's choice of constant.
+2. The wasm-lattice's saturation rule (`i32_add` of `top + {5,5}` →
+   `top`, because `i64::MAX + 5` would exceed `i32::MAX`) is
+   exercised on a real input, not just unit-tested on the lattice
+   crate.

--- a/crates/scry-analyzer/test-fixtures/fixture-02-with-param.wat
+++ b/crates/scry-analyzer/test-fixtures/fixture-02-with-param.wat
@@ -1,0 +1,5 @@
+(module
+  (func (export "doit") (param i32) (result i32)
+    local.get 0
+    i32.const 5
+    i32.add))


### PR DESCRIPTION
## Summary

Lands FEAT-001 acceptance criterion #1 — the v0.2 real interval-domain
abstract-interpretation fixpoint. Replaces the v0.1.0 scaffold's
hardcoded invariant bundle with a real pass that parses the input Wasm
Core Model module, walks straight-line arithmetic in each function,
and calls the imported `pulseengine:wasm-lattice/domain` interface for
every transfer function (DD-008 dogfood preserved).

## What now works

For each defined function in the input module:

1. Parameters → `domain::top()`, declared locals → `domain::constant_i32(0)` (Wasm zero-init).
2. Walks `wasmparser::OperatorsReader` and maintains an abstract operand stack.
3. Emits a `ProgramPoint` snapshot of locals after each handled instruction.
4. Reports `SHA-256(module_bytes)` in `invariant_bundle.module_sha256`.

Supported operators at v0.2 AC#1 (the straight-line arithmetic core):

| op                       | transfer                                    |
|--------------------------|---------------------------------------------|
| `i32.const N`            | push `domain::constant_i32(N)`              |
| `i64.const N`            | push `I64Interval(domain::constant_i64(N))` |
| `local.get i`            | push `locals[i]`                            |
| `local.set i`            | pop, `locals[i] = ...`                      |
| `local.tee i`            | `locals[i] = top` (no pop)                  |
| `i32.add` / `sub` / `mul`| pop a, pop b, push `domain::i32_op(b, a)`   |
| `end`                    | continue                                    |
| `return`                 | emit final point and break the function     |

Cross-component lattice probe (`domain::constant_i32(42) == {42, 42}`)
runs first and emits a single `Info` diagnostic on success, an
`UnsoundnessFallback` if the wac wire-up is broken.

## What's deferred (emits `UnsoundnessFallback`, scrubs locals to top)

Everything outside the arithmetic core. The unsupported-op branch
preserves soundness (REQ-001) by widening every local to `domain::top()`
before continuing:

- Control flow: `block`, `loop`, `if`, `else`, `br`, `br_if`, `br_table`, `select` → FEAT-006 (sound call-graph + reachability).
- Memory ops: `i32.load`, `i32.store`, `memory.size`, `memory.grow` → FEAT-005 (region-based memory).
- Calls: `call`, `call_indirect` → FEAT-006 + FEAT-007 (summary-based interprocedural).
- Reference types, GC, SIMD, tail calls, atomics → out of scope for v0.x.

## Concrete examples

Two `.wat` fixtures + adjacent `.md` docs in `crates/scry-analyzer/test-fixtures/`:

- **`fixture-01-constant-fold.wat`** — `(10 + 32) * 2`. Every operand stack
  state collapses to a singleton interval; final top is `{lo:84, hi:84}`.
  Exercises the cross-component lattice on the non-degenerate path.

- **`fixture-02-with-param.wat`** — `param i32 + 5`. Parameter initialized
  to top; result widens back to top per the lattice's saturation rule
  (`top + {5,5}` overflows `i32::MAX`). Pins the parameter-init rule and
  the saturation rule on a real input.

The Wasm-host harness named in FEAT-001 AC#3 (`crates/scry-host-tests`)
is not in this PR — Bazel doesn't currently expose a way to spin up
wasmtime + call into a composed component as a `cargo test` assertion,
so the end-to-end host loop lands separately. The fixtures plug in
unchanged when the harness arrives.

## Gates

- `bazel build //:scry` — green, ~5 min cold, produces `bazel-bin/scry.wasm`.
- `wasm-tools validate bazel-bin/scry.wasm` — accepts.
- `rivet validate` — PASS (0 warnings).
- Workspace + crate deps `default-features = false` so the crate
  stays `#![no_std]` and compiles cleanly to `wasm32-wasip2`.

## Files touched

- `Cargo.toml` (workspace) — add `wasmparser = "0.247"` + `sha2 = "0.10"` deps, both no-default-features.
- `Cargo.lock` — regenerated via `cargo generate-lockfile` (12 new transitive crates).
- `crates/scry-analyzer/Cargo.toml` — pull in `wasmparser` + `sha2` from workspace, drop the placeholder comment.
- `crates/scry-analyzer/BUILD.bazel` — add `deps = ["@scry_crates//:wasmparser", "@scry_crates//:sha2"]` to the `rust_wasm_component_bindgen` rule. Explicit `@scry_crates` repo name because `@crates` is shadowed by `rules_wasm_component`'s internal `crate_universe`.
- `crates/scry-analyzer/src/lib.rs` — full rewrite (588 lines). Two-pass design: first pass collects function types + import-func count, second pass walks the code section and interprets each operator via the shared lattice.
- `crates/scry-analyzer/test-fixtures/` (new) — two fixtures + `README.md`.
- `artifacts/requirements.yaml` — FEAT-001 description updated to describe AC#1 behaviour, tag `v0.2` added, link to FEAT-007 added (mentioned in prose).

## Test plan

- [x] `bazel build //:scry` succeeds.
- [x] `wasm-tools validate bazel-bin/scry.wasm` accepts.
- [x] `rivet validate` PASS (0 warnings).
- [ ] CI green on PR.
- [ ] Follow-up PR adds the wasmtime-host fixture harness (FEAT-001 AC#3) that drives the composed component against the two `.wat` files in this PR and asserts on `analysis-result`.