### PR TITLE
FEAT-008: invariant JSON-schema contract for loom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,4 +70,8 @@ anyhow = "1"
 # None of these reach the wasm32-wasip2 component build.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-jsonschema = "0.18"
+# Pinned to =0.18.3 for a deterministic API surface. The contract test
+# uses the default-feature `JSONSchema::compile` + `is_valid` API, which
+# is available without the `resolve-*` features (the crate-root
+# `validator_for` / `Validator` re-exports are gated behind those).
+jsonschema = "=0.18.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,13 @@ wasmtime = "45"
 wasmtime-wasi = "45"
 wat = "1"
 anyhow = "1"
+
+# ── FEAT-008: invariant JSON-schema contract validation (native) ─────
+# Consumed only by the native scry-host-tests crate's contract test
+# (tests/contract.rs). serde derives the representative analysis-result
+# structs, serde_json serializes them, and jsonschema validates the
+# serialized value against contracts/scry-invariants-v1.schema.json.
+# None of these reach the wasm32-wasip2 component build.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+jsonschema = "0.18"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -525,23 +525,53 @@ artifacts:
 
   - id: FEAT-008
     type: feature
-    title: "v0.5 — loom integration: invariant schema + consumption"
-    status: proposed
+    title: "v0.6 — loom contract: published invariant JSON schema (v1)"
+    status: draft
     description: >
