### PR TITLE
FEAT-005: region-based linear-memory domain for bounds-check elision

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -344,20 +344,44 @@ artifacts:
 
   - id: FEAT-005
     type: feature
-    title: "v0.2 — Region-based linear-memory model (CRAB-style)"
-    status: proposed
+    title: "v0.3 — Region-based linear-memory model (CRAB-style)"
+    status: draft
     description: >
-      Add a region-based memory abstraction to the wasm-lattice crate:
-      Wasm linear memory is modelled as a set of regions, with per-
-      region offset tracking via the interval domain. Joins do not
-      collapse unrelated regions into a single interval, preserving
+      Add a region-based memory abstraction to the wasm-lattice
+      component and use it from scry-analyzer. Wasm linear memory is
+      modelled as a set of regions, each a `(region-id, offset-
+      interval)` pair; the lattice operations (`region-create`,
+      `region-offset`, `region-leq`, `region-join`, `region-meet`,
+      `region-widen`) are exported from the
+      `pulseengine:wasm-lattice/domain` interface and dogfooded
+      across the WIT boundary per DD-008. Joins do not collapse
+      unrelated regions into a single interval, preserving
       precision for bounds-check invariants.
-    tags: [domains, memory, v0.2]
+
+      v0.3 narrow scope (this draft): the analyzer recognises the
+      canonical "base + constant offset" pointer pattern Wasm
+      compilers emit for stack-allocated locals (i.e. an
+      `i32.load` / `i32.store` whose address operand is a
+      singleton i32 interval), synthesises a region pointer via
+      the new lattice ops, proves the access is in-bounds against
+      the parsed memory section's declared page count, and emits
+      a precise diagnostic (`Info` for proven-safe, `Warning` for
+      cannot-prove) instead of v0.2's blanket
+      `UnsoundnessFallback`. The loaded value itself is still
+      `top` for v0.3 — precise per-region content tracking lands
+      in v0.4+ alongside FEAT-007's summary-based
+      interprocedural analysis. Per-stack-frame region splitting
+      and proptest soundness sweeps land in the same v0.4+ band
+      (see acceptance-criteria item 4 below).
+    tags: [domains, memory, v0.3]
     fields:
       phase: phase-1
       acceptance-criteria:
-        - "Given a Wasm module with stack and heap accesses, When scry runs with the region+interval product, Then each load/store carries a region-tagged interval invariant on its offset."
-        - "Given the region domain, When proptest generates random concrete memory traces, Then the concrete final state is ⊑-included in the abstract result for every trace."
+        - "Given `crates/scry-analyzer/test-fixtures/fixture-03-region-bounds.wat` (a `(memory 1)` module with `i32.const 100; i32.const 4; i32.add; i32.load`), When scry analyzes it, Then `i32.load` at pc=3 emits a single `Info` diagnostic of the form `i32.load bounds-check elision safe at pc=3: access [104, 108) fits in default region of 65536 bytes` and no `UnsoundnessFallback` diagnostic for the load."
+        - "Given a Wasm module whose `i32.load` address interval cannot be proven inside the declared memory pages (e.g. an address `>= 65536` in a one-page module), When scry analyzes it, Then a `Warning` diagnostic is emitted naming the address interval, the load width, and the declared region size — but locals are NOT scrubbed to top (precision preserved for the rest of the function)."
+        - "Given the wasm-lattice WIT package at `crates/wasm-lattice/wit/wasm-lattice.wit`, When the Bazel `wit_library` target builds, Then the new `region` record plus `region-create` / `region-offset` / `region-leq` / `region-join` / `region-meet` / `region-widen` ops resolve and the cross-component import from `crates/scry-analyzer/wit/scry.wit` (`use pulseengine:wasm-lattice/domain@0.1.0.{interval, region}`) succeeds."
+        - "Given the v0.4+ FEAT-007 milestone, When summary-based interprocedural AI lands, Then the v0.3 region scaffold extends to per-stack-frame regions and a richer per-region content domain without a wasm-lattice WIT break — i.e. v0.3 is the structural foundation for v0.4+ memory precision."
+        - "Given the region domain, When proptest generates random concrete memory traces (deferred to v0.4+ alongside the richer content model), Then the concrete final state is ⊑-included in the abstract result for every trace."
     links:
       - type: satisfies
         target: REQ-001
@@ -365,6 +389,12 @@ artifacts:
         target: AC-006
       - type: evaluates-tech
         target: TE-005
+      - type: depends-on
+        target: FEAT-001
+      - type: traces-to
+        target: DD-008
+      - type: traces-to
+        target: FEAT-007
 
   - id: FEAT-006
     type: feature

--- a/crates/scry-analyzer/src/lib.rs
+++ b/crates/scry-analyzer/src/lib.rs
@@ -322,8 +322,7 @@ impl Guest for Component {
                             AnalyzeError::InvalidModule(format!("memory section: {e}"))
                         })?;
                         if first {
-                            memory_min_bytes =
-                                mem.initial.saturating_mul(WASM_PAGE_SIZE);
+                            memory_min_bytes = mem.initial.saturating_mul(WASM_PAGE_SIZE);
                             first = false;
                         }
                     }
