### PR TITLE
fix(release): install Nix before bazel build (unblocks v0.7.0 release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,22 @@ jobs:
           echo "VERSION=$TAG" >> "$GITHUB_ENV"
           echo "BARE_VERSION=$BARE" >> "$GITHUB_ENV"
 
+      - name: Install Nix
+        # FEAT-012: scry's MODULE.bazel registers the Rocq toolchain
+        # unconditionally (mirroring synth's pattern), which forces
+        # Bazel to resolve `@rocq_toolchains` (via rules_nixpkgs) during
+        # analysis even for `bazel build //:scry`. Without nix-build on
+        # PATH that resolution fails with "Platform is not supported:
+        # nix-build not found in PATH". The CI `bazel-build` and `test`
+        # jobs already install Nix for exactly this reason; the release
+        # job must too. Earlier releases only survived on a warm Bazel
+        # cache that already held the nix-fetched repo — a fragile
+        # accident that broke the moment a BUILD.bazel / Cargo.lock
+        # change rotated the cache key (v0.7.0).
+        uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
       - uses: bazelbuild/setup-bazelisk@v3
 
       - name: Cache Bazel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,7 +617,8 @@ falsifier.
 See git history for pre-v0.1 work (initial scope-out + DD-002 closure
 in PR #2).
 
-[Unreleased]: https://github.com/pulseengine/scry/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/pulseengine/scry/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/pulseengine/scry/releases/tag/v0.7.0
 [0.6.0]: https://github.com/pulseengine/scry/releases/tag/v0.6.0
 [0.5.0]: https://github.com/pulseengine/scry/releases/tag/v0.5.0
 [0.4.0]: https://github.com/pulseengine/scry/releases/tag/v0.4.0

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,7 @@
 | Version | Status | Capability |
 |---|---|---|
 | pre-v0.1 | shipped 2026-05-26 | research + requirements + design + safety-case as 56 rivet artifacts; `research-ext` local schema; PASS validate; README + this roadmap |
+| v0.1 → v0.7 | shipped 2026-05-27 … 2026-05-29 | the capability ladder below, built in dependency order: interval fixpoint (v0.1/v0.2) → Verus+Rocq proof toolchain (v0.2) → region memory + host-oracle harness (v0.3) → sound `call_indirect` call graph (v0.4) → compositional interprocedural summaries (v0.5) → loom invariant JSON contract (v0.6) → `component-provenance` typed meld↔scry boundary + invariant projection (v0.7, FEAT-002 provenance slice). See `CHANGELOG.md` for the per-release falsification kill-criteria. |
 
 ## Forward path
 


### PR DESCRIPTION
## Summary

The **v0.7.0 release run failed** at `bazel build //:scry` with:

```
Platform is not supported: nix-build not found in PATH.
```

`MODULE.bazel` registers the Rocq toolchain (FEAT-012) unconditionally, so Bazel resolves `@rocq_toolchains` via `rules_nixpkgs` during *analysis* — even for a plain `bazel build //:scry`. The CI `bazel-build` and `test` jobs install Nix for exactly this reason; **release.yml never did**, and only survived on a warm Bazel cache that already held the nix-fetched repo. The v0.7.0 changes (`crates/scry-provenance/BUILD.bazel`, `Cargo.lock`) rotated the cache key (`hashFiles(... 'crates/**/BUILD.bazel' ...)`), forcing a fresh fetch and exposing the latent bug.

Fix: add the same `cachix/install-nix-action@v30` step the CI jobs use, before `setup-bazelisk` / `bazel build`.

Also bundled (doc-only, no code impact on the built artifact):
- `[0.7.0]` CHANGELOG version-link refs at the bottom of `CHANGELOG.md`.
- A shipped-versions row (v0.1 → v0.7) in `docs/roadmap.md`.

After merge, the release is re-triggered via `workflow_dispatch` (`tag=v0.7.0`); the tag already exists and `gh release create --verify-tag` will attach the assets.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: `workflow_dispatch` release.yml with `tag=v0.7.0` → release succeeds, assets + cosign sigs + SLSA + compliance bundle attached
- [ ] Clean-room verify the published v0.7.0 wasm (`wasm-tools validate` + `cosign verify-blob`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)