-      Define a stable on-disk JSON schema (v1) for scry's per-
-      instruction and per-function abstract invariants. Add loom's
-      side: ingest the JSON, attach invariants to loom's IR, use
-      them to strengthen the preconditions of bounds-check elision,
-      constant folding, and DCE transformations.
-    tags: [integration, loom, v0.5]
+      Publish a stable, versioned JSON schema (v1) for scry's per-
+      instruction and per-function abstract invariants so the loom
+      optimizer can validate scry output without coupling to scry's
+      WIT bindings. The v0.6 deliverable is the contract itself:
+      contracts/scry-invariants-v1.schema.json (JSON Schema draft
+      2020-12, $id https://pulseengine.eu/scry-invariants/v1),
+      documented field-by-field against the WIT analysis-result in
+      docs/invariant-schema-v1.md (DOC-INVARIANT-SCHEMA-V1). The
+      schema is the serialized form of the existing invariant-bundle
+      / call-graph / function-summaries types (no new WIT types). It
+      maps each invariant kind to a sound loom transform: a singleton
+      interval (lo == hi) enables constant folding; a region-pointer
+      whose offset is proven within the region size enables bounds-
+      check elision; a singleton, sound call-edge target set enables
+      devirtualization of call_indirect to a direct call. Loom-side
+      consumption of the contract is tracked as a separate cross-repo
+      issue (mirrors FEAT-002 / meld#192). Honest constraint: the
+      contract is validated against a HAND-CONSTRUCTED analysis-result
+      -shaped value, not a live analyze() run, because
+      rules_wasm_component's wac_compose emits root-level component
+      imports that wasmtime 45 rejects (the abstract-side host harness
+      is skipped — see crates/scry-host-tests/tests/soundness.rs).
+    tags: [integration, loom, contract, v0.5, v0.6]
     fields:
       phase: phase-1
       acceptance-criteria:
-        - "Given a meld→scry→loom pipeline run, When loom reports its applied transformations, Then loom names the scry invariants that enabled each invariant-dependent transformation."
-        - "Given the invariant schema, When loom is given a malformed or version-mismatched invariant file, Then loom refuses to apply invariant-dependent transformations and produces a clear error."
+        - "Given contracts/scry-invariants-v1.schema.json, When it is loaded as a JSON Schema, Then it is a valid draft 2020-12 schema declaring $id https://pulseengine.eu/scry-invariants/v1 and faithfully describes the WIT analysis-result (invariant-bundle, call-graph of call-edge, function-summaries of function-summary, abstract-value as a kind-tagged oneOf)."
+        - "Given a representative analysis-result-shaped value built with plain serde structs (independent of the WIT bindings), When the native contract test crates/scry-host-tests/tests/contract.rs serializes it via serde_json and validates it with the jsonschema crate, Then it validates against the v1 schema and the schema rejects malformed instances (bad kind, missing variant payload, additionalProperties, wrong schema URI, bad module-sha256, invalid soundness enum, missing required field)."
+        - "Given the v1 contract, When an invariant kind is read, Then the contract expresses each of the three loom transforms: a singleton interval (lo == hi) for constant folding (FEAT-001); a region-pointer with a bounded offset for bounds-check elision (FEAT-005); a singleton sound call-edge target set for devirtualizing call_indirect to call (FEAT-006)."
+        - "Given a meld→scry→loom pipeline run, When loom reports its applied transformations, Then loom names the scry invariants that enabled each invariant-dependent transformation. (Loom-side; deferred to the cross-repo loom-consumption issue.)"
+        - "Given the invariant schema, When loom is given a malformed or version-mismatched invariant file, Then loom refuses to apply invariant-dependent transformations and produces a clear error. (Loom-side; deferred to the cross-repo loom-consumption issue.)"
     links:
       - type: satisfies
         target: REQ-004
+      - type: traces-to
+        target: DD-007
+      - type: references-paper
+        target: AC-010
+      - type: depends-on
+        target: FEAT-001
+      - type: depends-on
+        target: FEAT-005
+      - type: depends-on
+        target: FEAT-006
 
   - id: FEAT-009
     type: feature

--- a/contracts/scry-invariants-v1.schema.json
+++ b/contracts/scry-invariants-v1.schema.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseengine.eu/scry-invariants/v1",
+  "title": "scry analysis-result (invariant contract v1)",
+  "description": "Stable, versioned JSON form of scry's `analysis-result` (crates/scry-analyzer/wit/scry.wit). Published for downstream optimizers (loom) and verifiers (witness) so they can consume scry invariants without coupling to scry's WIT bindings. FEAT-008. This schema is the serialized form of the existing InvariantBundle / CallGraph / FunctionSummaries types; it introduces no new types.",
+  "type": "object",
+  "required": ["invariants", "call-graph", "function-summaries"],
+  "additionalProperties": false,
+  "properties": {
+    "invariants": {
+      "description": "WIT field `analysis-result.invariants: invariant-bundle`.",
+      "$ref": "#/$defs/invariant-bundle"
+    },
+    "diagnostics": {
+      "description": "WIT field `analysis-result.diagnostics: list<diagnostic>`. Optional in the contract: loom does not consume diagnostics, but they may be present.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/diagnostic" }
+    },
+    "call-graph": {
+      "description": "WIT field `analysis-result.call-graph: list<call-edge>` (FEAT-006).",
+      "type": "array",
+      "items": { "$ref": "#/$defs/call-edge" }
+    },
+    "function-summaries": {
+      "description": "WIT field `analysis-result.function-summaries: list<function-summary>` (FEAT-007).",
+      "type": "array",
+      "items": { "$ref": "#/$defs/function-summary" }
+    }
+  },
+  "$defs": {
+    "u32": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 4294967295
+    },
+    "s64": {
+      "type": "integer",
+      "minimum": -9223372036854775808,
+      "maximum": 9223372036854775807
+    },
+    "invariant-bundle": {
+      "type": "object",
+      "description": "WIT record `invariant-bundle`: per-program-point abstract values (FEAT-001/FEAT-005).",
+      "required": ["schema", "module-sha256", "points"],
+      "additionalProperties": false,
+      "properties": {
+        "schema": {
+          "type": "string",
+          "description": "JSON-schema URI this document conforms to. Held constant per scry minor version; v1 must be the contract id.",
+          "const": "https://pulseengine.eu/scry-invariants/v1"
+        },
+        "module-sha256": {
+          "type": "string",
+          "description": "SHA-256 of the analyzed module bytes, lowercase hex.",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "points": {
+          "type": "array",
+          "description": "Per-program-point invariants. Order is not significant.",
+          "items": { "$ref": "#/$defs/program-point" }
+        }
+      }
+    },
+    "program-point": {
+      "type": "object",
+      "description": "WIT record `program-point`: invariants at one (func-index, pc).",
+      "required": ["func-index", "pc", "locals"],
+      "additionalProperties": false,
+      "properties": {
+        "func-index": {
+          "description": "Index of the function in the module.",
+          "$ref": "#/$defs/u32"
+        },
+        "pc": {
+          "description": "Program counter (byte offset within the function body).",
+          "$ref": "#/$defs/u32"
+        },
+        "locals": {
+          "type": "array",
+          "description": "Abstract values for the locals tracked at this point.",
+          "items": { "$ref": "#/$defs/local-invariant" }
+        }
+      }
+    },
+    "local-invariant": {
+      "type": "object",
+      "description": "WIT record `local-invariant`: abstract value for one local.",
+      "required": ["local-index", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "local-index": {
+          "description": "Local index.",
+          "$ref": "#/$defs/u32"
+        },
+        "value": { "$ref": "#/$defs/abstract-value" }
+      }
+    },
+    "interval": {
+      "type": "object",
+      "description": "WIT record `interval` (from pulseengine:wasm-lattice/domain): inclusive integer range [lo, hi] over s64.",
+      "required": ["lo", "hi"],
+      "additionalProperties": false,
+      "properties": {
+        "lo": {
+          "description": "Inclusive lower bound.",
+          "$ref": "#/$defs/s64"
+        },
+        "hi": {
+          "description": "Inclusive upper bound.",
+          "$ref": "#/$defs/s64"
+        }
+      }
+    },
+    "region": {
+      "type": "object",
+      "description": "WIT record `region-pointer-payload`: a memory-region pointer (FEAT-005). region-id plus a byte-offset interval into that region.",
+      "required": ["region-id", "offset"],
+      "additionalProperties": false,
+      "properties": {
+        "region-id": {
+          "description": "Region identifier (e.g. linear memory index).",
+          "$ref": "#/$defs/u32"
+        },
+        "offset": {
+          "description": "Byte offset within the region, as an interval.",
+          "$ref": "#/$defs/interval"
+        }
+      }
+    },
+    "abstract-value": {
+      "description": "WIT variant `abstract-value`, encoded as a `kind`-tagged union. Exactly one case applies.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "i32-interval(interval): 32-bit integer interval.",
+          "required": ["kind", "interval"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "i32-interval" },
+            "interval": { "$ref": "#/$defs/interval" }
+          }
+        },
+        {
+          "type": "object",
+          "description": "i64-interval(interval): 64-bit integer interval.",
+          "required": ["kind", "interval"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "i64-interval" },
+            "interval": { "$ref": "#/$defs/interval" }
+          }
+        },
+        {
+          "type": "object",
+          "description": "region-pointer(region-pointer-payload): pointer into a memory region.",
+          "required": ["kind", "region"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "region-pointer" },
+            "region": { "$ref": "#/$defs/region" }
+          }
+        },
+        {
+          "type": "object",
+          "description": "unknown: top of the abstract domain.",
+          "required": ["kind"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "unknown" }
+          }
+        }
+      ]
+    },
+    "diagnostic": {
+      "type": "object",
+      "description": "WIT record `diagnostic`: a non-fatal note emitted alongside the invariant bundle.",
+      "required": ["severity", "func-index", "pc", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "severity": {
+          "description": "WIT enum `diagnostic-severity`.",
+          "enum": ["info", "warning", "unsoundness-fallback"]
+        },
+        "func-index": { "$ref": "#/$defs/u32" },
+        "pc": { "$ref": "#/$defs/u32" },
+        "message": { "type": "string" }
+      }
+    },
+    "call-edge": {
+      "type": "object",
+      "description": "WIT record `call-edge`: one resolved call site (FEAT-006).",
+      "required": ["caller-func", "pc", "indirect", "resolved-targets", "soundness"],
+      "additionalProperties": false,
+      "properties": {
+        "caller-func": {
+          "description": "Index of the function containing this call site.",
+          "$ref": "#/$defs/u32"
+        },
+        "pc": {
+          "description": "Call-site program counter.",
+          "$ref": "#/$defs/u32"
+        },
+        "indirect": {
+          "type": "boolean",
+          "description": "true for call_indirect, false for a direct call."
+        },
+        "resolved-targets": {
+          "type": "array",
+          "description": "Resolved target function indices. A singleton sound set permits devirtualization. Empty means provably unreachable.",
+          "items": { "$ref": "#/$defs/u32" }
+        },
+        "soundness": {
+          "description": "WIT enum `soundness-tag`. `sound`: a sound (possibly over-approximating) cover of every reachable target. `unsound-fallback`: conservative fallback retained for constructs the analyzer cannot resolve soundly.",
+          "enum": ["sound", "unsound-fallback"]
+        }
+      }
+    },
+    "function-summary": {
+      "type": "object",
+      "description": "WIT record `function-summary`: compositional per-function summary (FEAT-007).",
+      "required": ["func-index", "param-count", "result-summary", "context-sensitive", "recursive"],
+      "additionalProperties": false,
+      "properties": {
+        "func-index": {
+          "description": "Absolute function index the summary describes.",
+          "$ref": "#/$defs/u32"
+        },
+        "param-count": {
+          "description": "Number of declared parameters.",
+          "$ref": "#/$defs/u32"
+        },
+        "result-summary": {
+          "type": "array",
+          "description": "Abstract value of each function result under the context-insensitive (top-input) summary, in result order.",
+          "items": { "$ref": "#/$defs/abstract-value" }
+        },
+        "context-sensitive": {
+          "type": "boolean",
+          "description": "True iff the analyzer also applies a context-sensitive re-evaluation at call sites with concrete argument intervals."
+        },
+        "recursive": {
+          "type": "boolean",
+          "description": "True iff the function is in a non-trivial call-graph SCC (self- or mutually-recursive)."
+        }
+      }
+    }
+  }
+}

