### PR TITLE
FEAT-002: component-provenance typed boundary + invariant projection (v0.7.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
       # promotes clippy to a hard gate per the witness/spar pattern.
       - name: cargo clippy --package scry-host-tests
         run: cargo clippy --package scry-host-tests --all-targets -- -D warnings
+      # FEAT-002: the pure meld<->scry boundary crate also lints on the
+      # cargo path (it compiles natively as well as to wasm32-wasip2).
+      - name: cargo clippy --package scry-provenance
+        run: cargo clippy --package scry-provenance --all-targets -- -D warnings
 
   test:
     name: Test
@@ -112,6 +116,12 @@ jobs:
         # override needed in CI; the env var is supported for local
         # iteration where bazel-bin may be elsewhere.
         run: cargo test --package scry-host-tests -- --nocapture
+      - name: cargo test --package scry-provenance
+        # FEAT-002: inline encode/decode/project unit tests for the
+        # meld<->scry boundary crate (the same source the analyzer
+        # links into the wasm component). The provenance round-trip is
+        # additionally exercised through scry-host-tests/tests/provenance.rs.
+        run: cargo test --package scry-provenance -- --nocapture
 
   rivet-validate:
     name: Rivet artifact validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,80 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-05-29
+
+Headline: **the meld→scry typed boundary**. scry can now decode the
+`component-provenance` custom section meld emits into a fused module and
+*project* every analyzed fused-module function index back to the
+component + function it was lowered from. This is the provenance-first
+slice of [[FEAT-002]] (Component-Model AI), realizing the option-(b)
+decision locked in [[DD-002]]: meld owns Core Wasm fusion correctness,
+scry owns Component-Model semantics, and the custom section is the typed
+contract between them.
+
+### Added
+
+- **`crates/scry-provenance`** — a pure, zero-dependency crate ([[FEAT-002]],
+  [[DD-002]]) defining the `component-provenance` section's binary format
+  (`SCPV` v1: magic + version + little-endian function-origin entries),
+  a strict `decode`, an `encode`, and the `project()` lookup. The *same
+  source* compiles into the `wasm32-wasip2` scry-analyzer component
+  (`#![no_std]` + `alloc`) and natively into the host harness, so the
+  contract is mechanically falsifiable on the cargo path. Carries inline
+  round-trip / strict-rejection / projection unit tests.
+- **Analyzer provenance pre-pass + projection** (`crates/scry-analyzer`).
+  The pre-pass decodes a `component-provenance` custom section via
+  `scry_provenance::decode` (a malformed section is a `Warning` + `none`,
+  never a partial parse); after the analysis phases, every analyzed fused
+  function is projected to its component origin via
+  `scry_provenance::project` and surfaced as a per-function diagnostic.
+- **WIT + contract additions** (additive, backward-compatible).
+  `analysis-result` gains `provenance: option<component-provenance>`
+  (records `component-provenance` / `component-origin`); the v1 JSON
+  contract (`contracts/scry-invariants-v1.schema.json`) gains an optional
+  `provenance` object — a v0.6 document with no `provenance` key still
+  validates.
+- **`docs/component-provenance-v1.md`** (`DOC-COMPONENT-PROVENANCE-V1`) —
+  the section's binary format, the meld⇄scry data flow (mermaid), and how
+  scry consumes it. `docs/invariant-schema-v1.md` extended with the
+  provenance field mapping.
+- **Native provenance test** (`crates/scry-host-tests/tests/provenance.rs`)
+  — exercises the boundary crate end-to-end, including round-tripping the
+  payload through a *real Wasm custom section* parsed back with the exact
+  `wasmparser` API the analyzer uses. The contract test gains a
+  `provenance_is_optional_and_tight` case. CI grows
+  `cargo clippy/test --package scry-provenance`.
+
+### Known limitations / deferred
+
+- **The meld-side section emitter is a separate cross-repo concern**
+  (the producer half), mirroring the [[FEAT-008]] / meld#192 pattern.
+  v0.7.0 ships scry's half: the format, the strict decoder, and the
+  projection primitive.
+- **Handle-state analysis is a later FEAT-002 slice.** The resource
+  handle lattice (fresh/owned/borrowed/dropped) + use-after-drop
+  detection (AC#1), host-call may-reach effect sets (AC#3), and WIT
+  refinement-predicate discharge (AC#4) are deferred.
+- **Projection validated against constructed origin tables**, not a live
+  `analyze()` call — the abstract-side host harness stays skipped on the
+  `wac_compose` root-import / wasmtime-45 limitation. The decode/project
+  mapping is well-defined and tested; live end-to-end projection lights
+  up when that limitation lifts.
+- `Verus Formal Proofs` CI job still informational.
+
+### Falsifiable kill-criterion for v0.7.0
+
+This release is wrong if a function-origin table that meld could
+legitimately emit fails to survive `decode(encode(x)) == x` lossless
+round-trip, or if `project()` ever mis-attributes a fused-module
+function index to the wrong component origin — or invents an origin for
+an unmapped index. The `crates/scry-provenance` unit tests and
+`crates/scry-host-tests/tests/provenance.rs` are the live falsifiers:
+they assert lossless round-trip (including through a real Wasm custom
+section), exact attribution, `None` for unmapped indices, and strict
+rejection of every malformed payload shape (bad magic, unknown version,
+truncation, trailing garbage).
+
 ## [0.6.0] — 2026-05-28
 
 Headline: **the analyzer→optimizer contract**. scry's invariant

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +53,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -56,10 +129,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -84,6 +184,12 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -189,6 +295,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +342,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation-sys"
@@ -426,6 +578,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +672,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +725,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -661,8 +843,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -734,6 +918,88 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -903,6 +1169,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1241,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0f4bea31643be4c6a678e9aa4ae44f0db9e5609d5ca9dc9083d06eb3e9a27a"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64",
+ "bytecount",
+ "clap",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.17",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1320,15 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1052,6 +1378,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1488,35 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1117,6 +1566,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -1219,6 +1674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1705,69 @@ dependencies = [
  "log",
  "rustc-hash",
  "smallvec",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -1285,10 +1812,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "scry-analyzer"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "scry-provenance",
  "sha2",
  "wasmparser 0.247.0",
 ]
@@ -1298,10 +1838,19 @@ name = "scry-host-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "jsonschema",
+ "scry-provenance",
+ "serde",
+ "serde_json",
+ "wasmparser 0.247.0",
  "wasmtime",
  "wasmtime-wasi",
  "wat",
 ]
+
+[[package]]
+name = "scry-provenance"
+version = "0.1.0"
 
 [[package]]
 name = "semver"
@@ -1366,6 +1915,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,6 +1975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1989,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1504,6 +2080,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,6 +2173,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,6 +2247,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -1640,6 +2297,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +2317,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1690,6 +2362,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2178,6 +2860,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wiggle"
 version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,6 +3274,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ resolver = "3"
 members = [
     "crates/wasm-lattice",
     "crates/scry-analyzer",
+    "crates/scry-provenance",
     "crates/scry-host-tests",
 ]
 

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -252,20 +252,51 @@ artifacts:
       Tracks resource handles as a linear/affine lattice (fresh /
       borrowed / owned / dropped), capability flow through composition
       graphs, and host-call effect sets per component function.
+
+      v0.7 narrow scope (this draft — the "provenance-first" slice):
+      ship the typed meld<->scry boundary and the projection primitive,
+      not yet the handle-state analysis. The deliverable is the
+      `component-provenance` custom section format (`SCPV` v1, defined
+      in the pure `crates/scry-provenance` crate: magic + version +
+      function-origin entries, with a strict decoder that rejects bad
+      magic / unknown version / truncation / trailing garbage), the
+      analyzer pre-pass that decodes the section, and the projection
+      step that attaches every analyzed fused-function index to its
+      component origin (`scry_provenance::project`), surfaced as
+      per-function diagnostics and on the new optional
+      `analysis-result.provenance` field (additive in the v1 invariant
+      contract). The format and projection are falsified natively
+      (`crates/scry-provenance` unit tests +
+      `crates/scry-host-tests/tests/provenance.rs`, which also
+      round-trips the payload through a real Wasm custom section).
+      Specified in `docs/component-provenance-v1.md`
+      (DOC-COMPONENT-PROVENANCE-V1). Deferred to a later FEAT-002
+      slice: the handle-state lattice + use-after-drop detection
+      (AC#1), host-call may-reach effect sets (AC#3), WIT refinement
+      predicate discharge (AC#4), and the meld-side section emitter
+      (the producer half of AC#5, tracked as a cross-repo concern
+      mirroring FEAT-008 / meld#192).
     tags: [component-model, capability, v0.7]
     fields:
       phase: phase-2
       acceptance-criteria:
-        - "Given a composed component graph using owned/borrowed handles, When scry runs its component-mode analysis on the original component sources, Then every use-after-drop on owned handles is reported with a witnessing abstract counterexample."
-        - "Given a fused module emitted by meld with the `component-provenance` custom section present, When scry runs its post-meld projection step, Then every Component-Model invariant from the pre-meld analysis is associated with a concrete location in the fused Core Wasm module."
-        - "Given a composition graph and a WASI import set, When scry runs, Then for each component the analyzer reports the may-reach set of host imports."
-        - "Given a WIT interface annotated with refinement predicates, When scry runs, Then the analyzer either discharges the predicate or reports a sound counterexample."
-        - "Given meld with the `component-provenance` custom section emitter, When meld is given a composition and the section is decoded, Then the section round-trips losslessly and contains one entry per fused-module function."
+        - "Given a composed component graph using owned/borrowed handles, When scry runs its component-mode analysis on the original component sources, Then every use-after-drop on owned handles is reported with a witnessing abstract counterexample. (Deferred to a later FEAT-002 slice — the handle-state lattice.)"
+        - "Given a fused module emitted by meld with the `component-provenance` custom section present, When scry runs its post-meld projection step, Then every Component-Model invariant from the pre-meld analysis is associated with a concrete location in the fused Core Wasm module. (v0.7: the analyzer decodes the section and projects every analyzed fused-function index to its component origin via `scry_provenance::project`, emitting it as diagnostics + on `analysis-result.provenance`.)"
+        - "Given a composition graph and a WASI import set, When scry runs, Then for each component the analyzer reports the may-reach set of host imports. (Deferred to a later FEAT-002 slice.)"
+        - "Given a WIT interface annotated with refinement predicates, When scry runs, Then the analyzer either discharges the predicate or reports a sound counterexample. (Deferred to a later FEAT-002 slice.)"
+        - "Given meld with the `component-provenance` custom section emitter, When meld is given a composition and the section is decoded, Then the section round-trips losslessly and contains one entry per fused-module function. (v0.7 ships the scry half: the `SCPV` v1 format + strict decoder + lossless `decode(encode(x)) == x` round-trip, falsified in `crates/scry-provenance` and `crates/scry-host-tests/tests/provenance.rs`. The meld-side emitter is the deferred cross-repo producer half.)"
     links:
       - type: satisfies
         target: REQ-003
       - type: traces-to
         target: DD-002
+      - type: depends-on
+        target: FEAT-001
+      # The provenance slice follows the same "producer publishes the
+      # contract; consumer is a cross-repo concern" pattern FEAT-008
+      # established (named in the description); typed link records it.
+      - type: traces-to
+        target: FEAT-008
 
   - id: FEAT-003
     type: feature
@@ -572,6 +603,11 @@ artifacts:
         target: FEAT-005
       - type: depends-on
         target: FEAT-006
+      # The loom-consumption-is-a-cross-repo-concern pattern this
+      # feature follows mirrors FEAT-002 / meld#192 (named in the
+      # description); typed link records that relationship.
+      - type: traces-to
+        target: FEAT-002
 
   - id: FEAT-009
     type: feature

--- a/contracts/scry-invariants-v1.schema.json
+++ b/contracts/scry-invariants-v1.schema.json
@@ -25,6 +25,10 @@
       "description": "WIT field `analysis-result.function-summaries: list<function-summary>` (FEAT-007).",
       "type": "array",
       "items": { "$ref": "#/$defs/function-summary" }
+    },
+    "provenance": {
+      "description": "WIT field `analysis-result.provenance: option<component-provenance>` (FEAT-002). Optional in the contract: present only when the analyzed module carried a well-formed `component-provenance` custom section emitted by meld. A v0.6 document with no provenance still validates.",
+      "$ref": "#/$defs/component-provenance"
     }
   },
   "$defs": {
@@ -212,6 +216,39 @@
         "soundness": {
           "description": "WIT enum `soundness-tag`. `sound`: a sound (possibly over-approximating) cover of every reachable target. `unsound-fallback`: conservative fallback retained for constructs the analyzer cannot resolve soundly.",
           "enum": ["sound", "unsound-fallback"]
+        }
+      }
+    },
+    "component-origin": {
+      "type": "object",
+      "description": "WIT record `component-origin` (FEAT-002 / DD-002): one fused-module function's origin. Decoded from meld's `component-provenance` custom section (binary format `SCPV` v1, defined by the scry-provenance crate).",
+      "required": ["fused-func-index", "component-id", "orig-func-index"],
+      "additionalProperties": false,
+      "properties": {
+        "fused-func-index": {
+          "description": "Function index in the fused Core Wasm module — the key program-point.func-index / call-edge.caller-func are also keyed by.",
+          "$ref": "#/$defs/u32"
+        },
+        "component-id": {
+          "description": "Opaque identifier of the originating component. Only equality is meaningful.",
+          "$ref": "#/$defs/u32"
+        },
+        "orig-func-index": {
+          "description": "Function index within the originating component, before fusion.",
+          "$ref": "#/$defs/u32"
+        }
+      }
+    },
+    "component-provenance": {
+      "type": "object",
+      "description": "WIT record `component-provenance` (FEAT-002): the decoded function-origin map meld emitted for a fused module.",
+      "required": ["origins"],
+      "additionalProperties": false,
+      "properties": {
+        "origins": {
+          "type": "array",
+          "description": "One entry per fused-module function meld recorded, in file order.",
+          "items": { "$ref": "#/$defs/component-origin" }
         }
       }
     },

--- a/crates/scry-analyzer/BUILD.bazel
+++ b/crates/scry-analyzer/BUILD.bazel
@@ -40,5 +40,10 @@ rust_wasm_component_bindgen(
     deps = [
         "@scry_crates//:wasmparser",
         "@scry_crates//:sha2",
+        # FEAT-002 (DD-002): the pure meld<->scry boundary crate. A
+        # first-party rust_library (no external deps) cross-compiled to
+        # wasm32-wasip2 alongside this component; provides the
+        # `component-provenance` section decode + projection lookup.
+        "//crates/scry-provenance:scry_provenance",
     ],
 )

--- a/crates/scry-analyzer/Cargo.toml
+++ b/crates/scry-analyzer/Cargo.toml
@@ -24,3 +24,10 @@ bitflags = { workspace = true }
 # rules_wasm_component.
 wasmparser = { workspace = true }
 sha2 = { workspace = true }
+
+# FEAT-002 (DD-002): the pure meld<->scry provenance boundary crate.
+# Same source compiles into this wasm32-wasip2 component and natively
+# into scry-host-tests. The Bazel build wires it via the
+# //crates/scry-provenance:scry_provenance rust_library target; this
+# path entry keeps the cargo metadata coherent.
+scry-provenance = { path = "../scry-provenance" }

--- a/crates/scry-analyzer/src/lib.rs
+++ b/crates/scry-analyzer/src/lib.rs
@@ -164,15 +164,21 @@ use sha2::{Digest, Sha256};
 use wasmparser::{Operator, Parser, Payload};
 
 use scry_analyzer_component_bindings::exports::pulseengine::scry::analyzer::{
-    AbstractValue, AnalysisConfig, AnalysisResult, AnalyzeError, CallEdge, Diagnostic,
-    DiagnosticSeverity, FunctionSummary, Guest, InvariantBundle, LocalInvariant, ProgramPoint,
-    SoundnessTag,
+    AbstractValue, AnalysisConfig, AnalysisResult, AnalyzeError, CallEdge, ComponentOrigin,
+    ComponentProvenance, Diagnostic, DiagnosticSeverity, FunctionSummary, Guest, InvariantBundle,
+    LocalInvariant, ProgramPoint, SoundnessTag,
 };
 use scry_analyzer_component_bindings::pulseengine::wasm_lattice::domain::{self, Interval};
+// The pure meld<->scry boundary crate (DD-002 / FEAT-002): the binary
+// format of the `component-provenance` custom section plus the
+// projection lookup. Aliased to avoid colliding with the WIT-binding
+// `ComponentOrigin` type above; conversion between the two is a trivial
+// field copy at the point we build the WIT `provenance` field.
+use scry_provenance::ComponentOrigin as ProvOrigin;
 
 struct Component;
 
-const SCRY_VERSION: &str = "0.5.0";
+const SCRY_VERSION: &str = "0.7.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).
@@ -600,6 +606,14 @@ impl Guest for Component {
         // table (sound, imprecise).
         let mut table_contents_unknown: bool = false;
 
+        // ── FEAT-002 component-provenance (DD-002) ───────────────────
+        // Decoded function-origin map from meld's `component-provenance`
+        // custom section, if the fused module carried one. `None` means
+        // either no section (a single un-fused component, or any plain
+        // Core Wasm input) or a section that failed to decode (reported
+        // via a Warning diagnostic — never a partial parse).
+        let mut provenance_origins: Option<Vec<ProvOrigin>> = None;
+
         for payload in Parser::new(0).parse_all(&module_bytes) {
             let payload = payload.map_err(|e| {
                 AnalyzeError::InvalidModule(format!("wasm parse failed (pre-pass): {e}"))
@@ -756,6 +770,33 @@ impl Guest for Component {
                                 // (which v0.4 doesn't model) — treat
                                 // the table contents as unknown.
                                 table_contents_unknown = true;
+                            }
+                        }
+                    }
+                }
+                Payload::CustomSection(reader) => {
+                    // FEAT-002 / DD-002: meld emits the function-origin
+                    // map as a `component-provenance` custom section.
+                    // Decode it strictly here — a malformed section is a
+                    // Warning + `none`, never a partial parse — so
+                    // phase 2 can project invariants onto component
+                    // origins. Other custom sections (name, producers,
+                    // dwarf, …) are ignored.
+                    if reader.name() == scry_provenance::SECTION_NAME {
+                        match scry_provenance::decode(reader.data()) {
+                            Ok(origins) => provenance_origins = Some(origins),
+                            Err(e) => {
+                                if config.emit_diagnostics {
+                                    diagnostics.push(Diagnostic {
+                                        severity: DiagnosticSeverity::Warning,
+                                        func_index: 0,
+                                        pc: 0,
+                                        message: format!(
+                                            "component-provenance section present but malformed: \
+                                             {e}; FEAT-002 projection disabled for this module"
+                                        ),
+                                    });
+                                }
                             }
                         }
                     }
@@ -1027,6 +1068,56 @@ impl Guest for Component {
             }
         }
 
+        // ───────────────────────────────────────────────────────────
+        // FEAT-002 (DD-002): project Component-Model results onto fused-
+        // module locations. With the decoded `component-provenance` map,
+        // every analyzed (fused) function index resolves to the
+        // component + function it was lowered from — the association that
+        // lets loom / witness / sigil attribute a fused-module invariant
+        // back to its component source. v0.7 emits the projection as
+        // per-function diagnostics and carries the decoded map on
+        // `analysis-result.provenance`; the richer handle-state /
+        // capability-flow analysis is a later FEAT-002 slice.
+        // ───────────────────────────────────────────────────────────
+        let provenance = provenance_origins.as_ref().map(|origins| {
+            if config.emit_diagnostics {
+                for func in &defined_funcs {
+                    match scry_provenance::project(origins, func.abs_index) {
+                        Some(origin) => diagnostics.push(Diagnostic {
+                            severity: DiagnosticSeverity::Info,
+                            func_index: func.abs_index,
+                            pc: 0,
+                            message: format!(
+                                "FEAT-002 projection: fused func {} originates from component {} \
+                                 function {}",
+                                func.abs_index, origin.component_id, origin.orig_func_index
+                            ),
+                        }),
+                        None => diagnostics.push(Diagnostic {
+                            severity: DiagnosticSeverity::Warning,
+                            func_index: func.abs_index,
+                            pc: 0,
+                            message: format!(
+                                "FEAT-002 projection: fused func {} has no component-provenance \
+                                 entry — invariant left unattributed",
+                                func.abs_index
+                            ),
+                        }),
+                    }
+                }
+            }
+            ComponentProvenance {
+                origins: origins
+                    .iter()
+                    .map(|o| ComponentOrigin {
+                        fused_func_index: o.fused_func_index,
+                        component_id: o.component_id,
+                        orig_func_index: o.orig_func_index,
+                    })
+                    .collect(),
+            }
+        });
+
         let invariants = InvariantBundle {
             schema: INVARIANT_SCHEMA_URL.to_string(),
             module_sha256,
@@ -1038,6 +1129,7 @@ impl Guest for Component {
             diagnostics,
             call_graph,
             function_summaries,
+            provenance,
         })
     }
 }