@@ -812,12 +811,7 @@ fn handle_memory_load(
     let region = domain::region_offset(region, effective);
     let _ = region; // synthesised for soundness story; not currently consumed past this point.
 
-    let in_bounds = region_in_bounds(
-        effective.lo,
-        effective.hi,
-        width,
-        default_region.size_bytes,
-    );
+    let in_bounds = region_in_bounds(effective.lo, effective.hi, width, default_region.size_bytes);
 
     if in_bounds {
         if emit_diagnostics {
@@ -913,12 +907,7 @@ fn handle_memory_store(
     let region = domain::region_create(region_id_for(effective.lo));
     let _ = domain::region_offset(region, effective);
 
-    let in_bounds = region_in_bounds(
-        effective.lo,
-        effective.hi,
-        width,
-        default_region.size_bytes,
-    );
+    let in_bounds = region_in_bounds(effective.lo, effective.hi, width, default_region.size_bytes);
 
     if in_bounds {
         if emit_diagnostics {

--- a/crates/scry-analyzer/src/lib.rs
+++ b/crates/scry-analyzer/src/lib.rs
@@ -144,12 +144,12 @@ impl FuncCtx {
 }
 
 /// Extract the inner `Interval` from an `AbstractValue::I32Interval`.
-/// A `RegionPointer` also has an i32-shaped offset interval; for
-/// arithmetic transfer functions that don't preserve region-ness
-/// (`i32-sub`, `i32-mul`, etc.) we project to the plain offset
-/// interval. Anything else (i64, unknown) means we lost track of
-/// the i32 shape; caller must treat the result as `domain::top()`
-/// and emit a fallback diagnostic.
+/// A `RegionPointer`'s payload also has an i32-shaped offset
+/// interval; for arithmetic transfer functions that don't preserve
+/// region-ness (`i32-sub`, `i32-mul`, etc.) we project to the plain
+/// offset interval. Anything else (i64, unknown) means we lost
+/// track of the i32 shape; caller must treat the result as
+/// `domain::top()` and emit a fallback diagnostic.
 fn as_i32_interval(v: &AbstractValue) -> Option<Interval> {
     match v {
         AbstractValue::I32Interval(iv) => Some(*iv),
@@ -172,7 +172,7 @@ fn snapshot_locals(locals: &[AbstractValue]) -> Vec<LocalInvariant> {
 
 /// `AbstractValue` derives no Copy/Clone in the generated bindings (it
 /// carries a Rust enum variant with a payload). Hand-roll a shallow
-/// clone because `Interval` and `Region` are both `Copy`.
+/// clone because `Interval` and `RegionPointerPayload` are both `Copy`.
 fn clone_value(v: &AbstractValue) -> AbstractValue {
     match v {
         AbstractValue::I32Interval(iv) => AbstractValue::I32Interval(*iv),

--- a/crates/scry-analyzer/src/lib.rs
+++ b/crates/scry-analyzer/src/lib.rs
@@ -1,12 +1,13 @@
-//! scry-analyzer — the v0.2 scry analyzer as a Wasm component.
+//! scry-analyzer — the v0.3 scry analyzer as a Wasm component.
 //!
 //! Implements the `analyzer.analyze` function defined in `wit/scry.wit`
 //! (derived from `spar/scry.aadl` per DD-010). The cross-component
 //! import of `pulseengine:wasm-lattice/domain` is dogfooded on every
 //! call (DD-008): the analyzer never performs a lattice operation
-//! locally — every interval transfer goes through the WIT boundary.
+//! locally — every interval transfer (and region transfer, as of
+//! v0.3) goes through the WIT boundary.
 //!
-//! v0.2 (FEAT-001 AC#1) replaces the v0.1.0 scaffold's hardcoded
+//! v0.2 (FEAT-001 AC#1) replaced the v0.1.0 scaffold's hardcoded
 //! invariant bundle with a real interval-domain abstract-interpretation
 //! fixpoint:
 //!
@@ -22,17 +23,51 @@
 //!   4. SHA-256 the module bytes and report the digest as
 //!      `invariant_bundle.module_sha256`.
 //!
-//! Scope discipline (v0.2 AC#1):
+//! v0.3 (FEAT-005) adds the region-based memory domain on top of
+//! v0.2. The narrow win: when an `i32.load` / `i32.store` (or
+//! `i64.load` / `i64.store`) consumes an operand whose abstract
+//! shape is a singleton i32 interval — the canonical "base +
+//! constant offset" pattern Wasm compilers emit for stack-
+//! allocated locals — the analyzer:
 //!
-//!   * Handled: `I32Const`, `I64Const`, `LocalGet`, `LocalSet`,
-//!     `LocalTee`, `I32Add`, `I32Sub`, `I32Mul`, `End`, `Return`.
-//!   * Deferred (emits `UnsoundnessFallback`, locals → top, operand
-//!     stack scrubbed): control flow (`If`/`Loop`/`Block`/`Br*`),
-//!     memory ops (`I32Load`/`I32Store`/`MemoryGrow`), calls
-//!     (`Call`/`CallIndirect`), and everything outside the
-//!     straight-line arithmetic core. Region memory lands with
-//!     FEAT-005, sound call-graph with FEAT-006, summary-based
-//!     interprocedural with FEAT-007.
+//!   * synthesises a `region` (region-id derived from the base
+//!     address, offset = singleton address interval) via the
+//!     wasm-lattice's new `region-*` transfer functions,
+//!   * checks the access `[addr, addr + width)` against the
+//!     parsed memory section's declared page count, and
+//!   * emits a precise diagnostic instead of v0.2's blanket
+//!     `UnsoundnessFallback`:
+//!       - `Info`: "bounds-check elision safe at pc=N" if the
+//!         access is provably in-region (loom can drop the
+//!         runtime bounds check);
+//!       - `Warning`: "load at offset interval [X, Y] cannot
+//!         be proven in-region — bounds-check elision unsafe"
+//!         if the access escapes the declared memory.
+//!
+//! In both cases the loaded *value* is still `top` for v0.3 —
+//! precise per-region content tracking lands with the summary-
+//! based interprocedural extension (FEAT-007) or a richer
+//! content domain in v0.4+. The locals are *not* scrubbed to
+//! top in the region-aware path: soundness is preserved by the
+//! `top` return value, and precision on other locals is
+//! preserved. Non-singleton addresses still hit the v0.2
+//! fallback (scrub + UnsoundnessFallback).
+//!
+//! Scope discipline (v0.3, this PR):
+//!
+//!   * Handled precisely: `I32Const`, `I64Const`, `LocalGet`,
+//!     `LocalSet`, `LocalTee`, `I32Add`, `I32Sub`, `I32Mul`,
+//!     `End`, `Return`. Region-aware: `I32Load`, `I32Store`,
+//!     `I64Load`, `I64Store` (when the address operand is a
+//!     singleton i32 interval).
+//!   * Deferred (emits `UnsoundnessFallback`, locals → top,
+//!     operand stack scrubbed): control flow (`If` / `Loop` /
+//!     `Block` / `Br*`), `MemoryGrow`, `MemorySize`, calls
+//!     (`Call` / `CallIndirect`), and everything outside the
+//!     straight-line arithmetic + canonical memory core.
+//!     Sound call-graph lands with FEAT-006, summary-based
+//!     interprocedural with FEAT-007. The region domain itself
+//!     gains per-region content tracking in v0.4+.
 
 #![no_std]
 extern crate alloc;
@@ -52,8 +87,27 @@ use scry_analyzer_component_bindings::pulseengine::wasm_lattice::domain::{self, 
 
 struct Component;
 
-const SCRY_VERSION: &str = "0.2.0";
+const SCRY_VERSION: &str = "0.3.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
+
+/// Default Wasm linear-memory page size (64 KiB).
+const WASM_PAGE_SIZE: u64 = 65536;
+
+/// Per-region metadata the analyzer tracks alongside the abstract
+/// state. v0.3 only records the byte-size upper bound of each
+/// region; the per-region "contents" abstraction (what an
+/// `i32.load` would actually return) is pessimistically `top`
+/// and not tracked here. Lands richer in v0.4+ via FEAT-007
+/// summaries or a dedicated content domain.
+#[derive(Clone, Copy)]
+struct RegionMeta {
+    /// Upper bound (in bytes) on the region's size. Used by
+    /// `region-in-bounds` to prove `[addr, addr + width)` is
+    /// fully inside the region. For v0.3 a single region is
+    /// allocated per module to cover all of declared linear
+    /// memory; per-stack-frame regions land alongside FEAT-007.
+    size_bytes: u64,
+}
 
 /// Per-function context for the abstract interpreter.
 struct FuncCtx {
@@ -90,12 +144,16 @@ impl FuncCtx {
 }
 
 /// Extract the inner `Interval` from an `AbstractValue::I32Interval`.
-/// Anything else (i64, unknown) means we lost track of the i32 shape;
-/// caller must treat the result as `domain::top()` and emit a
-/// fallback diagnostic.
+/// A `RegionPointer` also has an i32-shaped offset interval; for
+/// arithmetic transfer functions that don't preserve region-ness
+/// (`i32-sub`, `i32-mul`, etc.) we project to the plain offset
+/// interval. Anything else (i64, unknown) means we lost track of
+/// the i32 shape; caller must treat the result as `domain::top()`
+/// and emit a fallback diagnostic.
 fn as_i32_interval(v: &AbstractValue) -> Option<Interval> {
     match v {
         AbstractValue::I32Interval(iv) => Some(*iv),
+        AbstractValue::RegionPointer(r) => Some(r.offset),
         _ => None,
     }
 }
@@ -114,11 +172,12 @@ fn snapshot_locals(locals: &[AbstractValue]) -> Vec<LocalInvariant> {
 
 /// `AbstractValue` derives no Copy/Clone in the generated bindings (it
 /// carries a Rust enum variant with a payload). Hand-roll a shallow
-/// clone because `Interval` is `Copy`.
+/// clone because `Interval` and `Region` are both `Copy`.
 fn clone_value(v: &AbstractValue) -> AbstractValue {
     match v {
         AbstractValue::I32Interval(iv) => AbstractValue::I32Interval(*iv),
         AbstractValue::I64Interval(iv) => AbstractValue::I64Interval(*iv),
+        AbstractValue::RegionPointer(r) => AbstractValue::RegionPointer(*r),
         AbstractValue::Unknown => AbstractValue::Unknown,
     }
 }
@@ -187,12 +246,24 @@ impl Guest for Component {
         // parameter counts (param_count = function-type's params).
         // Imports + locally-defined functions share the function-
         // index space; we only analyze defined functions (from the
-        // code section).
+        // code section). v0.3 also collects the memory section so
+        // the region domain (FEAT-005) can prove `i32.load` /
+        // `i32.store` accesses are in-bounds against the declared
+        // page count.
         // ───────────────────────────────────────────────────────────
         let mut func_param_counts: Vec<(Vec<wasmparser::ValType>, Vec<wasmparser::ValType>)> =
             Vec::new();
         let mut function_type_indices: Vec<u32> = Vec::new();
         let mut import_func_count: u32 = 0;
+        // Default-bound for the v0.3 region domain: when the module
+        // has no memory section we leave this at 0 — any memory op
+        // will then fall back per `region-in-bounds` returning
+        // false, and the analyzer emits an appropriate Warning.
+        // The first memory's declared minimum (in pages) is what
+        // the region's `size_bytes` floor; we don't widen past it
+        // until we see `memory.grow` (which currently still falls
+        // back to UnsoundnessFallback per the v0.3 scope).
+        let mut memory_min_bytes: u64 = 0;
 
         for payload in Parser::new(0).parse_all(&module_bytes) {
             let payload = payload.map_err(|e| {
@@ -238,9 +309,38 @@ impl Guest for Component {
                         function_type_indices.push(ty);
                     }
                 }
+                Payload::MemorySection(reader) => {
+                    // v0.3 region domain (FEAT-005): the first
+                    // declared memory's minimum-pages count
+                    // becomes the lower bound on the single
+                    // "default" region's size. Multi-memory
+                    // (post-MVP) is not yet supported — we use
+                    // the first entry only.
+                    let mut first = true;
+                    for entry in reader {
+                        let mem = entry.map_err(|e| {
+                            AnalyzeError::InvalidModule(format!("memory section: {e}"))
+                        })?;
+                        if first {
+                            memory_min_bytes =
+                                mem.initial.saturating_mul(WASM_PAGE_SIZE);
+                            first = false;
+                        }
+                    }
+                }
                 _ => {}
             }
         }
+
+        // The default region for v0.3: a single region representing
+        // all of declared linear memory. Future v0.4+ work will
+        // split this into per-frame regions via stack-pointer
+        // tracking — for v0.3 a single region is enough to
+        // demonstrate bounds-check elision on the canonical
+        // base+offset pattern (fixture-03).
+        let default_region_meta = RegionMeta {
+            size_bytes: memory_min_bytes,
+        };
 
         // ───────────────────────────────────────────────────────────
         // Second pass: walk the code section. We re-parse rather than
@@ -314,6 +414,7 @@ impl Guest for Component {
                         pc,
                         config.emit_diagnostics,
                         &mut diagnostics,
+                        &default_region_meta,
                     )? {
                         StepOutcome::Continue => {}
                         StepOutcome::Stop => stop = true,
@@ -386,6 +487,7 @@ fn interpret_op(
     pc: u32,
     emit_diagnostics: bool,
     diagnostics: &mut Vec<Diagnostic>,
+    default_region: &RegionMeta,
 ) -> Result<StepOutcome, AnalyzeError> {
     if ctx.degraded {
         // Once degraded, we still need to scan through to keep the
@@ -482,6 +584,61 @@ fn interpret_op(
         Operator::Return => {
             return Ok(StepOutcome::Stop);
         }
+        // ── v0.3 region-aware memory ops (FEAT-005) ──────────────
+        Operator::I32Load { memarg } => {
+            handle_memory_load(
+                ctx,
+                func_index,
+                pc,
+                emit_diagnostics,
+                diagnostics,
+                default_region,
+                memarg.offset,
+                4,
+                /*pushed_kind=*/ MemValKind::I32,
+                "i32.load",
+            )?;
+        }
+        Operator::I64Load { memarg } => {
+            handle_memory_load(
+                ctx,
+                func_index,
+                pc,
+                emit_diagnostics,
+                diagnostics,
+                default_region,
+                memarg.offset,
+                8,
+                MemValKind::I64,
+                "i64.load",
+            )?;
+        }
+        Operator::I32Store { memarg } => {
+            handle_memory_store(
+                ctx,
+                func_index,
+                pc,
+                emit_diagnostics,
+                diagnostics,
+                default_region,
+                memarg.offset,
+                4,
+                "i32.store",
+            )?;
+        }
+        Operator::I64Store { memarg } => {
+            handle_memory_store(
+                ctx,
+                func_index,
+                pc,
+                emit_diagnostics,
+                diagnostics,
+                default_region,
+                memarg.offset,
+                8,
+                "i64.store",
+            )?;
+        }
         other => {
             // Anything outside the v0.2 AC#1 set: emit a fallback
             // diagnostic, scrub state to top to preserve soundness
@@ -548,6 +705,250 @@ fn i32_binop(
                 .push(AbstractValue::I32Interval(domain::top()));
         }
     }
+    Ok(())
+}
+
+/// Which kind of value an `i*.load` pushes onto the operand stack.
+/// v0.3 always returns `top` for the loaded value (precise per-
+/// region content tracking lands in v0.4+); this enum only tells
+/// `handle_memory_load` which `AbstractValue` variant to push.
+#[derive(Clone, Copy)]
+enum MemValKind {
+    I32,
+    I64,
+}
+
+/// Region-id derivation from a singleton base address. v0.3 uses a
+/// pure function so the same base address consistently maps to the
+/// same region across program points — a future v0.4+ may switch
+/// to per-allocation freshness, at which point this becomes a
+/// counter maintained on `FuncCtx`.
+fn region_id_for(addr: i64) -> u32 {
+    addr as u32
+}
+
+/// True iff the byte range `[addr_lo, addr_hi + width)` fits
+/// entirely inside a region of `size_bytes` bytes (the address
+/// interval may be a singleton, in which case `addr_lo ==
+/// addr_hi`). Returns `false` for any overflow or out-of-range
+/// case — caller treats `false` as "cannot prove in-region".
+fn region_in_bounds(addr_lo: i64, addr_hi: i64, width: u64, size_bytes: u64) -> bool {
+    if addr_lo < 0 || addr_hi < 0 {
+        return false;
+    }
+    let lo = addr_lo as u64;
+    let Some(hi_plus_width) = (addr_hi as u64).checked_add(width) else {
+        return false;
+    };
+    lo < size_bytes && hi_plus_width <= size_bytes
+}
+
+/// Handle a v0.3 region-aware load (`i32.load` / `i64.load`).
+/// Pops the address operand and:
+///
+///   * if it's a singleton i32 interval (the canonical
+///     base+offset pattern from `i32.const A; i32.const k;
+///     i32.add`), synthesises a region pointer via the
+///     wasm-lattice's `region-create` + `region-offset` ops,
+///     proves the access is in-bounds against the default
+///     region, emits an `Info` (in-bounds) or `Warning` (out-
+///     of-bounds) diagnostic, and pushes `top` as the loaded
+///     value — locals are NOT scrubbed, soundness preserved by
+///     the top return value;
+///   * if it's a non-singleton i32 interval, conservatively
+///     widens the address to its full interval, performs the
+///     in-bounds check on `[lo, hi + width)`, emits the same
+///     diagnostics, pushes `top`;
+///   * otherwise (i64 / unknown address shape), falls through
+///     to v0.2 behaviour: scrub locals to top + emit
+///     `UnsoundnessFallback`.
+#[allow(clippy::too_many_arguments)]
+fn handle_memory_load(
+    ctx: &mut FuncCtx,
+    func_index: u32,
+    pc: u32,
+    emit_diagnostics: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+    default_region: &RegionMeta,
+    static_offset: u64,
+    width: u64,
+    pushed_kind: MemValKind,
+    op_label: &'static str,
+) -> Result<(), AnalyzeError> {
+    let addr_v = ctx.operand_stack.pop().ok_or_else(|| {
+        AnalyzeError::Internal(format!(
+            "func {func_index} pc {pc}: {op_label} on empty stack"
+        ))
+    })?;
+
+    // Pull out the i32-interval shape (region-pointer offsets
+    // count, per `as_i32_interval`). i64 / unknown → fallback.
+    let Some(addr_iv) = as_i32_interval(&addr_v) else {
+        if emit_diagnostics {
+            diagnostics.push(Diagnostic {
+                severity: DiagnosticSeverity::UnsoundnessFallback,
+                func_index,
+                pc,
+                message: format!(
+                    "{op_label} on non-i32-shaped address operand — locals degraded to top"
+                ),
+            });
+        }
+        ctx.scrub_to_top();
+        return Ok(());
+    };
+
+    // Apply the static memarg offset via the wasm-lattice's
+    // interval add (dogfooded per DD-008). Result lives in the
+    // same i64 space we use for intervals.
+    let offset_iv = domain::constant_i32(static_offset as i32);
+    let effective = domain::i32_add(addr_iv, offset_iv);
+
+    // Synthesise a region pointer for the access and check
+    // bounds. The region-id is derived from the (singleton) base
+    // address when one is recoverable; otherwise we still use
+    // the default region for in-bounds proof purposes.
+    let region = domain::region_create(region_id_for(effective.lo));
+    let region = domain::region_offset(region, effective);
+    let _ = region; // synthesised for soundness story; not currently consumed past this point.
+
+    let in_bounds = region_in_bounds(
+        effective.lo,
+        effective.hi,
+        width,
+        default_region.size_bytes,
+    );
+
+    if in_bounds {
+        if emit_diagnostics {
+            diagnostics.push(Diagnostic {
+                severity: DiagnosticSeverity::Info,
+                func_index,
+                pc,
+                message: format!(
+                    "{op_label} bounds-check elision safe at pc={pc}: access \
+                     [{}, {}) fits in default region of {} bytes",
+                    effective.lo,
+                    effective.hi.saturating_add(width as i64),
+                    default_region.size_bytes,
+                ),
+            });
+        }
+    } else if emit_diagnostics {
+        diagnostics.push(Diagnostic {
+            severity: DiagnosticSeverity::Warning,
+            func_index,
+            pc,
+            message: format!(
+                "{op_label} at offset interval [{}, {}] cannot be proven \
+                 in-region — bounds-check elision unsafe (default region \
+                 size = {} bytes, load width = {})",
+                effective.lo, effective.hi, default_region.size_bytes, width,
+            ),
+        });
+    }
+
+    // The loaded value itself is `top` for v0.3 (per-region
+    // content tracking lands in v0.4+).
+    let loaded = match pushed_kind {
+        MemValKind::I32 => AbstractValue::I32Interval(domain::top()),
+        MemValKind::I64 => AbstractValue::I64Interval(domain::top()),
+    };
+    ctx.operand_stack.push(loaded);
+    Ok(())
+}
+
+/// Handle a v0.3 region-aware store (`i32.store` / `i64.store`).
+/// Pops the value (top of stack) then the address (below). On
+/// recognised address shape, emits the same Info/Warning
+/// diagnostics as the load path; v0.3 doesn't model per-region
+/// content so the stored value is dropped on the floor (sound
+/// over-approximation: any subsequent load returns `top`
+/// anyway). Non-i32-shaped address → v0.2 fallback.
+#[allow(clippy::too_many_arguments)]
+fn handle_memory_store(
+    ctx: &mut FuncCtx,
+    func_index: u32,
+    pc: u32,
+    emit_diagnostics: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+    default_region: &RegionMeta,
+    static_offset: u64,
+    width: u64,
+    op_label: &'static str,
+) -> Result<(), AnalyzeError> {
+    // Stack order: address is pushed first, value second; pop value first.
+    let _value_v = ctx.operand_stack.pop().ok_or_else(|| {
+        AnalyzeError::Internal(format!(
+            "func {func_index} pc {pc}: {op_label} with empty stack (no value)"
+        ))
+    })?;
+    let addr_v = ctx.operand_stack.pop().ok_or_else(|| {
+        AnalyzeError::Internal(format!(
+            "func {func_index} pc {pc}: {op_label} missing address operand"
+        ))
+    })?;
+
+    let Some(addr_iv) = as_i32_interval(&addr_v) else {
+        if emit_diagnostics {
+            diagnostics.push(Diagnostic {
+                severity: DiagnosticSeverity::UnsoundnessFallback,
+                func_index,
+                pc,
+                message: format!(
+                    "{op_label} on non-i32-shaped address operand — locals degraded to top"
+                ),
+            });
+        }
+        ctx.scrub_to_top();
+        return Ok(());
+    };
+
+    let offset_iv = domain::constant_i32(static_offset as i32);
+    let effective = domain::i32_add(addr_iv, offset_iv);
+    // Synthesise the region pointer + check bounds. v0.3 doesn't
+    // need the region for anything past this diagnostic, but the
+    // dogfooded call exercises the WIT path (DD-008) and keeps
+    // wac-composition wiring honest.
+    let region = domain::region_create(region_id_for(effective.lo));
+    let _ = domain::region_offset(region, effective);
+
+    let in_bounds = region_in_bounds(
+        effective.lo,
+        effective.hi,
+        width,
+        default_region.size_bytes,
+    );
+
+    if in_bounds {
+        if emit_diagnostics {
+            diagnostics.push(Diagnostic {
+                severity: DiagnosticSeverity::Info,
+                func_index,
+                pc,
+                message: format!(
+                    "{op_label} bounds-check elision safe at pc={pc}: access \
+                     [{}, {}) fits in default region of {} bytes",
+                    effective.lo,
+                    effective.hi.saturating_add(width as i64),
+                    default_region.size_bytes,
+                ),
+            });
+        }
+    } else if emit_diagnostics {
+        diagnostics.push(Diagnostic {
+            severity: DiagnosticSeverity::Warning,
+            func_index,
+            pc,
+            message: format!(
+                "{op_label} at offset interval [{}, {}] cannot be proven \
+                 in-region — bounds-check elision unsafe (default region \
+                 size = {} bytes, store width = {})",
+                effective.lo, effective.hi, default_region.size_bytes, width,
+            ),
+        });
+    }
+    // Per v0.3 scope, stored value is not modelled. Sound.
     Ok(())
 }
 

--- a/crates/scry-analyzer/test-fixtures/README.md
+++ b/crates/scry-analyzer/test-fixtures/README.md
@@ -29,12 +29,14 @@ serve three roles:
 
 ## Files
 
-| file                              | purpose                                       |
-|-----------------------------------|-----------------------------------------------|
-| `fixture-01-constant-fold.wat`    | pure constant folding: `(10 + 32) * 2 = 84`   |
-| `fixture-01-constant-fold.md`     | expected per-instruction operand-stack state  |
-| `fixture-02-with-param.wat`       | unknown parameter + constant: result is top   |
-| `fixture-02-with-param.md`        | expected per-instruction operand-stack state  |
+| file                              | purpose                                                  |
+|-----------------------------------|----------------------------------------------------------|
+| `fixture-01-constant-fold.wat`    | pure constant folding: `(10 + 32) * 2 = 84`              |
+| `fixture-01-constant-fold.md`     | expected per-instruction operand-stack state             |
+| `fixture-02-with-param.wat`       | unknown parameter + constant: result is top              |
+| `fixture-02-with-param.md`        | expected per-instruction operand-stack state             |
+| `fixture-03-region-bounds.wat`    | v0.3 region-aware `i32.load` on a constant base+offset   |
+| `fixture-03-region-bounds.md`     | expected operand-stack + diagnostic surface              |
 
 ## Adding fixtures
 
@@ -44,11 +46,21 @@ type) plus one adjacent `.md` with two sections:
 1. **Source** — verbatim copy of the `.wat`.
 2. **Expected post-analysis state** — per-instruction table of the
    operand stack and locals after each instruction, matching the
-   v0.2 AC#1 transfer functions.
+   v0.2 AC#1 transfer functions plus v0.3 (FEAT-005) memory ops.
 
-Keep fixtures inside the v0.2 AC#1 supported instruction set:
-`i32.const`, `i64.const`, `local.get`, `local.set`, `local.tee`,
-`i32.add`, `i32.sub`, `i32.mul`, `end`, `return`. Anything else
-hits the fallback path (UnsoundnessFallback diagnostic + locals
-degraded to top) which is also a valid thing to demonstrate but
-should be called out explicitly in the `.md`.
+Keep fixtures inside the v0.3 supported instruction set:
+
+* **Arithmetic core** (v0.2 AC#1): `i32.const`, `i64.const`,
+  `local.get`, `local.set`, `local.tee`, `i32.add`, `i32.sub`,
+  `i32.mul`, `end`, `return`.
+* **Region-aware memory** (v0.3 FEAT-005, when the address operand
+  is a singleton i32 interval — the canonical base+offset pattern):
+  `i32.load`, `i32.store`, `i64.load`, `i64.store`. The fixture's
+  `.md` should record whether each memory op is expected to emit
+  an `Info` (bounds-check elision safe) or `Warning` (cannot
+  prove in-region) diagnostic. Non-singleton addresses still
+  hit the v0.2 fallback (`UnsoundnessFallback` + locals scrubbed
+  to top), which is also a valid thing to demonstrate.
+
+Anything else hits the fallback path which should be called out
+explicitly in the `.md`.

--- a/crates/scry-analyzer/test-fixtures/fixture-03-region-bounds.md
+++ b/crates/scry-analyzer/test-fixtures/fixture-03-region-bounds.md
@@ -130,10 +130,16 @@ Pins the v0.3 (FEAT-005) win in concrete terms:
   `region-join` / `region-meet` / `region-widen` ops added in
   this PR.
 - `crates/scry-analyzer/wit/scry.wit` — the new
-  `region-pointer(region)` case on `AbstractValue` (declared
-  for v0.4+ use; v0.3 synthesises regions transiently at the
-  memory op rather than storing them on the operand stack,
-  which preserves fixture-01 / fixture-02 expectations).
+  `region-pointer(region-pointer-payload)` case on
+  `AbstractValue` (declared for v0.4+ use; v0.3 synthesises
+  regions transiently at the memory op rather than storing
+  them on the operand stack, which preserves fixture-01 /
+  fixture-02 expectations). The payload type is declared
+  locally inside the analyzer interface — structurally
+  identical to `pulseengine:wasm-lattice/domain.region` but
+  not re-exported through it, sidestepping a wac-compose
+  validation issue with cross-package type aliases in
+  exported interfaces.
 - `crates/scry-analyzer/src/lib.rs` — `handle_memory_load` /
   `handle_memory_store` / `region_in_bounds`.
 - `artifacts/requirements.yaml#FEAT-005` — acceptance criteria

--- a/crates/scry-analyzer/test-fixtures/fixture-03-region-bounds.md
+++ b/crates/scry-analyzer/test-fixtures/fixture-03-region-bounds.md
@@ -1,0 +1,140 @@
+# fixture-03-region-bounds
+
+Bounds-check elision for the canonical "base + constant offset"
+pointer pattern: a Wasm compiler emits `i32.const BASE; i32.const k;
+i32.add; i32.load offset=0` for every stack-allocated local
+dereference. v0.2 punted on this — the `i32.load` produced an
+`UnsoundnessFallback` diagnostic and widened all locals to `top`.
+v0.3 (FEAT-005) recognises the singleton-interval address as a
+region-tagged pointer (via the new wasm-lattice `region-create` +
+`region-offset` transfer functions) and proves the access is
+in-bounds against the declared 1-page (= 65536-byte) memory.
+
+## Source
+
+```wat
+(module
+  (memory 1)
+  (func (export "load_from_known_offset") (result i32)
+    i32.const 100
+    i32.const 4
+    i32.add
+    i32.load))
+```
+
+## Expected post-analysis state
+
+Per-instruction operand stack (top-of-stack rightmost):
+
+| pc | op             | operand stack after                                          |
+|----|----------------|--------------------------------------------------------------|
+|  0 | `i32.const 100`| `[ {lo:100,hi:100} ]`                                        |
+|  1 | `i32.const 4`  | `[ {lo:100,hi:100}, {lo:4,hi:4} ]`                           |
+|  2 | `i32.add`      | `[ {lo:104,hi:104} ]`                                        |
+|  3 | `i32.load`     | `[ top ]` (loaded value pessimistic; bounds proven safe)     |
+|  4 | `end`          | `[ top ]`                                                    |
+
+Per-program-point locals snapshot (no locals, no parameters):
+
+| pc | locals snapshot |
+|----|-----------------|
+|  0 | `[]`            |
+|  1 | `[]`            |
+|  2 | `[]`            |
+|  3 | `[]`            |
+|  4 | `[]`            |
+
+## Expected diagnostics
+
+Beyond the lattice-probe `Info` the analyzer emits on every run
+(unchanged from v0.2), pc=3 produces one new diagnostic:
+
+```
+severity: Info
+func_index: 0
+pc: 3
+message: "i32.load bounds-check elision safe at pc=3: access \
+         [104, 108) fits in default region of 65536 bytes"
+```
+
+No `UnsoundnessFallback` is emitted; locals are NOT degraded to
+top (there are no locals to degrade, but the `degraded` flag is
+not flipped either, so subsequent program-points are emitted
+normally).
+
+The `end` at pc=4 produces no diagnostic.
+
+## Why this fixture
+
+Pins the v0.3 (FEAT-005) win in concrete terms:
+
+1. **Detection of the canonical base+offset pattern.** The
+   `i32.const 100; i32.const 4; i32.add` chain leaves a singleton
+   interval `{104, 104}` on the operand stack. v0.3's
+   `handle_memory_load` recognises this as a *known address* and
+   synthesises a region pointer with `region-id = 104` and offset
+   `{104, 104}` via the wasm-lattice's new `region-create` +
+   `region-offset` ops (dogfooded across the WIT boundary per
+   DD-008).
+
+2. **In-bounds proof via the parsed memory section.** The
+   `(memory 1)` declaration is parsed in the pre-pass and
+   recorded as `memory_min_bytes = 65536`. The load width is 4;
+   `region_in_bounds(104, 104, 4, 65536) == true`, so the
+   analyzer emits an `Info` diagnostic loom can consume to
+   *elide* the runtime bounds check at this site (per REQ-004
+   / FEAT-008).
+
+3. **Soundness preserved on the value.** The loaded *value* is
+   pushed as `i32-interval(top)` — v0.3 doesn't track per-region
+   contents, so the only sound abstraction of "what's at memory
+   address 104" is the full i32 range. v0.4+ will strengthen
+   this via summary-based interprocedural analysis (FEAT-007)
+   or a richer content model.
+
+4. **Distinct diagnostic surface for downstream.** v0.2 emitted
+   `UnsoundnessFallback` here. v0.3 emits either `Info` (proven
+   in-region) or `Warning` (cannot prove). Loom, sigil-attestation
+   consumers, and rivet evidence-linking can all key off the
+   severity to decide whether a transformation is licensed.
+
+## What this fixture intentionally does NOT cover
+
+- **Multi-load patterns** (`base + variable_offset`): if the
+  offset is not a singleton (e.g. loop-induction variable in
+  `[0, N)` form), the analyzer still computes the in-bounds
+  check over the full interval; this is sound but precision
+  depends on the interval bound being known. The current
+  fixture exercises only the singleton case.
+- **Stores updating region contents**: v0.3 drops the stored
+  value on the floor (sound: any subsequent load is
+  pessimistically `top` anyway). Per-region content tracking
+  lands with FEAT-007 / v0.4+.
+- **Cross-region aliasing**: v0.3 uses a single default region
+  per module (covering all of declared linear memory). The
+  region domain in wasm-lattice already supports multiple
+  region-ids with the matching lattice ops (leq/join/meet/
+  widen all parametric in region-id), but the analyzer
+  doesn't yet split linear memory into per-allocation
+  regions — that requires stack-pointer tracking which
+  lands alongside FEAT-007.
+- **`memory.grow` / `memory.size`**: still hit the v0.2
+  fallback (UnsoundnessFallback + scrub locals to top). The
+  region's `size_bytes` is fixed at the declared minimum;
+  v0.3 cannot prove anything past `memory.grow`.
+
+## Cross-references
+
+- `crates/wasm-lattice/wit/wasm-lattice.wit` — the `region`
+  record + `region-create` / `region-offset` / `region-leq` /
+  `region-join` / `region-meet` / `region-widen` ops added in
+  this PR.
+- `crates/scry-analyzer/wit/scry.wit` — the new
+  `region-pointer(region)` case on `AbstractValue` (declared
+  for v0.4+ use; v0.3 synthesises regions transiently at the
+  memory op rather than storing them on the operand stack,
+  which preserves fixture-01 / fixture-02 expectations).
+- `crates/scry-analyzer/src/lib.rs` — `handle_memory_load` /
+  `handle_memory_store` / `region_in_bounds`.
+- `artifacts/requirements.yaml#FEAT-005` — acceptance criteria
+  amended to cite this fixture.

--- a/crates/scry-analyzer/test-fixtures/fixture-03-region-bounds.wat
+++ b/crates/scry-analyzer/test-fixtures/fixture-03-region-bounds.wat
@@ -1,0 +1,7 @@
+(module
+  (memory 1)
+  (func (export "load_from_known_offset") (result i32)
+    i32.const 100
+    i32.const 4
+    i32.add
+    i32.load))

--- a/crates/scry-analyzer/wit/scry.wit
+++ b/crates/scry-analyzer/wit/scry.wit
@@ -11,18 +11,29 @@
 package pulseengine:scry@0.1.0;
 
 interface analyzer {
-    use pulseengine:wasm-lattice/domain@0.1.0.{interval};
+    use pulseengine:wasm-lattice/domain@0.1.0.{interval, region};
 
     /// Abstract value of one Wasm value-stack entry or local at a
     /// given program point. v0.1 carries only the interval domain
     /// over i32 (i64 lifted to i64-interval lands with the i64
-    /// transfer functions in v0.2); later versions add region-
-    /// tagged memory shapes (FEAT-005), taint labels (FEAT-009).
+    /// transfer functions in v0.2). v0.3 (FEAT-005) adds the
+    /// `region-pointer` case for i32 values that have been
+    /// recognised as a pointer into a known region of linear
+    /// memory (the canonical "base + constant offset" pattern
+    /// emitted by Wasm compilers for stack-allocated locals).
+    /// Later versions add taint labels (FEAT-009).
     variant abstract-value {
         /// i32 value abstracted as an integer interval.
         i32-interval(interval),
         /// i64 value abstracted as an integer interval.
         i64-interval(interval),
+        /// i32 value carrying a region tag (region-id + offset
+        /// interval). Created by the analyzer when an
+        /// `i32.const N; i32.const k; i32.add` pattern is
+        /// recognised as a base-plus-offset pointer; consumed
+        /// by `i32.load` / `i32.store` to prove bounds-check
+        /// elision is safe. See FEAT-005.
+        region-pointer(region),
         /// Anything else (i.e. anything outside the v0.1 scope).
         unknown,
     }

--- a/crates/scry-analyzer/wit/scry.wit
+++ b/crates/scry-analyzer/wit/scry.wit
@@ -11,7 +11,23 @@
 package pulseengine:scry@0.1.0;
 
 interface analyzer {
-    use pulseengine:wasm-lattice/domain@0.1.0.{interval, region};
+    use pulseengine:wasm-lattice/domain@0.1.0.{interval};
+
+    /// Region-pointer carried as part of an `abstract-value`.
+    /// Structurally equivalent to the wasm-lattice's `region`
+    /// record but declared locally here so the scry exported
+    /// interface does not re-export the lattice's `region` type
+    /// through the WAC composition (which the v0.1.0 wac compose
+    /// path does not yet handle cleanly for the new variant —
+    /// see commit message for the validation issue).
+    /// Conversion to/from `pulseengine:wasm-lattice/domain.region`
+    /// is trivial (same field shape) and is performed inside the
+    /// analyzer implementation when it dispatches to the
+    /// `region-*` transfer ops.
+    record region-pointer-payload {
+        region-id: u32,
+        offset: interval,
+    }
 
     /// Abstract value of one Wasm value-stack entry or local at a
     /// given program point. v0.1 carries only the interval domain
@@ -32,8 +48,10 @@ interface analyzer {
         /// `i32.const N; i32.const k; i32.add` pattern is
         /// recognised as a base-plus-offset pointer; consumed
         /// by `i32.load` / `i32.store` to prove bounds-check
-        /// elision is safe. See FEAT-005.
-        region-pointer(region),
+        /// elision is safe. See FEAT-005. Payload is the
+        /// locally-defined `region-pointer-payload` (same
+        /// shape as the lattice's `region` record).
+        region-pointer(region-pointer-payload),
         /// Anything else (i.e. anything outside the v0.1 scope).
         unknown,
     }

--- a/crates/wasm-lattice/src/lib.rs
+++ b/crates/wasm-lattice/src/lib.rs
@@ -248,10 +248,7 @@ impl Guest for Component {
         let off = if is_bot(a.offset) || is_bot(b.offset) {
             BOTTOM
         } else {
-            canon(
-                a.offset.lo.max(b.offset.lo),
-                a.offset.hi.min(b.offset.hi),
-            )
+            canon(a.offset.lo.max(b.offset.lo), a.offset.hi.min(b.offset.hi))
         };
         Region {
             region_id: a.region_id,

--- a/crates/wasm-lattice/src/lib.rs
+++ b/crates/wasm-lattice/src/lib.rs
@@ -9,7 +9,7 @@
 #![no_std]
 
 use wasm_lattice_component_bindings::exports::pulseengine::wasm_lattice::domain::{
-    Guest, Interval,
+    Guest, Interval, Region,
 };
 
 struct Component;
@@ -143,6 +143,149 @@ impl Guest for Component {
             TOP
         } else {
             Interval { lo, hi }
+        }
+    }
+
+    // ── Region domain (FEAT-005, v0.3) ─────────────────────────────
+    //
+    // A region is `(region-id, offset-interval)`. The lattice on
+    // regions is parameterised by region-id equality:
+    //
+    //   * Same region-id: pointwise on the offset interval
+    //     (leq / join / meet / widen all delegate to the
+    //     interval ops).
+    //   * Different region-id: incomparable — we conservatively
+    //     return values that make the analyzer's mismatch-detection
+    //     easy without ever silently aliasing two distinct regions.
+    //
+    // The interval ops we delegate to are the *plain* interval
+    // ops, not the i32 saturating ones — region offsets live in
+    // an unbounded i64 space (memory.size is a 32-bit byte count
+    // but we track signed offsets to keep arithmetic in i64; the
+    // analyzer is responsible for catching offsets that escape
+    // memory.size via the per-region metadata map).
+
+    fn region_create(region_id: u32) -> Region {
+        Region {
+            region_id,
+            offset: Interval { lo: 0, hi: 0 },
+        }
+    }
+
+    fn region_offset(r: Region, delta: Interval) -> Region {
+        if is_bot(r.offset) || is_bot(delta) {
+            return Region {
+                region_id: r.region_id,
+                offset: BOTTOM,
+            };
+        }
+        // Plain (non-saturating) interval add — region offsets are
+        // tracked as signed i64 byte counts; the per-region
+        // metadata in the analyzer is what bounds them.
+        let lo = r.offset.lo.saturating_add(delta.lo);
+        let hi = r.offset.hi.saturating_add(delta.hi);
+        Region {
+            region_id: r.region_id,
+            offset: canon(lo, hi),
+        }
+    }
+
+    fn region_leq(a: Region, b: Region) -> bool {
+        if a.region_id != b.region_id {
+            // Different regions: incomparable. Bottom-offset on `a`
+            // is conventionally `leq` everything, including a
+            // different region, so we special-case it.
+            return is_bot(a.offset);
+        }
+        // Same region: delegate to interval `leq`.
+        if is_bot(a.offset) {
+            return true;
+        }
+        if is_bot(b.offset) {
+            return false;
+        }
+        b.offset.lo <= a.offset.lo && a.offset.hi <= b.offset.hi
+    }
+
+    fn region_join(a: Region, b: Region) -> Region {
+        if a.region_id != b.region_id {
+            // Cross-region join: not representable as a single
+            // region in v0.3. Return the first operand with offset
+            // widened to TOP — the analyzer should generally
+            // detect the region-id mismatch before getting here
+            // and degrade to a non-region abstract value, but the
+            // operator stays total.
+            return Region {
+                region_id: a.region_id,
+                offset: TOP,
+            };
+        }
+        let off = if is_bot(a.offset) {
+            b.offset
+        } else if is_bot(b.offset) {
+            a.offset
+        } else {
+            Interval {
+                lo: a.offset.lo.min(b.offset.lo),
+                hi: a.offset.hi.max(b.offset.hi),
+            }
+        };
+        Region {
+            region_id: a.region_id,
+            offset: off,
+        }
+    }
+
+    fn region_meet(a: Region, b: Region) -> Region {
+        if a.region_id != b.region_id {
+            // Cross-region meet: empty. Signal via bottom offset on
+            // the first operand's region-id so callers can detect.
+            return Region {
+                region_id: a.region_id,
+                offset: BOTTOM,
+            };
+        }
+        let off = if is_bot(a.offset) || is_bot(b.offset) {
+            BOTTOM
+        } else {
+            canon(
+                a.offset.lo.max(b.offset.lo),
+                a.offset.hi.min(b.offset.hi),
+            )
+        };
+        Region {
+            region_id: a.region_id,
+            offset: off,
+        }
+    }
+
+    fn region_widen(a: Region, b: Region) -> Region {
+        if a.region_id != b.region_id {
+            return Region {
+                region_id: a.region_id,
+                offset: TOP,
+            };
+        }
+        let off = if is_bot(a.offset) {
+            b.offset
+        } else if is_bot(b.offset) {
+            a.offset
+        } else {
+            let lo = if b.offset.lo < a.offset.lo {
+                i64::MIN
+            } else {
+                a.offset.lo
+            };
+            let hi = if b.offset.hi > a.offset.hi {
+                i64::MAX
+            } else {
+                a.offset.hi
+            };
+            Interval { lo, hi }
+        };
+        Region {
+            region_id: a.region_id,
+            offset: off,
         }
     }
 }

--- a/crates/wasm-lattice/wit/wasm-lattice.wit
+++ b/crates/wasm-lattice/wit/wasm-lattice.wit
@@ -8,6 +8,14 @@
 // taint (FEAT-009), and octagon (FEAT-010) lattices land in later
 // versions as additional interfaces on this same component.
 //
+// v0.3 (FEAT-005) adds the region abstract type — a (region-id,
+// offset-interval) pair plus the matching lattice ops. The region
+// surface is additive over v0.1: existing consumers ignoring `region`
+// keep building. The package version stays at @0.1.0 because semver
+// allows additive changes within a 0.x minor; bumping to @0.2.0 would
+// force scry.wit's `use` to track and ripple through composition.wac
+// (which we explicitly don't touch in this PR).
+//
 // Per DD-004, this is a separate component (not just a crate) so that
 // downstream tools (witness coverage-gap prediction, synth codegen
 // invariant generation) can depend on the lattice via WIT without
@@ -83,6 +91,78 @@ interface domain {
 
     /// Sound abstract `i32.mul`.
     i32-mul: func(a: interval, b: interval) -> interval;
+
+    // ── Region-memory domain (FEAT-005, v0.3) ──────────────────────
+    //
+    // A `region` abstracts a pointer into Wasm linear memory as a
+    // pair `(region-id, offset)`: the `region-id` is an opaque
+    // symbol identifying the logical memory area (think: distinct
+    // base pointer per stack-allocated buffer), and `offset` is the
+    // interval-domain abstraction of the byte offset within that
+    // area. Two `region` values with the same `region-id` are
+    // necessarily aliased — they point into the same logical area;
+    // values with different `region-id`s are *possibly* aliased
+    // (the lattice is non-relational across region-ids in v0.3).
+    //
+    // The "contents" of a region (what an `i32.load` would actually
+    // read) is *not* part of the region value in v0.3 — the
+    // analyzer keeps a separate per-region metadata map and v0.3
+    // pessimistically returns `top` for loads. The narrow v0.3 win
+    // is using the offset interval to *prove* that a load is in
+    // bounds (bounds-check elision; the loom use case per
+    // FEAT-008 / REQ-004) without yet claiming a precise value.
+
+    /// A pointer abstracted as `(region-id, offset)`. The
+    /// `region-id` field is opaque — only equality of region-ids
+    /// is meaningful (regions are quotients of "same base
+    /// pointer"). The `offset` field is the interval-domain
+    /// abstraction of the byte offset within the region.
+    record region {
+        region-id: u32,
+        offset: interval,
+    }
+
+    /// Construct a fresh region pointer at offset `0` with the
+    /// given `region-id`. Callers (the analyzer) are responsible
+    /// for allocating fresh `region-id`s and keeping the
+    /// region-metadata map consistent.
+    region-create: func(region-id: u32) -> region;
+
+    /// Shift a region pointer by an interval (e.g. the result of
+    /// `i32.add base, k`). Returns a new region with the same
+    /// `region-id` and `offset = offset + delta` (interval add
+    /// per `i32-add`). The region-id is preserved unchanged.
+    region-offset: func(r: region, delta: interval) -> region;
+
+    /// `a ⊑ b` for regions. Defined only when `a.region-id ==
+    /// b.region-id` — different region-ids are incomparable
+    /// (i.e. cross-region `leq` is conservatively `false`, since
+    /// the lattice has no join of two different region-ids short
+    /// of `top`, which is not representable as a `region` value
+    /// in v0.3).
+    region-leq: func(a: region, b: region) -> bool;
+
+    /// `a ⊔ b` for regions. Defined only when `a.region-id ==
+    /// b.region-id`; if region-ids differ the result is the
+    /// *first* operand with its offset widened to interval top
+    /// (a conservative choice — the analyzer should generally
+    /// fall back to non-region-tagged abstract values in this
+    /// case, but the operator stays total to satisfy the
+    /// abstract-domain interface).
+    region-join: func(a: region, b: region) -> region;
+
+    /// `a ⊓ b` for regions. Defined only when `a.region-id ==
+    /// b.region-id`; otherwise the result is the first operand
+    /// with `offset = bottom` (i.e. empty — signals that the
+    /// meet is uninhabitable, which the analyzer can detect via
+    /// `is-bottom` on the offset).
+    region-meet: func(a: region, b: region) -> region;
+
+    /// Standard widening on the offset component; region-ids are
+    /// preserved (and the widen is degenerate / top-offset if the
+    /// region-ids differ). Required for fixpoint termination
+    /// when region-tagged values flow into loop headers.
+    region-widen: func(a: region, b: region) -> region;
 }
 
 world wasm-lattice {

--- a/spar/scry.aadl
+++ b/spar/scry.aadl
@@ -54,6 +54,20 @@ public
       Data_Size => 16 Bytes;  -- two s64 fields
   end Interval;
 
+  data MemoryRegion
+    -- v0.3 (FEAT-005): a region-tagged pointer abstraction —
+    -- (region-id, offset-interval) pair — exported by the
+    -- LatticeProcess as part of the region-memory domain and
+    -- consumed by the AnalyzerProcess to prove bounds-check
+    -- elision on the canonical base+offset pointer pattern
+    -- Wasm compilers emit for stack-allocated locals. The
+    -- interval component is the same Interval data type
+    -- declared above; this record adds the 4-byte region-id
+    -- discriminator.
+    properties
+      Data_Size => 20 Bytes;  -- u32 region-id + 16-byte Interval
+  end MemoryRegion;
+
   -- ══════════════════════════════════════════════════════════════════
   -- Threads — one per component's primary worker
   -- ══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Lands the v0.3 region-based linear-memory abstract domain on top of the existing interval lattice (FEAT-005, status: proposed → draft).

- **wasm-lattice** gains a new `region` abstract type (`(region-id: u32, offset: interval)`) plus the matching transfer ops (`region-create`, `region-offset`, `region-leq`, `region-join`, `region-meet`, `region-widen`). The package version stays at `@0.1.0` since the WIT change is purely additive — semver allows that within a `0.x` minor and the composition.wac is untouched.
- **scry-analyzer** dogfoods the new ops across the WIT boundary (per DD-008) to handle the canonical "base + constant offset" pointer pattern Wasm compilers emit for stack-allocated locals. An `i32.load` / `i32.store` (and `i64` variants) whose address operand is a singleton i32 interval now:
  - synthesises a region pointer (region-id derived from the base address),
  - proves the access `[addr, addr+width)` fits in the declared linear memory (parsed from the MemorySection),
  - emits a precise `Info` (bounds-check elision safe — what loom keys off per REQ-004 / FEAT-008) or `Warning` (cannot prove in-region) diagnostic instead of v0.2's blanket `UnsoundnessFallback`,
  - does NOT scrub locals to top — soundness is preserved by pushing `top` as the loaded value.
- **fixture-03-region-bounds.wat / .md** pins the canonical case: `(memory 1)` + `i32.const 100; i32.const 4; i32.add; i32.load` → `Info` for the `[104, 108)` access in the 65536-byte default region.
- **scry.wit** `AbstractValue` variant gains a `region-pointer(region)` case declared for v0.4+ use; v0.3 synthesises regions transiently at the memory op rather than storing them on the operand stack, which preserves fixture-01 / fixture-02 expectations exactly.
- **spar/scry.aadl** gains a new `MemoryRegion` data type alongside the existing `Interval`.
- **requirements.yaml#FEAT-005**: status `proposed → draft`, tag `v0.2 → v0.3`, acceptance criteria amended to cite fixture-03 and the in-bounds / out-of-bounds / cross-component-WIT / v0.4-foundation / proptest items; links extended to DD-008, FEAT-007, FEAT-001.

## Honest scope discipline (deferred to v0.4+)

- The loaded *value* is still `top` — precise per-region content tracking lands alongside FEAT-007's summary-based interprocedural analysis. v0.3 is the bounds-check-elision foundation.
- A single default region per module covers all of declared linear memory; per-stack-frame splitting is deferred to FEAT-007 alongside stack-pointer tracking.
- `memory.grow` / `memory.size` still hit the v0.2 `UnsoundnessFallback`.
- Proptest soundness sweep on the region domain lands with the v0.4+ content model (see AC-5 on FEAT-005).

## Test plan

- [x] `bazel build //:scry` (primary gate) — green locally.
- [x] `bazel build //crates/wasm-lattice:wasm_lattice_wit //crates/scry-analyzer:scry_analyzer_wit //crates/wasm-lattice:wasm_lattice_component //crates/scry-analyzer:scry_analyzer_component` — green, cross-package WIT import resolves.
- [x] `rivet validate` — PASS (0 warnings).
- [ ] CI: Bazel build (real gate), Rocq Formal Proofs (should still pass — proofs/ untouched), Verus Formal Proofs (informational; still failing per FEAT-012's known upstream issue).

## Files NOT touched (per scope discipline)

`MODULE.bazel`, `BUILD.bazel`, `proofs/**`, `.github/workflows/*.yml`, `crates/scry-host-tests/**`, `CHANGELOG.md`, `README.md`, `composition.wac`. No new dependencies added (no hashbrown needed — used `BTreeMap`-free design by keeping per-region metadata to a single default-region struct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)