--- a/crates/scry-host-tests/Cargo.toml
+++ b/crates/scry-host-tests/Cargo.toml
@@ -31,3 +31,10 @@ anyhow = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wat = { workspace = true }
+
+# FEAT-008: contract test (tests/contract.rs) — native serde + jsonschema
+# validation of a representative analysis-result against the published
+# scry-invariants v1 JSON schema. Pure native, no wasmtime/component.
+serde = { workspace = true }
+serde_json = { workspace = true }
+jsonschema = { workspace = true }

--- a/crates/scry-host-tests/tests/contract.rs
+++ b/crates/scry-host-tests/tests/contract.rs
@@ -1,0 +1,422 @@
+//! Contract test for the scry invariant JSON schema — FEAT-008.
+//!
+//! This is the mechanical check that the published JSON contract
+//! (`contracts/scry-invariants-v1.schema.json`) is a faithful, tight
+//! description of scry's `analysis-result`. It is pure native — plain
+//! serde structs + `serde_json` + the `jsonschema` crate — with no
+//! wasmtime / component model involved, so it runs under `cargo test`
+//! even though the component-loading tests in `tests/soundness.rs` skip
+//! on the wac-compose/wasmtime limitation.
+//!
+//! Why plain serde structs (not the WIT bindings): the whole point of
+//! FEAT-008 is that loom consumes the JSON contract WITHOUT coupling to
+//! scry's WIT. So the contract has to stand on its own as a JSON shape.
+//! We therefore define independent serde structs here that mirror the
+//! WIT `analysis-result` (`crates/scry-analyzer/wit/scry.wit`),
+//! serialize a representative value, and validate it against the schema.
+//! If the schema and the WIT shape ever drift, this test fails.
+//!
+//! The representative value deliberately exercises all three loom
+//! transforms the contract is meant to unlock (see
+//! `docs/invariant-schema-v1.md`):
+//!
+//!   * a singleton interval (`{84,84}`)              -> constant-fold
+//!   * a region-pointer with a bounded offset         -> bounds-check elision
+//!   * a singleton, `sound` call-edge target set      -> devirtualize
+//!
+//! Honest constraint: this is a HAND-CONSTRUCTED value, not the output
+//! of a live `analyze()` call. CI cannot drive a live analyze->JSON
+//! round-trip because the composed component uses wac
+//! `--import-dependencies` (root-level component imports) that wasmtime
+//! 45 rejects — see the module doc in `tests/soundness.rs`. The v0.6.0
+//! deliverable is the contract plus this mechanical validation.
+
+#![forbid(unsafe_code)]
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::Value;
+
+// ── Serde mirror of the WIT `analysis-result` ───────────────────────
+// All structs rename to kebab-case so the serialized JSON matches the
+// WIT field names verbatim (which is what the schema keys on).
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct AnalysisResult {
+    invariants: InvariantBundle,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    diagnostics: Vec<Diagnostic>,
+    call_graph: Vec<CallEdge>,
+    function_summaries: Vec<FunctionSummary>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct InvariantBundle {
+    schema: String,
+    module_sha256: String,
+    points: Vec<ProgramPoint>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct ProgramPoint {
+    func_index: u32,
+    pc: u32,
+    locals: Vec<LocalInvariant>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct LocalInvariant {
+    local_index: u32,
+    value: AbstractValue,
+}
+
+/// WIT `variant abstract-value` -> `kind`-tagged JSON union.
+/// `#[serde(tag = "kind", rename_all = "kebab-case")]` produces
+/// `{"kind":"i32-interval","interval":{...}}` etc., matching the schema.
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+enum AbstractValue {
+    I32Interval { interval: Interval },
+    I64Interval { interval: Interval },
+    RegionPointer { region: Region },
+    Unknown,
+}
+
+#[derive(Serialize)]
+struct Interval {
+    lo: i64,
+    hi: i64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct Region {
+    region_id: u32,
+    offset: Interval,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct Diagnostic {
+    severity: String,
+    func_index: u32,
+    pc: u32,
+    message: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct CallEdge {
+    caller_func: u32,
+    pc: u32,
+    indirect: bool,
+    resolved_targets: Vec<u32>,
+    soundness: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct FunctionSummary {
+    func_index: u32,
+    param_count: u32,
+    result_summary: Vec<AbstractValue>,
+    context_sensitive: bool,
+    recursive: bool,
+}
+
+// ── Schema location + representative value ───────────────────────────
+
+const SCHEMA_ID: &str = "https://pulseengine.eu/scry-invariants/v1";
+
+/// Path to the published contract, relative to the workspace root
+/// (two levels up from this crate's manifest dir).
+fn schema_path() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| manifest.clone());
+    workspace_root
+        .join("contracts")
+        .join("scry-invariants-v1.schema.json")
+}
+
+fn load_schema() -> Value {
+    let path = schema_path();
+    let bytes =
+        std::fs::read(&path).unwrap_or_else(|e| panic!("read schema {}: {e}", path.display()));
+    serde_json::from_slice(&bytes)
+        .unwrap_or_else(|e| panic!("parse schema {} as JSON: {e}", path.display()))
+}
+
+/// A representative `analysis-result` that exercises every kind in the
+/// contract and all three loom-transform shapes.
+fn representative_result() -> AnalysisResult {
+    AnalysisResult {
+        invariants: InvariantBundle {
+            schema: SCHEMA_ID.to_string(),
+            module_sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                .to_string(),
+            points: vec![
+                ProgramPoint {
+                    func_index: 0,
+                    pc: 12,
+                    locals: vec![
+                        LocalInvariant {
+                            local_index: 0,
+                            value: AbstractValue::I32Interval {
+                                interval: Interval { lo: 0, hi: 42 },
+                            },
+                        },
+                        // region-pointer -> bounds-check elision shape.
+                        LocalInvariant {
+                            local_index: 1,
+                            value: AbstractValue::RegionPointer {
+                                region: Region {
+                                    region_id: 0,
+                                    offset: Interval { lo: 0, hi: 16 },
+                                },
+                            },
+                        },
+                    ],
+                },
+                ProgramPoint {
+                    func_index: 0,
+                    pc: 40,
+                    locals: vec![
+                        // singleton interval {84,84} -> constant-fold shape.
+                        LocalInvariant {
+                            local_index: 0,
+                            value: AbstractValue::I32Interval {
+                                interval: Interval { lo: 84, hi: 84 },
+                            },
+                        },
+                        LocalInvariant {
+                            local_index: 1,
+                            value: AbstractValue::Unknown,
+                        },
+                        LocalInvariant {
+                            local_index: 2,
+                            value: AbstractValue::I64Interval {
+                                interval: Interval { lo: -1, hi: 100 },
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        diagnostics: vec![Diagnostic {
+            severity: "info".to_string(),
+            func_index: 0,
+            pc: 4,
+            message: "analyzed".to_string(),
+        }],
+        call_graph: vec![
+            // singleton sound target set -> devirtualize shape.
+            CallEdge {
+                caller_func: 0,
+                pc: 28,
+                indirect: true,
+                resolved_targets: vec![3],
+                soundness: "sound".to_string(),
+            },
+            CallEdge {
+                caller_func: 1,
+                pc: 9,
+                indirect: true,
+                resolved_targets: vec![3, 4, 5],
+                soundness: "unsound-fallback".to_string(),
+            },
+        ],
+        function_summaries: vec![
+            FunctionSummary {
+                func_index: 0,
+                param_count: 1,
+                result_summary: vec![AbstractValue::I32Interval {
+                    interval: Interval { lo: 84, hi: 84 },
+                }],
+                context_sensitive: true,
+                recursive: false,
+            },
+            FunctionSummary {
+                func_index: 3,
+                param_count: 0,
+                result_summary: vec![AbstractValue::Unknown],
+                context_sensitive: false,
+                recursive: true,
+            },
+        ],
+    }
+}
+
+fn compile() -> jsonschema::Validator {
+    let schema = load_schema();
+    jsonschema::validator_for(&schema)
+        .unwrap_or_else(|e| panic!("compile scry-invariants v1 schema: {e}"))
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+/// The schema document itself compiles as a JSON Schema validator and
+/// declares draft 2020-12 with the v1 `$id`. This catches a malformed
+/// schema before any instance check runs.
+#[test]
+fn schema_is_well_formed_draft_2020_12() {
+    let schema = load_schema();
+    assert_eq!(
+        schema.get("$schema").and_then(Value::as_str),
+        Some("https://json-schema.org/draft/2020-12/schema"),
+        "contract must declare the draft 2020-12 dialect"
+    );
+    assert_eq!(
+        schema.get("$id").and_then(Value::as_str),
+        Some(SCHEMA_ID),
+        "contract $id must be the v1 invariant URI"
+    );
+    // Compiling is the real well-formedness check.
+    let _ = compile();
+}
+
+/// A representative `analysis-result`-shaped value, serialized via
+/// serde_json, validates against the published v1 schema. This is the
+/// mechanical check that the JSON contract stands alone for loom.
+#[test]
+fn representative_result_validates_against_schema() {
+    let validator = compile();
+    let instance =
+        serde_json::to_value(representative_result()).expect("serialize representative result");
+
+    if let Err(error) = validator.validate(&instance) {
+        // `validate` returns at most one error in 0.18; iter_errors gives all.
+        let all: Vec<String> = validator
+            .iter_errors(&instance)
+            .map(|e| format!("  at {}: {}", e.instance_path, e))
+            .collect();
+        panic!(
+            "representative analysis-result failed schema validation:\n{}\nfirst error: {error}",
+            all.join("\n")
+        );
+    }
+    assert!(
+        validator.is_valid(&instance),
+        "representative analysis-result must be valid against the v1 contract"
+    );
+}
+
+/// The three loom-transform shapes are present and well-formed in the
+/// representative value:
+///   * singleton interval {84,84}       -> constant-fold
+///   * region-pointer w/ bounded offset -> bounds-check elision
+///   * singleton sound call-edge        -> devirtualize
+#[test]
+fn loom_transform_shapes_present_and_valid() {
+    let validator = compile();
+    let instance = serde_json::to_value(representative_result()).expect("serialize");
+    assert!(
+        validator.is_valid(&instance),
+        "instance must validate first"
+    );
+
+    // singleton interval (lo == hi) at the final program point.
+    let last_point = &instance["invariants"]["points"][1];
+    let local0 = &last_point["locals"][0]["value"];
+    assert_eq!(local0["kind"], "i32-interval");
+    assert_eq!(
+        local0["interval"]["lo"], local0["interval"]["hi"],
+        "constant-fold shape: local 0 at pc 40 must be a singleton interval"
+    );
+
+    // region-pointer with a bounded offset interval.
+    let region_val = &instance["invariants"]["points"][0]["locals"][1]["value"];
+    assert_eq!(region_val["kind"], "region-pointer");
+    assert!(
+        region_val["region"]["offset"]["hi"].is_i64(),
+        "bounds-check-elision shape: region-pointer must carry an offset interval"
+    );
+
+    // singleton, sound call-edge.
+    let edge0 = &instance["call-graph"][0];
+    assert_eq!(edge0["soundness"], "sound");
+    assert_eq!(
+        edge0["resolved-targets"].as_array().map(Vec::len),
+        Some(1),
+        "devirtualize shape: a sound call-edge with a singleton target set"
+    );
+}
+
+/// The contract is tight: structurally-broken instances are rejected.
+/// This guards against an accidentally-permissive schema (e.g. dropping
+/// `additionalProperties: false` or the `oneOf` discriminator).
+#[test]
+fn schema_rejects_malformed_instances() {
+    let validator = compile();
+
+    // Base valid instance as mutable JSON.
+    let mut base = serde_json::to_value(representative_result()).expect("serialize");
+    assert!(validator.is_valid(&base), "base must be valid");
+
+    // 1. abstract-value with a bad `kind`.
+    let mut bad = base.clone();
+    bad["invariants"]["points"][1]["locals"][0]["value"] =
+        serde_json::json!({ "kind": "f32-interval", "interval": { "lo": 1, "hi": 1 } });
+    assert!(
+        !validator.is_valid(&bad),
+        "unknown abstract-value kind must be rejected"
+    );
+
+    // 2. i32-interval missing its `interval` payload.
+    let mut bad = base.clone();
+    bad["invariants"]["points"][1]["locals"][0]["value"] =
+        serde_json::json!({ "kind": "i32-interval" });
+    assert!(
+        !validator.is_valid(&bad),
+        "i32-interval without interval must be rejected"
+    );
+
+    // 3. unexpected additional property on a closed object.
+    let mut bad = base.clone();
+    bad["invariants"]["bogus"] = serde_json::json!(1);
+    assert!(
+        !validator.is_valid(&bad),
+        "additionalProperties on invariant-bundle must be rejected"
+    );
+
+    // 4. wrong `schema` URI const.
+    let mut bad = base.clone();
+    bad["invariants"]["schema"] = serde_json::json!("https://example.com/other");
+    assert!(
+        !validator.is_valid(&bad),
+        "wrong schema URI const must be rejected"
+    );
+
+    // 5. malformed module-sha256 (not 64 lowercase hex).
+    let mut bad = base.clone();
+    bad["invariants"]["module-sha256"] = serde_json::json!("NOTAHEXDIGEST");
+    assert!(
+        !validator.is_valid(&bad),
+        "bad module-sha256 pattern must be rejected"
+    );
+
+    // 6. invalid soundness enum value.
+    let mut bad = base.clone();
+    bad["call-graph"][0]["soundness"] = serde_json::json!("maybe");
+    assert!(
+        !validator.is_valid(&bad),
+        "invalid soundness enum must be rejected"
+    );
+
+    // 7. dropping a required top-level field.
+    base.as_object_mut().unwrap().remove("call-graph");
+    assert!(
+        !validator.is_valid(&base),
+        "missing required call-graph must be rejected"
+    );
+}

--- a/crates/scry-host-tests/tests/contract.rs
+++ b/crates/scry-host-tests/tests/contract.rs
@@ -255,9 +255,18 @@ fn representative_result() -> AnalysisResult {
     }
 }
 
-fn compile() -> jsonschema::Validator {
+/// Compile the published contract into a validator.
+///
+/// Uses `jsonschema::JSONSchema::compile`, the default-feature
+/// constructor that is stable across the pinned 0.18.x line (the
+/// crate-root `validator_for` / `Validator` re-exports are gated behind
+/// the optional `resolve-*` features, so we avoid them). Validity is
+/// then driven through `JSONSchema::is_valid` (`&Value -> bool`), which
+/// needs no extra features and no version-specific error types.
+#[allow(deprecated)]
+fn compile() -> jsonschema::JSONSchema {
     let schema = load_schema();
-    jsonschema::validator_for(&schema)
+    jsonschema::JSONSchema::compile(&schema)
         .unwrap_or_else(|e| panic!("compile scry-invariants v1 schema: {e}"))
 }
 
@@ -294,20 +303,11 @@ fn representative_result_validates_against_schema() {
     let instance =
         serde_json::to_value(representative_result()).expect("serialize representative result");
 
-    if let Err(error) = validator.validate(&instance) {
-        // `validate` returns at most one error in 0.18; iter_errors gives all.
-        let all: Vec<String> = validator
-            .iter_errors(&instance)
-            .map(|e| format!("  at {}: {}", e.instance_path, e))
-            .collect();
-        panic!(
-            "representative analysis-result failed schema validation:\n{}\nfirst error: {error}",
-            all.join("\n")
-        );
-    }
     assert!(
         validator.is_valid(&instance),
-        "representative analysis-result must be valid against the v1 contract"
+        "representative analysis-result must be valid against the v1 contract; \
+         serialized value:\n{}",
+        serde_json::to_string_pretty(&instance).unwrap_or_default()
     );
 }
 
@@ -355,7 +355,13 @@ fn loom_transform_shapes_present_and_valid() {
 /// The contract is tight: structurally-broken instances are rejected.
 /// This guards against an accidentally-permissive schema (e.g. dropping
 /// `additionalProperties: false` or the `oneOf` discriminator).
+///
+/// `clippy::no_effect` is allowed: clippy (Rust 1.96+) false-positives on
+/// the `bad[index] = serde_json::json!(..)` assignment statements — the
+/// `IndexMut` assignment mutates `bad`, but the lint flags the `json!`
+/// macro expansion as effect-free.
 #[test]
+#[allow(clippy::no_effect)]
 fn schema_rejects_malformed_instances() {
     let validator = compile();
 

--- a/docs/invariant-schema-v1.md
+++ b/docs/invariant-schema-v1.md
@@ -1,0 +1,208 @@
+---
+id: DOC-INVARIANT-SCHEMA-V1
+type: spec
+status: draft
+tags: [contract, loom, schema, v0.6]
+---
+
+# scry invariant JSON-schema contract (v1)
+
+This document specifies the stable, versioned JSON contract that scry publishes
+for its `analyze()` output, so the loom optimizer (and the witness verifier) can
+consume scry invariants without coupling to scry's WIT bindings.
+
+- Schema file: `contracts/scry-invariants-v1.schema.json`
+- Schema id / URI: `https://pulseengine.eu/scry-invariants/v1`
+- JSON Schema dialect: draft 2020-12
+- Realizes [[FEAT-008]]; satisfies [[REQ-004]]; decided in [[DD-007]].
+
+The contract is the serialized form of the WIT `analysis-result`
+(`crates/scry-analyzer/wit/scry.wit`). It introduces no new types — it is a
+projection of the existing `invariant-bundle` / `call-graph` (list of
+`call-edge`) / `function-summaries` (list of `function-summary`) structures onto
+draft-2020-12 JSON Schema. The WIT remains the source of truth; this schema is
+the wire contract loom validates against.
+
+> Note on the document `type`: rivet's document schema names this document type
+> `spec`. The FEAT-008 brief asked for a specification document; this repo's
+> rivet schema spells that type `spec`.
+
+## Why a JSON contract (and not the WIT)
+
+scry already emits everything loom needs through the WIT `analysis-result`:
+interval invariants ([[FEAT-001]]), region-pointers ([[FEAT-005]]), the sound
+call graph ([[FEAT-006]]), and per-function compositional summaries (added at
+v0.5, in the Stiévenart & De Roover summary style — [[AC-010]]). But making loom
+link against scry's `wit-bindgen` output would couple the optimizer to scry's
+component ABI and release cadence. Per [[DD-007]], the analysis output is
+schema-stable and decoupled from the WIT: loom ingests a plain JSON document and
+validates it against this versioned schema. This mirrors FEAT-002 / meld#192,
+where the producer publishes the contract and the consumer side is a separate
+cross-repo concern.
+
+The `invariant-bundle.schema` field carries the URI above; v1 freezes the
+field-by-field mapping below. Future incompatible changes get a new `/v2` id.
+
+## WIT to JSON field mapping
+
+WIT records map to JSON objects; WIT `kebab-case` field names are preserved
+verbatim as JSON keys. The WIT `variant abstract-value` maps to a `kind`-tagged
+union. Numeric widths are range-constrained in JSON (`u32`, `s64`).
+
+| WIT type / field | JSON encoding |
+| --- | --- |
+| `analysis-result` | object `{ "invariants", "diagnostics"?, "call-graph", "function-summaries" }` |
+| `analysis-result.invariants: invariant-bundle` | `"invariants"` — object |
+| `analysis-result.diagnostics: list<diagnostic>` | `"diagnostics"` — array (optional; loom ignores it) |
+| `analysis-result.call-graph: list<call-edge>` | `"call-graph"` — array |
+| `analysis-result.function-summaries: list<function-summary>` | `"function-summaries"` — array |
+| `invariant-bundle.schema: string` | `"schema"` — `const` = the v1 URI |
+| `invariant-bundle.module-sha256: string` | `"module-sha256"` — `^[0-9a-f]{64}$` (lowercase hex) |
+| `invariant-bundle.points: list<program-point>` | `"points"` — array |
+| `program-point.func-index: u32` | `"func-index"` — integer `[0, 2^32-1]` |
+| `program-point.pc: u32` | `"pc"` — integer `[0, 2^32-1]` |
+| `program-point.locals: list<local-invariant>` | `"locals"` — array |
+| `local-invariant.local-index: u32` | `"local-index"` — integer u32 |
+| `local-invariant.value: abstract-value` | `"value"` — tagged union (below) |
+| `interval.lo: s64`, `interval.hi: s64` | `{ "lo", "hi" }` — integers in s64 range, inclusive |
+| `region-pointer-payload.region-id: u32` | `"region-id"` — integer u32 |
+| `region-pointer-payload.offset: interval` | `"offset"` — interval object |
+| `call-edge.caller-func: u32` | `"caller-func"` — integer u32 |
+| `call-edge.pc: u32` | `"pc"` — integer u32 |
+| `call-edge.indirect: bool` | `"indirect"` — boolean |
+| `call-edge.resolved-targets: list<u32>` | `"resolved-targets"` — array of u32 |
+| `call-edge.soundness: soundness-tag` | `"soundness"` — `"sound"` \| `"unsound-fallback"` |
+| `function-summary.func-index: u32` | `"func-index"` — integer u32 |
+| `function-summary.param-count: u32` | `"param-count"` — integer u32 |
+| `function-summary.result-summary: list<abstract-value>` | `"result-summary"` — array of tagged unions |
+| `function-summary.context-sensitive: bool` | `"context-sensitive"` — boolean |
+| `function-summary.recursive: bool` | `"recursive"` — boolean |
+| `diagnostic.severity: diagnostic-severity` | `"severity"` — `"info"` \| `"warning"` \| `"unsoundness-fallback"` |
+
+### `abstract-value` variant -> `kind`-tagged union
+
+The WIT `variant abstract-value` becomes a `oneOf` discriminated on `"kind"`:
+
+| WIT case | JSON |
+| --- | --- |
+| `i32-interval(interval)` | `{ "kind": "i32-interval", "interval": { "lo", "hi" } }` |
+| `i64-interval(interval)` | `{ "kind": "i64-interval", "interval": { "lo", "hi" } }` |
+| `region-pointer(region-pointer-payload)` | `{ "kind": "region-pointer", "region": { "region-id", "offset" } }` |
+| `unknown` | `{ "kind": "unknown" }` |
+
+Every object in the contract is closed (`"additionalProperties": false`), so loom
+gets a tight contract: unknown fields are a hard validation error rather than a
+silently-ignored extension. The one deliberately optional field is top-level
+`diagnostics`, which loom does not consume.
+
+## Rationale: each invariant kind maps to the loom transform it unlocks
+
+The contract exists to drive optimizer transforms. Each invariant kind maps to a
+specific, sound loom rewrite (the substance of [[FEAT-008]]'s loom integration):
+
+- Singleton interval (`lo == hi`) maps to constant-fold. When a local's
+  `abstract-value` is `i32-interval`/`i64-interval` with `lo == hi`, the value is
+  statically known. loom replaces uses of that local with the constant and folds
+  dependent arithmetic. Provenance: the interval domain of [[FEAT-001]].
+
+- In-region load (offset proven within `memory.size`) maps to bounds-check
+  elision. When a load/store address is a `region-pointer` whose `offset`
+  interval, plus the access width, is provably within the region's size, the
+  access cannot trap. loom elides the dynamic bounds check. Provenance: the
+  region-pointer domain of [[FEAT-005]].
+
+- Singleton call-edge target set maps to devirtualize `call_indirect` to `call`.
+  When a `call-edge` for a `call_indirect` site (`indirect == true`) has exactly
+  one entry in `resolved-targets` and `soundness == "sound"`, the callee is
+  uniquely determined. loom rewrites the indirect call into a direct call
+  (enabling inlining). `unsound-fallback` edges are never devirtualized.
+  Provenance: the sound call graph of [[FEAT-006]].
+
+Each transform is sound only because the underlying analysis is sound; loom is
+expected to discharge each rewrite with a Z3 translation-validation check (see
+data flow below).
+
+## scry to loom data flow
+
+```mermaid
+graph LR
+    W[Wasm module] --> A[scry analyze]
+    A --> J[invariant JSON conforms to v1 schema]
+    J --> V{validate vs scry-invariants-v1.schema.json}
+    V -->|valid| I[loom ingest]
+    V -->|invalid| R[reject]
+    I --> T[loom transforms: const-fold / bce / devirt]
+    T --> O[transformed Wasm]
+    T --> Z[Z3 translation validation: original equiv transformed]
+    Z -->|equiv| O
+    Z -->|counterexample| R
+```
+
+## Worked example: `fixture-01-constant-fold`
+
+A function whose single integer local is narrowed to a singleton interval by the
+final program point — the canonical input for the singleton-to-constant-fold
+transform. The local at the last program point (`pc = 40`) is the constant `84`,
+encoded as the singleton interval `{ "lo": 84, "hi": 84 }`.
+
+```json
+{
+  "invariants": {
+    "schema": "https://pulseengine.eu/scry-invariants/v1",
+    "module-sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "points": [
+      {
+        "func-index": 0,
+        "pc": 12,
+        "locals": [
+          { "local-index": 0, "value": { "kind": "i32-interval", "interval": { "lo": 0, "hi": 42 } } }
+        ]
+      },
+      {
+        "func-index": 0,
+        "pc": 40,
+        "locals": [
+          { "local-index": 0, "value": { "kind": "i32-interval", "interval": { "lo": 84, "hi": 84 } } }
+        ]
+      }
+    ]
+  },
+  "call-graph": [],
+  "function-summaries": [
+    {
+      "func-index": 0,
+      "param-count": 1,
+      "result-summary": [ { "kind": "i32-interval", "interval": { "lo": 84, "hi": 84 } } ],
+      "context-sensitive": true,
+      "recursive": false
+    }
+  ]
+}
+```
+
+At `pc = 40`, `locals[0]` has `lo == hi == 84`: loom may replace every use of
+local 0 with the constant `84` and propagate. The function summary records the
+same singleton as the result, so an interprocedural caller can const-fold the
+call's result too.
+
+## Validation status (honest constraint)
+
+The contract is validated in CI by a native test
+(`crates/scry-host-tests/tests/contract.rs`): it builds a representative
+`analysis-result`-shaped value with plain serde structs (independent of the WIT
+bindings — the point is that the JSON contract stands alone for loom), serializes
+it with `serde_json`, and validates it against
+`contracts/scry-invariants-v1.schema.json` using the `jsonschema` crate. The test
+also asserts the three loom-transform shapes are expressible (a singleton
+interval, a `region-pointer`, and a singleton sound `call-edge`) and that the
+schema rejects malformed instances.
+
+This is a hand-constructed value, not the output of a live `analyze()` call. The
+abstract-side host harness in `crates/scry-host-tests/` is SKIPPED in CI because
+`rules_wasm_component`'s `wac_compose` emits root-level component imports that
+wasmtime 45 rejects (see the module-level doc in
+`crates/scry-host-tests/tests/soundness.rs`). We therefore cannot drive a live
+`analyze()` to JSON round-trip in CI yet. The v0.6.0 deliverable is the contract
+plus its mechanical validation against a representative value; wiring a live
+component round-trip is gated on the compose-toolchain fix. The loom-side
+consumption of this contract is tracked as a separate cross-repo issue.

--- a/spar/scry.aadl
+++ b/spar/scry.aadl
@@ -38,6 +38,12 @@ public
   data InvariantBundle
     -- JSON-encoded per-instruction and per-function abstract
     -- invariants.
+    --
+    -- FEAT-008: the published v1 JSON schema
+    -- (contracts/scry-invariants-v1.schema.json) is purely the
+    -- serialized form of this InvariantBundle together with CallGraph
+    -- and FunctionSummaries below. It introduces no new architecture
+    -- types; see docs/invariant-schema-v1.md (DOC-INVARIANT-SCHEMA-V1).
     properties
       Data_Size => 16 MByte;
   end InvariantBundle;


### PR DESCRIPTION
## Summary

FEAT-008 publishes scry's invariant output as a stable, versioned JSON-schema **contract** so the loom optimizer can validate scry output without coupling to scry's WIT bindings. The v0.6 deliverable is the contract itself (mirrors FEAT-002 / meld#192 — scry publishes the contract; loom-side consumption is a separate cross-repo issue, which the parent will file).

- **`contracts/scry-invariants-v1.schema.json`** — JSON Schema draft 2020-12, `$id https://pulseengine.eu/scry-invariants/v1`. Faithful, tight (`additionalProperties: false`) serialization of the WIT `analysis-result` (`crates/scry-analyzer/wit/scry.wit`). No new types — it is the serialized form of the existing `invariant-bundle` / `call-graph` (list of `call-edge`) / `function-summaries` (list of `function-summary`).
- **`docs/invariant-schema-v1.md`** (`DOC-INVARIANT-SCHEMA-V1`) — field-by-field WIT→JSON mapping, scry→loom data-flow mermaid diagram, worked `fixture-01-constant-fold` example (final program point's singleton `{84,84}`), and the honest hand-built-value note.
- **`crates/scry-host-tests/tests/contract.rs`** — native serde + `serde_json` + `jsonschema` test that serializes a representative `analysis-result`-shaped value (plain serde structs, independent of the WIT bindings) and validates it against the schema; also asserts the schema rejects 7 malformed instances.
- **`artifacts/requirements.yaml`** — FEAT-008 `proposed`→`draft`, retitled to the v0.6 loom contract; acceptance-criteria cite the schema file, the contract test, and the three loom transforms; links REQ-004, DD-007, AC-010, FEAT-001, FEAT-005, FEAT-006.
- **`spar/scry.aadl`** — light comment noting the v1 schema is the serialized form of the existing `InvariantBundle` / `CallGraph` / `FunctionSummaries` types (no new architecture types).

## WIT → JSON mapping (highlights)

- `analysis-result` → `{ invariants, diagnostics?, call-graph, function-summaries }`
- `abstract-value` variant → `kind`-tagged `oneOf`: `i32-interval` / `i64-interval` carry `{interval:{lo,hi}}`, `region-pointer` carries `{region:{region-id,offset}}`, `unknown` carries nothing
- `call-edge` → `{caller-func, pc, indirect, resolved-targets:[u32], soundness}` where `soundness` is `sound` | `unsound-fallback`
- `function-summary` → `{func-index, param-count, result-summary:[abstract-value], context-sensitive, recursive}`

The actual WIT field names (`invariants`, `caller-func`, `resolved-targets`, `soundness-tag`, `result-summary`, `region-pointer-payload`) differ from the names sketched in the issue; the schema follows the real WIT in `crates/scry-analyzer/wit/scry.wit`.

## Three loom transforms the contract unlocks

- **Singleton interval (`lo == hi`) → constant-fold** (interval domain, FEAT-001).
- **In-region load (offset proven within `memory.size`) → bounds-check elision** (region-pointer domain, FEAT-005).
- **Singleton, `sound` call-edge target set → devirtualize `call_indirect` → `call`** (sound call graph, FEAT-006).

## Honest constraint (hand-built value)

The contract is validated against a **hand-constructed** `analysis-result`-shaped value, not a live `analyze()` run. The abstract-side host harness in `crates/scry-host-tests/` is SKIPPED because `rules_wasm_component`'s `wac_compose` emits root-level component imports that wasmtime 45 rejects (see the module doc in `crates/scry-host-tests/tests/soundness.rs`). We therefore cannot drive a live `analyze()` → JSON round-trip in CI yet; wiring that is gated on the compose-toolchain fix. The contract + its mechanical validation is the v0.6.0 deliverable.

## Test plan

- [ ] CI: Bazel build //:scry + Host tests (the contract test runs in `cargo test`) + rivet-delta green
- [x] new doc's `[[ID]]` refs all reference existing artifacts (FEAT-001/005/006/008, REQ-004, DD-007, AC-010)

> Note: `cargo test`, `cargo fmt`, `cargo clippy`, and `bazel build` could not be run locally in this environment (sandbox auto-denied build commands), and `Cargo.lock` was not regenerated for the new deps — CI will resolve and pull serde/serde_json/jsonschema and run the contract test. If CI fails on a `Cargo.lock` mismatch, `cargo build` / `cargo update -p jsonschema --precise 0.18.x` locally will refresh it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)