--- a/crates/scry-analyzer/wit/scry.wit
+++ b/crates/scry-analyzer/wit/scry.wit
@@ -205,13 +205,50 @@ interface analyzer {
         recursive: bool,
     }
 
+    /// One fused-module function's origin (FEAT-002 / DD-002). Decoded
+    /// from meld's `component-provenance` custom section: it maps a
+    /// function index in the fused Core Wasm module back to the
+    /// component + function it was lowered from. This is the minimal
+    /// function-origin map of DD-002 variant (b.1) — resource/handle
+    /// shapes are NOT carried here (scry derives those from the
+    /// original component sources directly).
+    record component-origin {
+        /// Index of the function in the fused Core Wasm module. This is
+        /// the same index scry's `program-point.func-index` and
+        /// `call-edge.caller-func` are keyed by, so projecting an
+        /// invariant onto its origin is a join on this field.
+        fused-func-index: u32,
+        /// Opaque identifier of the originating component in the
+        /// composition graph. Only equality is meaningful.
+        component-id: u32,
+        /// Index of the function within its originating component,
+        /// before fusion.
+        orig-func-index: u32,
+    }
+
+    /// The decoded `component-provenance` custom section (FEAT-002):
+    /// the function-origin map meld emitted for a fused module. Present
+    /// on `analysis-result.provenance` only when the analyzed module
+    /// actually carried a well-formed section; a module with no section
+    /// (e.g. a single un-fused component, or any v0.1-style Core Wasm
+    /// input) yields `none`, and a malformed section is reported via a
+    /// `diagnostic` and also yields `none` (never a partial parse).
+    record component-provenance {
+        /// One entry per fused-module function meld recorded, in file
+        /// order. The byte format is defined by the `scry-provenance`
+        /// crate (`SCPV` v1).
+        origins: list<component-origin>,
+    }
+
     /// Full analyzer output for one analyze call. v0.4 (FEAT-006)
     /// adds the `call-graph` field: the list of resolved call-site
     /// edges discovered during the abstract interpretation. v0.5
     /// (FEAT-007) adds `function-summaries`: the per-function abstract
-    /// summary computed bottom-up over the call graph. Both fields are
-    /// additive over the earlier shape — consumers that only read
-    /// `invariants` / `diagnostics` keep working.
+    /// summary computed bottom-up over the call graph. v0.7 (FEAT-002)
+    /// adds the optional `provenance` field: the decoded
+    /// `component-provenance` map when the fused module carried one. All
+    /// fields are additive over the earlier shape — consumers that only
+    /// read `invariants` / `diagnostics` keep working.
     record analysis-result {
         invariants: invariant-bundle,
         diagnostics: list<diagnostic>,
@@ -222,6 +259,10 @@ interface analyzer {
         /// defined (non-import) function, computed bottom-up over the
         /// call-graph SCC condensation and applied at call sites.
         function-summaries: list<function-summary>,
+        /// Decoded component provenance (FEAT-002), present only when
+        /// the analyzed module carried a well-formed
+        /// `component-provenance` custom section emitted by meld.
+        provenance: option<component-provenance>,
     }
 
     /// Reasons an analyze call can fail without producing a partial

--- a/crates/scry-host-tests/Cargo.toml
+++ b/crates/scry-host-tests/Cargo.toml
@@ -38,3 +38,14 @@ wat = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 jsonschema = { workspace = true }
+
+# FEAT-002: provenance round-trip + projection test (tests/provenance.rs)
+# exercises the pure meld<->scry boundary crate natively — the same
+# source the wasm32-wasip2 analyzer links — so the encode/decode/project
+# contract is falsifiable on the cargo path even while the live
+# component round-trip stays blocked by the wac/wasmtime-45 limitation.
+scry-provenance = { path = "../scry-provenance" }
+# Used by the provenance test to build a real Wasm module with a
+# `component-provenance` custom section and walk it back out with the
+# exact API the analyzer's pre-pass uses (Parser + CustomSection).
+wasmparser = { workspace = true }

--- a/crates/scry-host-tests/tests/contract.rs
+++ b/crates/scry-host-tests/tests/contract.rs
@@ -50,6 +50,10 @@ struct AnalysisResult {
     diagnostics: Vec<Diagnostic>,
     call_graph: Vec<CallEdge>,
     function_summaries: Vec<FunctionSummary>,
+    // FEAT-002: optional in the contract (WIT `option<component-provenance>`).
+    // Skipped when None so a v0.6-shaped document still validates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provenance: Option<ComponentProvenance>,
 }
 
 #[derive(Serialize)]
@@ -127,6 +131,21 @@ struct FunctionSummary {
     result_summary: Vec<AbstractValue>,
     context_sensitive: bool,
     recursive: bool,
+}
+
+/// FEAT-002 — serde mirror of WIT `component-provenance` / `component-origin`.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct ComponentProvenance {
+    origins: Vec<ComponentOrigin>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct ComponentOrigin {
+    fused_func_index: u32,
+    component_id: u32,
+    orig_func_index: u32,
 }
 
 // ── Schema location + representative value ───────────────────────────
@@ -252,6 +271,22 @@ fn representative_result() -> AnalysisResult {
                 recursive: true,
             },
         ],
+        // FEAT-002: a decoded component-provenance map attributing two
+        // fused functions to their originating components.
+        provenance: Some(ComponentProvenance {
+            origins: vec![
+                ComponentOrigin {
+                    fused_func_index: 0,
+                    component_id: 0,
+                    orig_func_index: 0,
+                },
+                ComponentOrigin {
+                    fused_func_index: 3,
+                    component_id: 1,
+                    orig_func_index: 1,
+                },
+            ],
+        }),
     }
 }
 
@@ -424,5 +459,60 @@ fn schema_rejects_malformed_instances() {
     assert!(
         !validator.is_valid(&base),
         "missing required call-graph must be rejected"
+    );
+}
+
+/// FEAT-002: the optional `provenance` field is backward-compatible and
+/// tightly typed. A document with no provenance (the v0.6 shape) still
+/// validates; a well-formed provenance map validates; a malformed one is
+/// rejected.
+#[test]
+#[allow(clippy::no_effect)]
+fn provenance_is_optional_and_tight() {
+    let validator = compile();
+
+    // With provenance (the representative value carries it).
+    let with_prov = serde_json::to_value(representative_result()).expect("serialize");
+    assert!(
+        with_prov.is_object() && with_prov.get("provenance").is_some(),
+        "representative value must carry provenance"
+    );
+    assert!(
+        validator.is_valid(&with_prov),
+        "a value WITH provenance must validate"
+    );
+
+    // Without provenance — a v0.6-shaped document. Backward compat: the
+    // optional field's absence must still validate.
+    let mut without_prov = with_prov.clone();
+    without_prov.as_object_mut().unwrap().remove("provenance");
+    assert!(
+        validator.is_valid(&without_prov),
+        "a v0.6 document with no provenance must still validate (backward compat)"
+    );
+
+    // Malformed: an origin missing a required field.
+    let mut bad = with_prov.clone();
+    bad["provenance"]["origins"][0] =
+        serde_json::json!({ "fused-func-index": 0, "component-id": 0 });
+    assert!(
+        !validator.is_valid(&bad),
+        "component-origin missing orig-func-index must be rejected"
+    );
+
+    // Malformed: an unexpected property on the closed origin object.
+    let mut bad = with_prov.clone();
+    bad["provenance"]["origins"][0]["bogus"] = serde_json::json!(1);
+    assert!(
+        !validator.is_valid(&bad),
+        "additionalProperties on component-origin must be rejected"
+    );
+
+    // Malformed: an unexpected property on the closed provenance object.
+    let mut bad = with_prov;
+    bad["provenance"]["extra"] = serde_json::json!(true);
+    assert!(
+        !validator.is_valid(&bad),
+        "additionalProperties on component-provenance must be rejected"
     );
 }

--- a/crates/scry-host-tests/tests/provenance.rs
+++ b/crates/scry-host-tests/tests/provenance.rs
@@ -1,0 +1,211 @@
+//! Provenance round-trip + projection test — FEAT-002 (DD-002).
+//!
+//! This is the native falsifier for the v0.7.0 provenance slice. It
+//! exercises the `scry-provenance` crate — the *same source* the
+//! `wasm32-wasip2` scry-analyzer component links — directly under
+//! `cargo test`, so the meld<->scry section contract is mechanically
+//! checked even though a live `analyze()` round-trip is still blocked by
+//! the wac-compose / wasmtime-45 limitation documented in
+//! `tests/soundness.rs`.
+//!
+//! What it asserts:
+//!
+//!   * `decode(encode(x)) == x` for representative origin tables
+//!     (lossless round-trip — FEAT-002 AC#5, scry half).
+//!   * `project()` attributes a fused-module function index to its
+//!     component origin and never invents an origin for an unmapped
+//!     index (FEAT-002 AC#2, the projection primitive).
+//!   * the strict decoder rejects every malformed shape (bad magic,
+//!     unknown version, truncation, trailing garbage) rather than
+//!     silently partial-parsing.
+
+#![forbid(unsafe_code)]
+
+use scry_provenance::{
+    ComponentOrigin, DecodeError, FORMAT_VERSION, MAGIC, SECTION_NAME, decode, encode, project,
+};
+
+fn sample() -> Vec<ComponentOrigin> {
+    vec![
+        // Two functions from component 0 (e.g. the lattice component),
+        // one from component 1 (the analyzer), with a non-trivial
+        // fused-index gap to prove projection isn't positional.
+        ComponentOrigin {
+            fused_func_index: 0,
+            component_id: 0,
+            orig_func_index: 0,
+        },
+        ComponentOrigin {
+            fused_func_index: 1,
+            component_id: 0,
+            orig_func_index: 1,
+        },
+        ComponentOrigin {
+            fused_func_index: 5,
+            component_id: 1,
+            orig_func_index: 0,
+        },
+        ComponentOrigin {
+            fused_func_index: 6,
+            component_id: 1,
+            orig_func_index: 1,
+        },
+    ]
+}
+
+#[test]
+fn section_name_is_the_meld_contract() {
+    // If this string ever changes, meld's emitter and scry's reader
+    // disagree and projection silently disappears — pin it.
+    assert_eq!(SECTION_NAME, "component-provenance");
+    assert_eq!(&MAGIC, b"SCPV");
+    assert_eq!(FORMAT_VERSION, 1);
+}
+
+#[test]
+fn round_trip_is_lossless() {
+    let origins = sample();
+    let bytes = encode(&origins);
+    let decoded = decode(&bytes).expect("round-trip decode must succeed");
+    assert_eq!(
+        decoded, origins,
+        "decode(encode(x)) must equal x (FEAT-002 AC#5)"
+    );
+}
+
+#[test]
+fn empty_table_round_trips() {
+    assert_eq!(decode(&encode(&[])), Ok(Vec::new()));
+}
+
+#[test]
+fn projection_attributes_and_never_invents() {
+    let origins = sample();
+
+    // A mapped fused index resolves to its exact component origin.
+    assert_eq!(
+        project(&origins, 5),
+        Some(ComponentOrigin {
+            fused_func_index: 5,
+            component_id: 1,
+            orig_func_index: 0
+        }),
+        "projection must attribute fused func 5 to component 1 / func 0"
+    );
+
+    // Projection is keyed by fused-func-index, not position: index 6
+    // (the 4th entry) resolves correctly.
+    assert_eq!(
+        project(&origins, 6),
+        Some(ComponentOrigin {
+            fused_func_index: 6,
+            component_id: 1,
+            orig_func_index: 1
+        })
+    );
+
+    // Unmapped fused indices must yield None — never a fabricated
+    // origin (the soundness property of attribution: scry never claims
+    // a component source it cannot prove).
+    assert_eq!(project(&origins, 2), None);
+    assert_eq!(project(&origins, 4), None);
+    assert_eq!(project(&origins, 100), None);
+    assert_eq!(project(&[], 0), None);
+}
+
+#[test]
+fn round_trips_through_a_real_wasm_custom_section() {
+    // Build a minimal core module and append a real Wasm custom section
+    // named `component-provenance` carrying the encoded payload, then
+    // confirm the section name + payload survive the Wasm encoding and
+    // decode back to the original table. This is the exact byte path the
+    // analyzer's pre-pass walks: `reader.name() == SECTION_NAME` then
+    // `decode(reader.data())`.
+    let origins = sample();
+    let payload = encode(&origins);
+
+    // Smallest valid core module: the 8-byte header `\0asm` + version 1.
+    let mut module: Vec<u8> = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+    // Custom section: id 0, then a size-prefixed body of
+    // (name-len, name, payload).
+    let name = SECTION_NAME.as_bytes();
+    let mut body: Vec<u8> = Vec::new();
+    write_uleb128(&mut body, name.len() as u64);
+    body.extend_from_slice(name);
+    body.extend_from_slice(&payload);
+    module.push(0x00); // custom section id
+    write_uleb128(&mut module, body.len() as u64);
+    module.extend_from_slice(&body);
+
+    // Walk the module with wasmparser exactly as the analyzer does and
+    // pull the `component-provenance` section back out.
+    let mut found: Option<Vec<ComponentOrigin>> = None;
+    for payload in wasmparser::Parser::new(0).parse_all(&module) {
+        if let wasmparser::Payload::CustomSection(reader) =
+            payload.expect("module the test just built must parse")
+            && reader.name() == SECTION_NAME
+        {
+            found = Some(decode(reader.data()).expect("section payload must decode"));
+        }
+    }
+    assert_eq!(
+        found,
+        Some(origins),
+        "the component-provenance custom section must survive Wasm encoding and decode losslessly"
+    );
+}
+
+#[test]
+fn decoder_rejects_malformed_payloads() {
+    // Bad magic.
+    let mut bad = encode(&sample());
+    bad[0] = b'Z';
+    assert!(matches!(decode(&bad), Err(DecodeError::BadMagic { .. })));
+
+    // Unknown version.
+    let mut bad = encode(&sample());
+    bad[4] = 9;
+    assert_eq!(
+        decode(&bad),
+        Err(DecodeError::UnsupportedVersion { found: 9 })
+    );
+
+    // Truncated body.
+    let mut bad = encode(&sample());
+    bad.truncate(bad.len() - 1);
+    assert!(matches!(
+        decode(&bad),
+        Err(DecodeError::LengthMismatch { .. })
+    ));
+
+    // Trailing garbage.
+    let mut bad = encode(&sample());
+    bad.push(0x00);
+    assert!(matches!(
+        decode(&bad),
+        Err(DecodeError::LengthMismatch { .. })
+    ));
+
+    // Too short for the header.
+    assert!(matches!(
+        decode(&[0x53, 0x43]),
+        Err(DecodeError::TooShortForHeader { .. })
+    ));
+}
+
+/// Minimal unsigned LEB128 writer — wasmparser reads sizes as LEB128, so
+/// the test must encode the custom-section name length and body length
+/// the same way. (We don't pull in `wasm-encoder` just for this.)
+fn write_uleb128(out: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}

--- a/crates/scry-provenance/BUILD.bazel
+++ b/crates/scry-provenance/BUILD.bazel
@@ -1,0 +1,36 @@
+"""scry-provenance — the typed meld<->scry boundary (DD-002, FEAT-002).
+
+A pure, zero-dependency Rust library: the binary format of meld's
+`component-provenance` custom section plus the projection lookup scry
+uses to associate Component-Model invariants with fused-module
+locations. Built for `wasm32-wasip2` as a dependency of the
+scry-analyzer component, and natively for the scry-host-tests harness.
+"""
+
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# The library. No deps — it is `#![no_std]` + `alloc` only, so it
+# composes into the wasm32-wasip2 component build without pulling in
+# anything the cdylib doesn't already have.
+rust_library(
+    name = "scry_provenance",
+    srcs = ["src/lib.rs"],
+    crate_name = "scry_provenance",
+    edition = "2024",
+    tags = ["feat-002"],
+)
+
+# Inline unit tests (#[cfg(test)] in src/lib.rs): encode/decode
+# round-trip, strict malformed-payload rejection, and projection
+# hit/miss. Builds with `--cfg test` (std test harness) for the host.
+# The same assertions are exercised on the cargo path by CI's
+# `cargo test --package scry-provenance` and by the scry-host-tests
+# harness (tests/provenance.rs, which deps this crate natively).
+rust_test(
+    name = "scry_provenance_test",
+    crate = ":scry_provenance",
+    edition = "2024",
+    tags = ["feat-002"],
+)

--- a/crates/scry-provenance/Cargo.toml
+++ b/crates/scry-provenance/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "scry-provenance"
+description = "Encode/decode + projection for meld's `component-provenance` custom section (DD-002, FEAT-002)."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+# Pure library. Intentionally zero dependencies: the same source compiles
+# both into the `wasm32-wasip2` scry-analyzer component (#![no_std] +
+# alloc) and natively into the scry-host-tests harness, so the
+# encode->decode->project round-trip is mechanically falsifiable on the
+# native cargo path even while the live component `analyze()` round-trip
+# stays blocked by the wac-compose / wasmtime-45 limitation.
+[lib]
+path = "src/lib.rs"
+
+[dependencies]

--- a/crates/scry-provenance/src/lib.rs
+++ b/crates/scry-provenance/src/lib.rs
@@ -1,0 +1,399 @@
+//! scry-provenance — the typed boundary between meld and scry for the
+//! Wasm Component Model analysis (DD-002, [[FEAT-002]]).
+//!
+//! ## What this is
+//!
+//! Per DD-002 (closed 2026-05-26 in favour of option (b)), scry runs its
+//! Component-Model analysis on the *original component sources* upstream
+//! of meld, while meld emits a minimal `component-provenance` custom
+//! section into the fused Core Wasm module. That section maps each
+//! fused-module function index back to the component + function it came
+//! from. scry's post-meld stage decodes the section and *projects* its
+//! Component-Model invariants onto concrete fused-module locations so
+//! they stay consumable by loom, witness, and the sigil/rivet evidence
+//! chain.
+//!
+//! This crate is exactly that typed contract: the on-the-wire byte
+//! format of the section, plus the projection lookup. meld is the
+//! producer (its emitter is a separate cross-repo concern, mirroring
+//! FEAT-008 / meld#192); scry is the consumer. Putting the format in
+//! one pure crate means both sides agree on the bytes by construction
+//! rather than by prose.
+//!
+//! ## v0.7.0 scope (provenance-first slice)
+//!
+//! This is the *provenance half* of FEAT-002. It delivers the typed
+//! boundary + the projection primitive; the handle-state lattice
+//! (fresh/owned/borrowed/dropped) and use-after-drop detection are a
+//! later slice. Per DD-002's chosen variant (b.1), the section is the
+//! minimal function-origin map only — resource type names and handle
+//! shapes are NOT recorded here (scry derives those from the original
+//! component sources directly).
+//!
+//! ## Why a separate, zero-dependency crate
+//!
+//! The same source compiles into the `wasm32-wasip2` scry-analyzer
+//! component (`#![no_std]` + `alloc`) *and* natively into the
+//! scry-host-tests harness. Keeping it dependency-free means the
+//! encode -> decode -> project round-trip is mechanically falsifiable on
+//! the native cargo path (`cargo test`) even while the live component
+//! `analyze()` round-trip stays blocked by the wac-compose / wasmtime-45
+//! limitation documented in `crates/scry-host-tests/tests/soundness.rs`.
+//!
+//! ## Binary format (`SCPV` v1)
+//!
+//! The custom section's *payload* (i.e. the bytes after the Wasm
+//! custom-section name `component-provenance`) is:
+//!
+//! ```text
+//! offset  size  field
+//! 0       4     magic = b"SCPV" (0x53 0x43 0x50 0x56)
+//! 4       1     format-version = 1
+//! 5       4     entry-count : u32 little-endian
+//! 9       12*n  entries, each:
+//!                 0  4  fused-func-index : u32 LE
+//!                 4  4  component-id     : u32 LE
+//!                 8  4  orig-func-index  : u32 LE
+//! ```
+//!
+//! All multi-byte integers are little-endian. The decoder is strict:
+//! it rejects a bad magic, an unknown version, a truncated buffer, and
+//! any trailing bytes past the declared entry count — so a malformed or
+//! version-mismatched section is a hard error, never a silent
+//! partial-parse.
+
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::fmt;
+
+/// Wasm custom-section name meld writes and scry reads. This is the
+/// `name` field of the Wasm custom section, not the payload.
+pub const SECTION_NAME: &str = "component-provenance";
+
+/// Payload magic: `b"SCPV"` — "scry component provenance".
+pub const MAGIC: [u8; 4] = *b"SCPV";
+
+/// The format version this crate emits and is the maximum it accepts.
+pub const FORMAT_VERSION: u8 = 1;
+
+/// Fixed payload header size: 4 (magic) + 1 (version) + 4 (count).
+const HEADER_LEN: usize = 9;
+
+/// Fixed per-entry size: three u32s.
+const ENTRY_LEN: usize = 12;
+
+/// One fused-module function's origin: which component + which function
+/// in that component it was lowered from. This is the minimal
+/// function-origin map of DD-002 variant (b.1) — no resource/handle
+/// shapes are recorded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ComponentOrigin {
+    /// Index of the function in the fused Core Wasm module meld emitted.
+    /// This is the key scry's invariants / call-edges are already
+    /// keyed by, so projection is a join on this field.
+    pub fused_func_index: u32,
+    /// Opaque identifier of the originating component in the
+    /// composition graph. Only equality is meaningful; the mapping
+    /// from id to a component name (if any) is out of scope for the
+    /// minimal section.
+    pub component_id: u32,
+    /// Index of the function within its originating component, before
+    /// fusion.
+    pub orig_func_index: u32,
+}
+
+/// Why decoding a `component-provenance` payload failed. The decoder is
+/// deliberately strict: every failure mode is a distinct, testable
+/// variant rather than a lenient best-effort parse.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DecodeError {
+    /// The payload is shorter than the fixed 9-byte header.
+    TooShortForHeader {
+        /// Actual payload length in bytes.
+        len: usize,
+    },
+    /// The first four bytes were not the `SCPV` magic.
+    BadMagic {
+        /// The four bytes that were found instead.
+        found: [u8; 4],
+    },
+    /// The format-version byte names a version this build cannot decode.
+    UnsupportedVersion {
+        /// The version byte that was found.
+        found: u8,
+    },
+    /// The declared entry count does not match the number of entry-sized
+    /// chunks actually present after the header. Catches both truncation
+    /// (fewer bytes than declared) and trailing garbage (more bytes than
+    /// declared).
+    LengthMismatch {
+        /// Entry count declared in the header.
+        declared_entries: u32,
+        /// Number of payload bytes after the 9-byte header.
+        body_len: usize,
+    },
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecodeError::TooShortForHeader { len } => write!(
+                f,
+                "component-provenance payload too short for header: {len} bytes (need >= {HEADER_LEN})"
+            ),
+            DecodeError::BadMagic { found } => write!(
+                f,
+                "component-provenance bad magic: found {found:?}, expected {MAGIC:?}"
+            ),
+            DecodeError::UnsupportedVersion { found } => write!(
+                f,
+                "component-provenance unsupported format version {found} (this build accepts <= {FORMAT_VERSION})"
+            ),
+            DecodeError::LengthMismatch {
+                declared_entries,
+                body_len,
+            } => write!(
+                f,
+                "component-provenance length mismatch: header declares {declared_entries} entries \
+                 ({} body bytes) but {body_len} body bytes are present",
+                (*declared_entries as usize).saturating_mul(ENTRY_LEN)
+            ),
+        }
+    }
+}
+
+/// Serialize a function-origin table into a `component-provenance`
+/// section payload (the bytes after the section name). The output is
+/// always a valid `SCPV` v1 payload: `decode(&encode(x)) == Ok(x)`.
+pub fn encode(origins: &[ComponentOrigin]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(HEADER_LEN + origins.len() * ENTRY_LEN);
+    out.extend_from_slice(&MAGIC);
+    out.push(FORMAT_VERSION);
+    out.extend_from_slice(&(origins.len() as u32).to_le_bytes());
+    for o in origins {
+        out.extend_from_slice(&o.fused_func_index.to_le_bytes());
+        out.extend_from_slice(&o.component_id.to_le_bytes());
+        out.extend_from_slice(&o.orig_func_index.to_le_bytes());
+    }
+    out
+}
+
+/// Read a u32 little-endian at `off`. Caller guarantees the slice has at
+/// least `off + 4` bytes (the bounds are pre-checked by `decode`).
+fn read_u32_le(bytes: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes([bytes[off], bytes[off + 1], bytes[off + 2], bytes[off + 3]])
+}
+
+/// Decode a `component-provenance` section payload into its
+/// function-origin table. Strict: see [`DecodeError`] for every
+/// rejected shape. On success the returned vector has exactly the
+/// declared number of entries, in file order.
+pub fn decode(bytes: &[u8]) -> Result<Vec<ComponentOrigin>, DecodeError> {
+    if bytes.len() < HEADER_LEN {
+        return Err(DecodeError::TooShortForHeader { len: bytes.len() });
+    }
+    let magic = [bytes[0], bytes[1], bytes[2], bytes[3]];
+    if magic != MAGIC {
+        return Err(DecodeError::BadMagic { found: magic });
+    }
+    let version = bytes[4];
+    if version != FORMAT_VERSION {
+        return Err(DecodeError::UnsupportedVersion { found: version });
+    }
+    let declared_entries = read_u32_le(bytes, 5);
+    let body_len = bytes.len() - HEADER_LEN;
+    // Exact match required: catches truncation AND trailing garbage.
+    // Use u64 math so the multiply can't overflow `usize` on a 32-bit
+    // host before the comparison.
+    let expected_body = (declared_entries as u64).saturating_mul(ENTRY_LEN as u64);
+    if expected_body != body_len as u64 {
+        return Err(DecodeError::LengthMismatch {
+            declared_entries,
+            body_len,
+        });
+    }
+    let mut origins = Vec::with_capacity(declared_entries as usize);
+    let mut off = HEADER_LEN;
+    for _ in 0..declared_entries {
+        origins.push(ComponentOrigin {
+            fused_func_index: read_u32_le(bytes, off),
+            component_id: read_u32_le(bytes, off + 4),
+            orig_func_index: read_u32_le(bytes, off + 8),
+        });
+        off += ENTRY_LEN;
+    }
+    Ok(origins)
+}
+
+/// Project a fused-module function index back to its component origin.
+///
+/// This is the core of FEAT-002's "associate every Component-Model
+/// invariant with a concrete location in the fused module" step: scry's
+/// invariants and call-edges are keyed by `fused_func_index`, so
+/// attaching an origin is a lookup in the decoded table.
+///
+/// Returns the first matching origin (meld emits at most one entry per
+/// fused function; if a malformed section ever carried duplicates the
+/// first wins, which is sound for attribution — it never invents an
+/// origin for an unmapped function).
+pub fn project(origins: &[ComponentOrigin], fused_func_index: u32) -> Option<ComponentOrigin> {
+    origins
+        .iter()
+        .find(|o| o.fused_func_index == fused_func_index)
+        .copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn sample() -> Vec<ComponentOrigin> {
+        vec![
+            ComponentOrigin {
+                fused_func_index: 0,
+                component_id: 0,
+                orig_func_index: 0,
+            },
+            ComponentOrigin {
+                fused_func_index: 1,
+                component_id: 0,
+                orig_func_index: 1,
+            },
+            ComponentOrigin {
+                fused_func_index: 7,
+                component_id: 3,
+                orig_func_index: 2,
+            },
+            ComponentOrigin {
+                fused_func_index: u32::MAX,
+                component_id: u32::MAX,
+                orig_func_index: u32::MAX,
+            },
+        ]
+    }
+
+    #[test]
+    fn round_trip_is_lossless() {
+        let origins = sample();
+        let bytes = encode(&origins);
+        // Header + 4 entries.
+        assert_eq!(bytes.len(), HEADER_LEN + 4 * ENTRY_LEN);
+        assert_eq!(&bytes[0..4], &MAGIC);
+        assert_eq!(bytes[4], FORMAT_VERSION);
+        let decoded = decode(&bytes).expect("round-trip decode");
+        assert_eq!(decoded, origins, "decode(encode(x)) must equal x");
+    }
+
+    #[test]
+    fn empty_table_round_trips() {
+        let bytes = encode(&[]);
+        assert_eq!(bytes.len(), HEADER_LEN);
+        assert_eq!(decode(&bytes), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn projection_hits_and_misses() {
+        let origins = sample();
+        assert_eq!(
+            project(&origins, 7),
+            Some(ComponentOrigin {
+                fused_func_index: 7,
+                component_id: 3,
+                orig_func_index: 2,
+            })
+        );
+        assert_eq!(
+            project(&origins, 0),
+            Some(ComponentOrigin {
+                fused_func_index: 0,
+                component_id: 0,
+                orig_func_index: 0,
+            })
+        );
+        // An unmapped fused index must not be invented.
+        assert_eq!(project(&origins, 2), None);
+        assert_eq!(project(&origins, 999), None);
+        assert_eq!(project(&[], 0), None);
+    }
+
+    #[test]
+    fn rejects_short_header() {
+        assert_eq!(
+            decode(&[0x53, 0x43, 0x50]),
+            Err(DecodeError::TooShortForHeader { len: 3 })
+        );
+        assert_eq!(decode(&[]), Err(DecodeError::TooShortForHeader { len: 0 }));
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let mut bytes = encode(&sample());
+        bytes[1] = b'X';
+        assert_eq!(
+            decode(&bytes),
+            Err(DecodeError::BadMagic {
+                found: [b'S', b'X', b'P', b'V']
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let mut bytes = encode(&sample());
+        bytes[4] = 2;
+        assert_eq!(
+            decode(&bytes),
+            Err(DecodeError::UnsupportedVersion { found: 2 })
+        );
+    }
+
+    #[test]
+    fn rejects_truncated_body() {
+        let mut bytes = encode(&sample());
+        // Drop the last 3 bytes of the final entry → body shorter than
+        // the header's declared 4 entries.
+        bytes.truncate(bytes.len() - 3);
+        let body_len = bytes.len() - HEADER_LEN;
+        assert_eq!(
+            decode(&bytes),
+            Err(DecodeError::LengthMismatch {
+                declared_entries: 4,
+                body_len,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_trailing_garbage() {
+        let mut bytes = encode(&sample());
+        bytes.push(0xff);
+        let body_len = bytes.len() - HEADER_LEN;
+        assert_eq!(
+            decode(&bytes),
+            Err(DecodeError::LengthMismatch {
+                declared_entries: 4,
+                body_len,
+            })
+        );
+    }
+
+    #[test]
+    fn count_overstated_without_bytes_is_rejected() {
+        // Header claims 5 entries but no body bytes follow.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MAGIC);
+        bytes.push(FORMAT_VERSION);
+        bytes.extend_from_slice(&5u32.to_le_bytes());
+        assert_eq!(
+            decode(&bytes),
+            Err(DecodeError::LengthMismatch {
+                declared_entries: 5,
+                body_len: 0,
+            })
+        );
+    }
+}

--- a/docs/component-provenance-v1.md
+++ b/docs/component-provenance-v1.md
@@ -1,0 +1,122 @@
+---
+id: DOC-COMPONENT-PROVENANCE-V1
+type: spec
+status: draft
+title: scry component-provenance custom section (SCPV v1)
+tags: [contract, meld, component-model, provenance, v0.7]
+---
+
+# scry component-provenance custom section (`SCPV` v1)
+
+This document specifies the typed boundary between **meld** (the verification-fusion
+tool) and **scry** for Wasm Component Model analysis: the `component-provenance`
+custom section. It realizes [[FEAT-002]] (provenance slice) and is the concrete
+form of the decision recorded in [[DD-002]].
+
+- Section name (Wasm custom-section `name`): `component-provenance`
+- Payload format id: `SCPV`, version `1`
+- Producer: meld (emitter is a separate cross-repo concern — see below)
+- Consumer: scry (`crates/scry-provenance` + the analyzer pre-pass)
+- Reference implementation: `crates/scry-provenance/src/lib.rs`
+
+## Why a custom section (and not re-analysis after fusion)
+
+Per [[DD-002]], scry runs its Component-Model analysis on the *original component
+sources* upstream of meld, where owned/borrowed handles, capability flow, and
+host-call effects are still visible. meld then lowers the component graph to a
+single fused Core Wasm module — at which point every downstream consumer (loom,
+witness, sigil/rivet evidence) operates on fused-module function indices, not on
+components.
+
+To keep scry's Component-Model invariants attached to concrete fused-module
+locations, meld emits a minimal **function-origin map** as a custom section:
+fused-module function index → (originating component, originating function). scry
+decodes it and *projects* its invariants onto the fused module. The boundary is
+cleanly typed: meld owns Core Wasm fusion correctness (proven in Rocq); scry owns
+Component-Model semantics. The section is the contract between them.
+
+The investigation in [[DD-002]] established that meld already tracks per-function
+origin tuples internally (`MergedFunction.origin`) and already emits a custom
+section — so adding `component-provenance` is a small bolt-on, not an
+architectural change. Per the chosen variant (b.1) the section is the **minimal**
+function-origin map only: resource type names and handle shapes are *not* recorded
+(scry derives those from the original component sources directly).
+
+## Binary format
+
+The section payload (the bytes after the Wasm custom-section name
+`component-provenance`) is:
+
+| offset | size   | field                                            |
+| ------ | ------ | ------------------------------------------------ |
+| 0      | 4      | magic = `b"SCPV"` (`0x53 0x43 0x50 0x56`)        |
+| 4      | 1      | format-version = `1`                             |
+| 5      | 4      | entry-count : `u32` little-endian                |
+| 9      | 12·n   | entries (see below)                              |
+
+Each entry is 12 bytes, all little-endian:
+
+| offset | size | field              |
+| ------ | ---- | ------------------ |
+| 0      | 4    | `fused-func-index` : u32 |
+| 4      | 4    | `component-id`     : u32 |
+| 8      | 4    | `orig-func-index`  : u32 |
+
+The decoder (`scry_provenance::decode`) is **strict**: it rejects a bad magic, an
+unknown version, a payload shorter than the 9-byte header, and any body length
+that does not exactly equal `12 × entry-count` (catching both truncation and
+trailing garbage). A malformed section is a hard error, never a silent
+partial-parse — scry reports it as a `diagnostic` and proceeds with `provenance =
+none` so the core invariants stay sound.
+
+## How scry consumes it
+
+1. The analyzer's pre-pass walks the module with `wasmparser`. On a
+   `CustomSection` whose `name()` equals `component-provenance`, it calls
+   `scry_provenance::decode(reader.data())`.
+2. After the abstract-interpretation phases, for every analyzed (fused) function
+   the analyzer calls `scry_provenance::project(origins, fused_func_index)` to
+   recover the component origin, and emits a projection diagnostic.
+3. The decoded map is carried on `analysis-result.provenance`
+   (`option<component-provenance>`) so loom / witness / sigil can attribute any
+   fused-module invariant — keyed by `func-index` — back to its component source.
+
+The `provenance` field is additive and optional in the v1 invariant contract
+(`contracts/scry-invariants-v1.schema.json`): a module with no section (a single
+un-fused component, or any plain Core Wasm input) yields `none`, and a v0.6-shaped
+document with no `provenance` key still validates. See `docs/invariant-schema-v1.md`.
+
+## scry ⇄ meld data flow
+
+```mermaid
+graph LR
+    C[component sources] --> S1[scry component-mode analysis]
+    C --> M[meld fuse]
+    M --> F[fused Core Wasm]
+    M -->|emits| P[component-provenance section SCPV v1]
+    F --> A[scry analyze fused module]
+    P --> A
+    S1 -.invariants.-> A
+    A -->|project func-index to origin| J[analysis-result.provenance + diagnostics]
+    J --> L[loom / witness / sigil attribute invariants to components]
+```
+
+## Validation status (honest constraint)
+
+The format is mechanically falsified on the native cargo path:
+
+- `crates/scry-provenance` carries inline `encode`/`decode`/`project` unit tests
+  (round-trip lossless, strict malformed rejection, projection hit/miss).
+- `crates/scry-host-tests/tests/provenance.rs` re-exercises the same crate — the
+  *same source* the wasm32-wasip2 analyzer links — and additionally round-trips
+  the payload through a **real Wasm custom section** parsed back out with the exact
+  `wasmparser` API the analyzer's pre-pass uses.
+
+As with [[FEAT-008]], a live `analyze()` round-trip in the composed component is
+not yet exercised in CI because `rules_wasm_component`'s `wac_compose` emits
+root-level component imports that wasmtime 45 rejects (see the module doc in
+`crates/scry-host-tests/tests/soundness.rs`). The v0.7.0 deliverable is the typed
+boundary, its strict decoder, and the projection primitive — all falsified
+natively. The **meld-side emitter** is tracked as a separate cross-repo concern,
+mirroring the [[FEAT-008]] / meld#192 pattern; the handle-state lattice and
+use-after-drop detection are a later FEAT-002 slice.

--- a/docs/invariant-schema-v1.md
+++ b/docs/invariant-schema-v1.md
@@ -2,6 +2,7 @@
 id: DOC-INVARIANT-SCHEMA-V1
 type: spec
 status: draft
+title: scry invariant JSON-schema contract (v1)
 tags: [contract, loom, schema, v0.6]
 ---
 
@@ -36,7 +37,7 @@ v0.5, in the Stiévenart & De Roover summary style — [[AC-010]]). But making l
 link against scry's `wit-bindgen` output would couple the optimizer to scry's
 component ABI and release cadence. Per [[DD-007]], the analysis output is
 schema-stable and decoupled from the WIT: loom ingests a plain JSON document and
-validates it against this versioned schema. This mirrors FEAT-002 / meld#192,
+validates it against this versioned schema. This mirrors [[FEAT-002]] / meld#192,
 where the producer publishes the contract and the consumer side is a separate
 cross-repo concern.
 
@@ -51,11 +52,16 @@ union. Numeric widths are range-constrained in JSON (`u32`, `s64`).
 
 | WIT type / field | JSON encoding |
 | --- | --- |
-| `analysis-result` | object `{ "invariants", "diagnostics"?, "call-graph", "function-summaries" }` |
+| `analysis-result` | object `{ "invariants", "diagnostics"?, "call-graph", "function-summaries", "provenance"? }` |
 | `analysis-result.invariants: invariant-bundle` | `"invariants"` — object |
 | `analysis-result.diagnostics: list<diagnostic>` | `"diagnostics"` — array (optional; loom ignores it) |
 | `analysis-result.call-graph: list<call-edge>` | `"call-graph"` — array |
 | `analysis-result.function-summaries: list<function-summary>` | `"function-summaries"` — array |
+| `analysis-result.provenance: option<component-provenance>` | `"provenance"` — object (optional; [[FEAT-002]]) |
+| `component-provenance.origins: list<component-origin>` | `"origins"` — array |
+| `component-origin.fused-func-index: u32` | `"fused-func-index"` — integer u32 |
+| `component-origin.component-id: u32` | `"component-id"` — integer u32 |
+| `component-origin.orig-func-index: u32` | `"orig-func-index"` — integer u32 |
 | `invariant-bundle.schema: string` | `"schema"` — `const` = the v1 URI |
 | `invariant-bundle.module-sha256: string` | `"module-sha256"` — `^[0-9a-f]{64}$` (lowercase hex) |
 | `invariant-bundle.points: list<program-point>` | `"points"` — array |

--- a/spar/scry.aadl
+++ b/spar/scry.aadl
@@ -133,6 +133,23 @@ public
       Data_Size => 16 MByte;  -- list of FunctionSummary records
   end FunctionSummaries;
 
+  data ComponentProvenance
+    -- v0.7 (FEAT-002 / DD-002): the decoded `component-provenance`
+    -- custom section meld emits into a fused module — the
+    -- function-origin map (fused-module function index → originating
+    -- component id + originating function index). meld is the
+    -- producer; the AnalyzerProcess decodes the section in its
+    -- pre-pass (via the pure scry-provenance crate, binary format
+    -- `SCPV` v1) and projects its Component-Model invariants onto the
+    -- fused-module locations so loom / witness / sigil can attribute
+    -- them back to their component source. Optional on the analysis
+    -- result: present only when the analyzed module carried a
+    -- well-formed section. See docs/component-provenance-v1.md
+    -- (DOC-COMPONENT-PROVENANCE-V1).
+    properties
+      Data_Size => 16 MByte;  -- list of (fused-idx, component-id, orig-idx) entries
+  end ComponentProvenance;
+
   -- ══════════════════════════════════════════════════════════════════
   -- Threads — one per component's primary worker
   -- ══════════════════════════════════════════════════════════════════
@@ -173,6 +190,10 @@ public
       -- v0.5 (FEAT-007): the per-function abstract summaries emitted
       -- alongside the invariant bundle and call graph.
       summaries_out:   out event data port FunctionSummaries;
+      -- v0.7 (FEAT-002): the decoded component provenance, emitted
+      -- when the analyzed fused module carried a `component-provenance`
+      -- custom section.
+      provenance_out:  out event data port ComponentProvenance;
       -- Connection to LatticeOps. Modelled as a port pair; in the
       -- Component Model this is a WIT cross-component import.
       lattice_call_out: out event data port;
@@ -216,6 +237,7 @@ public
       diagnostics_out: out event data port AnalysisDiagnostic;
       callgraph_out:   out event data port CallGraph;
       summaries_out:   out event data port FunctionSummaries;
+      provenance_out:  out event data port ComponentProvenance;
       lattice_call_out: out event data port;
       lattice_result_in: in event data port Interval;
   end AnalyzerProcess;
@@ -230,6 +252,7 @@ public
       c_diagnostics:   port analyzer_thread.diagnostics_out -> diagnostics_out;
       c_callgraph:     port analyzer_thread.callgraph_out -> callgraph_out;
       c_summaries:     port analyzer_thread.summaries_out -> summaries_out;
+      c_provenance:    port analyzer_thread.provenance_out -> provenance_out;
       c_lattice_call:  port analyzer_thread.lattice_call_out -> lattice_call_out;
       c_lattice_result: port lattice_result_in -> analyzer_thread.lattice_result_in;
   end AnalyzerProcess.IntervalV01;
@@ -246,6 +269,7 @@ public
       diagnostics_out: out event data port AnalysisDiagnostic;
       callgraph_out:   out event data port CallGraph;
       summaries_out:   out event data port FunctionSummaries;
+      provenance_out:  out event data port ComponentProvenance;
   end Scry;
 
   system implementation Scry.V01
@@ -264,6 +288,7 @@ public
       s_diagnostics:   port analyzer.diagnostics_out -> diagnostics_out;
       s_callgraph:     port analyzer.callgraph_out -> callgraph_out;
       s_summaries:     port analyzer.summaries_out -> summaries_out;
+      s_provenance:    port analyzer.provenance_out -> provenance_out;
       -- Internal cross-component wiring (analyzer → lattice)
       s_lattice_call:  port analyzer.lattice_call_out -> lattice.op_in;
       s_lattice_result: port lattice.op_out -> analyzer.lattice_result_in;


### PR DESCRIPTION
## Summary

The **provenance-first slice of FEAT-002** (Component-Model AI), realizing the option-(b) decision locked in **DD-002**: meld owns Core Wasm fusion correctness, scry owns Component-Model semantics, and meld's `component-provenance` custom section is the typed contract between them. This is v0.7.0 per the roadmap.

- **`crates/scry-provenance`** — a pure, zero-dependency crate defining the section's binary format (`SCPV` v1: magic + version + little-endian function-origin entries), a strict `decode`, an `encode`, and the `project()` lookup. The *same source* compiles into the `wasm32-wasip2` analyzer component (`#![no_std]` + `alloc`) and natively into the host harness, so the contract is mechanically falsifiable on the cargo path.
- **Analyzer** decodes a `component-provenance` custom section in its pre-pass (a malformed section is a `Warning` + `none`, never a partial parse) and projects every analyzed fused-function index to its component origin as a per-function diagnostic. `analysis-result` gains `provenance: option<component-provenance>` (additive).
- **Contract**: optional `provenance` object added to `scry-invariants-v1.schema.json` — a v0.6 document with no `provenance` key still validates.
- **Docs**: `docs/component-provenance-v1.md` (`DOC-COMPONENT-PROVENANCE-V1`) with the scry⇄meld data-flow; `invariant-schema-v1.md` extended.
- **spar/rivet**: AADL `ComponentProvenance` type + port; FEAT-002 → `draft`, tag `v0.7`, with the shipped-slice acceptance criteria spelled out and deferred ACs marked.

### Deferred (honest constraints)
- The **meld-side section emitter** is a separate cross-repo concern (the producer half), mirroring the FEAT-008 / meld#192 pattern. This PR ships scry's half.
- **Handle-state analysis** (use-after-drop, host-call may-reach, WIT refinement) is a later FEAT-002 slice.
- Projection is validated against constructed origin tables, not a live `analyze()` call — the abstract-side host harness stays skipped on the `wac_compose` root-import / wasmtime-45 limitation.

### Falsifiable kill-criterion
Wrong if `decode(encode(x)) != x` for any emittable origin table, or if `project()` mis-attributes a fused index / invents an origin for an unmapped one. `crates/scry-provenance` unit tests + `crates/scry-host-tests/tests/provenance.rs` are the live falsifiers (the latter round-trips the payload through a **real Wasm custom section** parsed with the exact `wasmparser` API the analyzer uses).

## Test plan

- [x] `cargo test --package scry-provenance` (9 inline tests)
- [x] `cargo test --package scry-host-tests` (contract: 5 incl. `provenance_is_optional_and_tight`; provenance: 6; soundness fixtures: 4)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --package scry-host-tests --package scry-provenance --all-targets -- -D warnings` clean
- [x] `bazel build //:scry` green — the pure crate cross-compiles to wasm32-wasip2 alongside the analyzer; `wasm-tools validate bazel-bin/scry.wasm` passes; composed WIT carries `component-provenance` + `provenance` field
- [x] `rivet validate` PASS (0 warnings); `spar parse spar/scry.aadl` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)