### PR TITLE
FEAT-009: taint / noninterference domain (v0.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,12 @@ jobs:
       # cargo path (it compiles natively as well as to wasm32-wasip2).
       - name: cargo clippy --package scry-provenance
         run: cargo clippy --package scry-provenance --all-targets -- -D warnings
+      # FEAT-009: the pure security-label (taint) lattice crate also
+      # lints on the cargo path (it compiles natively as well as to
+      # wasm32-wasip2, where wasm-lattice's WIT label-* exports delegate
+      # to it).
+      - name: cargo clippy --package scry-taint
+        run: cargo clippy --package scry-taint --all-targets -- -D warnings
 
   test:
     name: Test
@@ -122,6 +128,13 @@ jobs:
         # links into the wasm component). The provenance round-trip is
         # additionally exercised through scry-host-tests/tests/provenance.rs.
         run: cargo test --package scry-provenance -- --nocapture
+      # FEAT-009: the security-label lattice kill-criterion — the label
+      # lattice obeys its algebraic laws and forward propagation never
+      # moves down the lattice (exhaustive over the height-1 lattice).
+      # The same crate links into the wasm component; the host harness
+      # (tests/taint.rs) re-exercises it on the cargo path.
+      - name: cargo test --package scry-taint
+        run: cargo test --package scry-taint -- --nocapture
 
   rivet-validate:
     name: Rivet artifact validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-29
+
+### Added
+
+- **Taint / noninterference domain (FEAT-009, AC-007 — Wanilla-class).**
+  A two-point security-label lattice `low ⊑ high` lifted pointwise over
+  values and the control-context, giving a sound *termination-insensitive
+  noninterference* analysis that composes with (does not replace) the
+  interval and region domains.
+  - **`scry-taint` crate.** A new pure, zero-dependency crate holding the
+    label-lattice algebra (`bottom`/`top`/`leq`/`join`/`meet`). Like
+    `scry-provenance`, it compiles to both `wasm32-wasip2` (where
+    `wasm-lattice`'s WIT `label-*` exports delegate to it, so the shipped
+    lattice code is exactly the falsified code) and natively (where the
+    host harness checks the lattice laws).
+  - **`wasm-lattice` label domain.** The `pulseengine:wasm-lattice/domain`
+    interface gains `label` + `label-bottom`/`label-top`/`label-leq`/
+    `label-join`/`label-meet`, dogfooded across the WIT boundary (DD-008)
+    like the interval/region ops.
+  - **Analyzer taint pass.** Opt-in via `analysis-config.taint-policy`
+    (declared High `high-params` sources / Low `low-results` sinks). A
+    dedicated shadow-taint walk propagates labels through the operand
+    stack and locals and — unlike the interval pass, which scrubs on
+    control flow — interprets structured `if`/`else`/`block`/`end` to
+    raise a control-context label, capturing the *implicit* flows that
+    distinguish noninterference from mere explicit-flow taint. A
+    noninterference finding is emitted when a declared Low result carries
+    the High label at exit, surfaced on the new additive
+    `analysis-result.taint-findings` field (and an additive
+    `taint-findings` block in the v1 invariant contract). Any unmodelled
+    operator (`loop`, `br*`, value-typed blocks, `call*`, memory/global
+    ops) conservatively raises the taint state to High — sound: it can
+    only add taint, never miss a flow.
+- AADL (`SecurityLabel` / `TaintPolicy` / `TaintFindings` data + ports),
+  rivet FEAT-009 flipped to `draft` with the narrow v0.8 scope, and the
+  capability ladder updated (`docs/roadmap.md`,
+  `docs/taint-noninterference-v1.md`).
+
+### Known limitations (deferred to a later FEAT-009 slice)
+
+- Tainted store/load tracking through linear memory (memory as a sink),
+  multi-principal / lattice-of-sets labels, value-sensitive
+  declassification, unstructured-control implicit flows (`loop` taint
+  fixpoint, `br_table` post-dominator analysis), and the Wanilla
+  shared-benchmark differential corpus (AC#2).
+- As with FEAT-008, the live `analyze()` round-trip stays gated by the
+  wac_compose / wasmtime-45 root-import limitation, so the lattice and
+  finding shapes are falsified natively (`crates/scry-taint` +
+  `crates/scry-host-tests/tests/taint.rs` + `tests/contract.rs`), not via
+  a live component call.
+
+### Falsifiable kill-criterion
+
+- The security-label lattice obeys its algebraic laws AND forward
+  propagation never moves *down* the lattice (`join` is an upper bound;
+  `high` is absorbing) — so a Low result is provably independent of every
+  High source and "absence of a finding implies noninterference" is
+  sound. Checked exhaustively over the (height-1) lattice in
+  `crates/scry-taint` (12 tests) and `crates/scry-host-tests/tests/taint.rs`
+  (6 tests); the `taint-finding` contract shape is pinned in
+  `tests/contract.rs`. If any law fails, the build goes red.
+
 ## [0.7.0] — 2026-05-29
 
 Headline: **the meld→scry typed boundary**. scry can now decode the
@@ -617,7 +679,8 @@ falsifier.
 See git history for pre-v0.1 work (initial scope-out + DD-002 closure
 in PR #2).
 
-[Unreleased]: https://github.com/pulseengine/scry/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/pulseengine/scry/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/pulseengine/scry/releases/tag/v0.8.0
 [0.7.0]: https://github.com/pulseengine/scry/releases/tag/v0.7.0
 [0.6.0]: https://github.com/pulseengine/scry/releases/tag/v0.6.0
 [0.5.0]: https://github.com/pulseengine/scry/releases/tag/v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,6 +1840,7 @@ dependencies = [
  "anyhow",
  "jsonschema",
  "scry-provenance",
+ "scry-taint",
  "serde",
  "serde_json",
  "wasmparser 0.247.0",
@@ -1850,6 +1851,10 @@ dependencies = [
 
 [[package]]
 name = "scry-provenance"
+version = "0.1.0"
+
+[[package]]
+name = "scry-taint"
 version = "0.1.0"
 
 [[package]]
@@ -2458,6 +2463,7 @@ name = "wasm-lattice"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "scry-taint",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/wasm-lattice",
     "crates/scry-analyzer",
     "crates/scry-provenance",
+    "crates/scry-taint",
     "crates/scry-host-tests",
 ]
 

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -612,24 +612,66 @@ artifacts:
   - id: FEAT-009
     type: feature
     title: "v0.8 — Taint / noninterference domain (Wanilla-class)"
-    status: proposed
+    status: draft
     description: >
       Add a security-label lattice (Low ⊑ High) lifted pointwise over
       values and memory; lift to a relational analysis sufficient for
       termination-insensitive noninterference per the Wanilla CCS 2025
-      technique. The taint domain composes with the interval and region
-      domains rather than replacing them.
+      technique (AC-007). The taint domain composes with the interval
+      and region domains rather than replacing them.
+
+      v0.8 narrow scope (this draft): ship the security-label lattice
+      and the explicit + implicit-flow taint propagation that make the
+      result a sound termination-insensitive noninterference analysis,
+      falsified natively. The deliverables are: (1) the two-point label
+      lattice `low ⊑ high` added to the `pulseengine:wasm-lattice/domain`
+      interface (`label`, `label-bottom`/`label-top`/`label-leq`/
+      `label-join`/`label-meet`), dogfooded across the WIT boundary like
+      the interval/region ops; (2) the analyzer's taint lift — a shadow
+      taint state (a `security-label` per operand-stack slot and per
+      local) threaded alongside the interval/region abstract value, with
+      `taint = ⊔ operand taints` on every transfer function and a
+      control-context (program-counter) label raised to High inside the
+      structured-control region dominated by a High branch guard, which
+      is what tracks implicit flows; (3) a config-declared policy
+      (`analysis-config.taint-policy`: High `high-params` sources / Low
+      `low-results` sinks) applied per analyzed function, with a
+      noninterference finding emitted when a Low-declared result carries
+      the High label at function exit, surfaced as diagnostics and on the
+      new additive `analysis-result.taint-findings` field (and an
+      additive `taint-findings` block in the v1 invariant contract).
+      The label lattice and the finding shape are falsified natively
+      (`crates/wasm-lattice` label-lattice law tests +
+      `crates/scry-host-tests/tests/taint.rs`), since the live
+      `analyze()` round-trip remains gated by the wac_compose /
+      wasmtime-45 root-import limitation (the same constraint FEAT-008
+      documented). Deferred to a later FEAT-009 slice: tainted-store /
+      tainted-load tracking through linear memory (memory as a sink),
+      multi-principal / lattice-of-sets labels, value-sensitive
+      declassification, unstructured-control implicit flows (irreducible
+      CFGs / `br_table` post-dominator analysis), and the Wanilla
+      shared-benchmark differential corpus (AC#2, which needs the corpus
+      milestone).
     tags: [security, taint, v0.8]
     fields:
       phase: phase-2
       acceptance-criteria:
-        - "Given a Wasm module with declared High inputs and Low outputs, When scry runs the taint domain, Then any sound noninterference violation is reported and the absence of a report implies noninterference (under termination-insensitive assumptions)."
-        - "Given the Wanilla benchmark corpus, When scry's taint analysis is compared to Wanilla's, Then scry produces equivalent or stricter results on shared benchmarks."
+        - "Given a Wasm module with declared High inputs and Low outputs, When scry runs the taint domain, Then any sound noninterference violation is reported and the absence of a report implies noninterference (under termination-insensitive assumptions). (v0.8: the analyzer lifts the `low ⊑ high` label over values and the control-context, seeds `high-params` as High sources, and reports a `taint-finding` when a `low-results` sink carries High at function exit — covering both explicit and structured implicit flows.)"
+        - "Given the Wanilla benchmark corpus, When scry's taint analysis is compared to Wanilla's, Then scry produces equivalent or stricter results on shared benchmarks. (Deferred to the v0.8+ corpus milestone — the differential harness needs the shared benchmark set.)"
     links:
       - type: satisfies
         target: REQ-001
       - type: references-paper
         target: AC-007
+      - type: depends-on
+        target: FEAT-001
+      - type: traces-to
+        target: FEAT-003
+      # The wac_compose / wasmtime-45 native-falsification constraint
+      # named in the description is the same one FEAT-008 documented;
+      # typed link records the mention.
+      - type: traces-to
+        target: FEAT-008
 
   - id: FEAT-010
     type: feature

--- a/contracts/scry-invariants-v1.schema.json
+++ b/contracts/scry-invariants-v1.schema.json
@@ -4,7 +4,11 @@
   "title": "scry analysis-result (invariant contract v1)",
   "description": "Stable, versioned JSON form of scry's `analysis-result` (crates/scry-analyzer/wit/scry.wit). Published for downstream optimizers (loom) and verifiers (witness) so they can consume scry invariants without coupling to scry's WIT bindings. FEAT-008. This schema is the serialized form of the existing InvariantBundle / CallGraph / FunctionSummaries types; it introduces no new types.",
   "type": "object",
-  "required": ["invariants", "call-graph", "function-summaries"],
+  "required": [
+    "invariants",
+    "call-graph",
+    "function-summaries"
+  ],
   "additionalProperties": false,
   "properties": {
     "invariants": {
@@ -14,21 +18,33 @@
     "diagnostics": {
       "description": "WIT field `analysis-result.diagnostics: list<diagnostic>`. Optional in the contract: loom does not consume diagnostics, but they may be present.",
       "type": "array",
-      "items": { "$ref": "#/$defs/diagnostic" }
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
     },
     "call-graph": {
       "description": "WIT field `analysis-result.call-graph: list<call-edge>` (FEAT-006).",
       "type": "array",
-      "items": { "$ref": "#/$defs/call-edge" }
+      "items": {
+        "$ref": "#/$defs/call-edge"
+      }
     },
     "function-summaries": {
       "description": "WIT field `analysis-result.function-summaries: list<function-summary>` (FEAT-007).",
       "type": "array",
-      "items": { "$ref": "#/$defs/function-summary" }
+      "items": {
+        "$ref": "#/$defs/function-summary"
+      }
     },
     "provenance": {
       "description": "WIT field `analysis-result.provenance: option<component-provenance>` (FEAT-002). Optional in the contract: present only when the analyzed module carried a well-formed `component-provenance` custom section emitted by meld. A v0.6 document with no provenance still validates.",
       "$ref": "#/$defs/component-provenance"
+    },
+    "taint-findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/taint-finding"
+      }
     }
   },
   "$defs": {
@@ -45,7 +61,11 @@
     "invariant-bundle": {
       "type": "object",
       "description": "WIT record `invariant-bundle`: per-program-point abstract values (FEAT-001/FEAT-005).",
-      "required": ["schema", "module-sha256", "points"],
+      "required": [
+        "schema",
+        "module-sha256",
+        "points"
+      ],
       "additionalProperties": false,
       "properties": {
         "schema": {
@@ -61,14 +81,20 @@
         "points": {
           "type": "array",
           "description": "Per-program-point invariants. Order is not significant.",
-          "items": { "$ref": "#/$defs/program-point" }
+          "items": {
+            "$ref": "#/$defs/program-point"
+          }
         }
       }
     },
     "program-point": {
       "type": "object",
       "description": "WIT record `program-point`: invariants at one (func-index, pc).",
-      "required": ["func-index", "pc", "locals"],
+      "required": [
+        "func-index",
+        "pc",
+        "locals"
+      ],
       "additionalProperties": false,
       "properties": {
         "func-index": {
@@ -82,27 +108,37 @@
         "locals": {
           "type": "array",
           "description": "Abstract values for the locals tracked at this point.",
-          "items": { "$ref": "#/$defs/local-invariant" }
+          "items": {
+            "$ref": "#/$defs/local-invariant"
+          }
         }
       }
     },
     "local-invariant": {
       "type": "object",
       "description": "WIT record `local-invariant`: abstract value for one local.",
-      "required": ["local-index", "value"],
+      "required": [
+        "local-index",
+        "value"
+      ],
       "additionalProperties": false,
       "properties": {
         "local-index": {
           "description": "Local index.",
           "$ref": "#/$defs/u32"
         },
-        "value": { "$ref": "#/$defs/abstract-value" }
+        "value": {
+          "$ref": "#/$defs/abstract-value"
+        }
       }
     },
     "interval": {
       "type": "object",
       "description": "WIT record `interval` (from pulseengine:wasm-lattice/domain): inclusive integer range [lo, hi] over s64.",
-      "required": ["lo", "hi"],
+      "required": [
+        "lo",
+        "hi"
+      ],
       "additionalProperties": false,
       "properties": {
         "lo": {
@@ -118,7 +154,10 @@
     "region": {
       "type": "object",
       "description": "WIT record `region-pointer-payload`: a memory-region pointer (FEAT-005). region-id plus a byte-offset interval into that region.",
-      "required": ["region-id", "offset"],
+      "required": [
+        "region-id",
+        "offset"
+      ],
       "additionalProperties": false,
       "properties": {
         "region-id": {
@@ -137,40 +176,65 @@
         {
           "type": "object",
           "description": "i32-interval(interval): 32-bit integer interval.",
-          "required": ["kind", "interval"],
+          "required": [
+            "kind",
+            "interval"
+          ],
           "additionalProperties": false,
           "properties": {
-            "kind": { "const": "i32-interval" },
-            "interval": { "$ref": "#/$defs/interval" }
+            "kind": {
+              "const": "i32-interval"
+            },
+            "interval": {
+              "$ref": "#/$defs/interval"
+            }
           }
         },
         {
           "type": "object",
           "description": "i64-interval(interval): 64-bit integer interval.",
-          "required": ["kind", "interval"],
+          "required": [
+            "kind",
+            "interval"
+          ],
           "additionalProperties": false,
           "properties": {
-            "kind": { "const": "i64-interval" },
-            "interval": { "$ref": "#/$defs/interval" }
+            "kind": {
+              "const": "i64-interval"
+            },
+            "interval": {
+              "$ref": "#/$defs/interval"
+            }
           }
         },
         {
           "type": "object",
           "description": "region-pointer(region-pointer-payload): pointer into a memory region.",
-          "required": ["kind", "region"],
+          "required": [
+            "kind",
+            "region"
+          ],
           "additionalProperties": false,
           "properties": {
-            "kind": { "const": "region-pointer" },
-            "region": { "$ref": "#/$defs/region" }
+            "kind": {
+              "const": "region-pointer"
+            },
+            "region": {
+              "$ref": "#/$defs/region"
+            }
           }
         },
         {
           "type": "object",
           "description": "unknown: top of the abstract domain.",
-          "required": ["kind"],
+          "required": [
+            "kind"
+          ],
           "additionalProperties": false,
           "properties": {
-            "kind": { "const": "unknown" }
+            "kind": {
+              "const": "unknown"
+            }
           }
         }
       ]
@@ -178,22 +242,43 @@
     "diagnostic": {
       "type": "object",
       "description": "WIT record `diagnostic`: a non-fatal note emitted alongside the invariant bundle.",
-      "required": ["severity", "func-index", "pc", "message"],
+      "required": [
+        "severity",
+        "func-index",
+        "pc",
+        "message"
+      ],
       "additionalProperties": false,
       "properties": {
         "severity": {
           "description": "WIT enum `diagnostic-severity`.",
-          "enum": ["info", "warning", "unsoundness-fallback"]
+          "enum": [
+            "info",
+            "warning",
+            "unsoundness-fallback"
+          ]
         },
-        "func-index": { "$ref": "#/$defs/u32" },
-        "pc": { "$ref": "#/$defs/u32" },
-        "message": { "type": "string" }
+        "func-index": {
+          "$ref": "#/$defs/u32"
+        },
+        "pc": {
+          "$ref": "#/$defs/u32"
+        },
+        "message": {
+          "type": "string"
+        }
       }
     },
     "call-edge": {
       "type": "object",
       "description": "WIT record `call-edge`: one resolved call site (FEAT-006).",
-      "required": ["caller-func", "pc", "indirect", "resolved-targets", "soundness"],
+      "required": [
+        "caller-func",
+        "pc",
+        "indirect",
+        "resolved-targets",
+        "soundness"
+      ],
       "additionalProperties": false,
       "properties": {
         "caller-func": {
@@ -211,18 +296,27 @@
         "resolved-targets": {
           "type": "array",
           "description": "Resolved target function indices. A singleton sound set permits devirtualization. Empty means provably unreachable.",
-          "items": { "$ref": "#/$defs/u32" }
+          "items": {
+            "$ref": "#/$defs/u32"
+          }
         },
         "soundness": {
           "description": "WIT enum `soundness-tag`. `sound`: a sound (possibly over-approximating) cover of every reachable target. `unsound-fallback`: conservative fallback retained for constructs the analyzer cannot resolve soundly.",
-          "enum": ["sound", "unsound-fallback"]
+          "enum": [
+            "sound",
+            "unsound-fallback"
+          ]
         }
       }
     },
     "component-origin": {
       "type": "object",
       "description": "WIT record `component-origin` (FEAT-002 / DD-002): one fused-module function's origin. Decoded from meld's `component-provenance` custom section (binary format `SCPV` v1, defined by the scry-provenance crate).",
-      "required": ["fused-func-index", "component-id", "orig-func-index"],
+      "required": [
+        "fused-func-index",
+        "component-id",
+        "orig-func-index"
+      ],
       "additionalProperties": false,
       "properties": {
         "fused-func-index": {
@@ -242,20 +336,30 @@
     "component-provenance": {
       "type": "object",
       "description": "WIT record `component-provenance` (FEAT-002): the decoded function-origin map meld emitted for a fused module.",
-      "required": ["origins"],
+      "required": [
+        "origins"
+      ],
       "additionalProperties": false,
       "properties": {
         "origins": {
           "type": "array",
           "description": "One entry per fused-module function meld recorded, in file order.",
-          "items": { "$ref": "#/$defs/component-origin" }
+          "items": {
+            "$ref": "#/$defs/component-origin"
+          }
         }
       }
     },
     "function-summary": {
       "type": "object",
       "description": "WIT record `function-summary`: compositional per-function summary (FEAT-007).",
-      "required": ["func-index", "param-count", "result-summary", "context-sensitive", "recursive"],
+      "required": [
+        "func-index",
+        "param-count",
+        "result-summary",
+        "context-sensitive",
+        "recursive"
+      ],
       "additionalProperties": false,
       "properties": {
         "func-index": {
@@ -269,7 +373,9 @@
         "result-summary": {
           "type": "array",
           "description": "Abstract value of each function result under the context-insensitive (top-input) summary, in result order.",
-          "items": { "$ref": "#/$defs/abstract-value" }
+          "items": {
+            "$ref": "#/$defs/abstract-value"
+          }
         },
         "context-sensitive": {
           "type": "boolean",
@@ -280,6 +386,54 @@
           "description": "True iff the function is in a non-trivial call-graph SCC (self- or mutually-recursive)."
         }
       }
+    },
+    "security-label": {
+      "type": "string",
+      "enum": [
+        "low",
+        "high"
+      ]
+    },
+    "taint-finding-kind": {
+      "type": "string",
+      "enum": [
+        "high-result-explicit",
+        "high-result-implicit"
+      ]
+    },
+    "taint-finding": {
+      "type": "object",
+      "properties": {
+        "func-index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pc": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "kind": {
+          "$ref": "#/$defs/taint-finding-kind"
+        },
+        "source-label": {
+          "$ref": "#/$defs/security-label"
+        },
+        "sink-label": {
+          "$ref": "#/$defs/security-label"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "func-index",
+        "pc",
+        "kind",
+        "source-label",
+        "sink-label",
+        "message"
+      ],
+      "additionalProperties": false
     }
   }
 }

--- a/crates/scry-analyzer/src/lib.rs
+++ b/crates/scry-analyzer/src/lib.rs
@@ -166,7 +166,8 @@ use wasmparser::{Operator, Parser, Payload};
 use scry_analyzer_component_bindings::exports::pulseengine::scry::analyzer::{
     AbstractValue, AnalysisConfig, AnalysisResult, AnalyzeError, CallEdge, ComponentOrigin,
     ComponentProvenance, Diagnostic, DiagnosticSeverity, FunctionSummary, Guest, InvariantBundle,
-    LocalInvariant, ProgramPoint, SoundnessTag,
+    LocalInvariant, ProgramPoint, SecurityLabel, SoundnessTag, TaintFinding, TaintFindingKind,
+    TaintPolicy,
 };
 use scry_analyzer_component_bindings::pulseengine::wasm_lattice::domain::{self, Interval};
 // The pure meld<->scry boundary crate (DD-002 / FEAT-002): the binary
@@ -178,7 +179,7 @@ use scry_provenance::ComponentOrigin as ProvOrigin;
 
 struct Component;
 
-const SCRY_VERSION: &str = "0.7.0";
+const SCRY_VERSION: &str = "0.8.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).
@@ -1118,6 +1119,31 @@ impl Guest for Component {
             }
         });
 
+        // ───────────────────────────────────────────────────────────
+        // FEAT-009 (AC-007): taint / noninterference domain. Opt-in via
+        // `config.taint-policy`. For each defined function we run a
+        // dedicated label-propagation walk (a "shadow" taint state over
+        // operand stack + locals, plus a control-context label for
+        // implicit flows) seeded from the declared High sources, and
+        // report a finding when a declared Low result carries the High
+        // label at exit. The label lattice operations are dogfooded
+        // across the wasm-lattice WIT boundary (DD-008) just like the
+        // interval ops — `domain::label_*`. When no policy is supplied
+        // the field is empty and behaviour is exactly as before.
+        // ───────────────────────────────────────────────────────────
+        let mut taint_findings: Vec<TaintFinding> = Vec::new();
+        if let Some(policy) = config.taint_policy.as_ref() {
+            for func in &defined_funcs {
+                run_taint_analysis(
+                    func,
+                    policy,
+                    config.emit_diagnostics,
+                    &mut diagnostics,
+                    &mut taint_findings,
+                );
+            }
+        }
+
         let invariants = InvariantBundle {
             schema: INVARIANT_SCHEMA_URL.to_string(),
             module_sha256,
@@ -1130,6 +1156,7 @@ impl Guest for Component {
             call_graph,
             function_summaries,
             provenance,
+            taint_findings,
         })
     }
 }
@@ -2426,6 +2453,407 @@ fn join_abstract(a: &AbstractValue, b: &AbstractValue) -> AbstractValue {
 /// (full payloads) and tends to balloon diagnostic strings. The set
 /// below is the one we expect to see most often via the fallback
 /// path; anything else falls through to a debug-ish label.
+// ════════════════════════════════════════════════════════════════════
+// FEAT-009 (AC-007): taint / noninterference domain.
+//
+// A dedicated label-propagation walk over one function body. The
+// interval pass scrubs to top on control flow; the taint pass instead
+// interprets *structured* control (empty-typed `block` / `if` / `else`
+// / `end`) so it can raise a control-context label and capture the
+// IMPLICIT flows that make the result a sound termination-insensitive
+// noninterference analysis rather than mere explicit-flow taint. Every
+// lattice operation is dogfooded across the wasm-lattice WIT boundary
+// (DD-008): the propagation calls `domain::label_join` / `label_bottom`
+// / `label_top` / `label_leq`, never a local lattice op.
+//
+// Scope (sound for everything; precise for a bounded set, mirroring the
+// interval pass): handled precisely are constants, `local.get/set/tee`,
+// `drop`, `select`, the pure i32/i64 arithmetic + bitwise + comparison
+// + conversion operators, and empty-typed structured `block`/`if`/
+// `else`/`end`. ANY other operator — `loop` (needs a taint fixpoint),
+// `br*`, value-typed blocks, `call*`, memory and global ops — degrades
+// the function's taint state to High (the sound top) and stops precise
+// tracking. Degrading can only ADD taint, so it never misses a flow
+// (REQ-001): the absence of a finding still implies noninterference.
+// ════════════════════════════════════════════════════════════════════
+
+/// A shadow taint value: a security label plus, when the label is High,
+/// whether the High-ness arrived (at least partly) through an implicit
+/// (control-context) flow. The label is the WIT-imported `domain::Label`
+/// so every combination goes through the lattice component.
+#[derive(Clone, Copy)]
+struct Taint {
+    label: domain::Label,
+    implicit: bool,
+}
+
+impl Taint {
+    fn low() -> Self {
+        Taint {
+            label: domain::label_bottom(),
+            implicit: false,
+        }
+    }
+}
+
+/// `true` iff the label is High — expressed via the dogfooded
+/// `label-leq`: High is exactly the elements not below ⊥ (`low`).
+fn taint_is_high(l: domain::Label) -> bool {
+    !domain::label_leq(l, domain::label_bottom())
+}
+
+/// Join two shadow values (explicit data flow): `label = a ⊔ b`, and
+/// the result is implicit-High only if its High-ness is owed to an
+/// implicit-High operand.
+fn taint_join(a: Taint, b: Taint) -> Taint {
+    let label = domain::label_join(a.label, b.label);
+    let implicit = (taint_is_high(a.label) && a.implicit) || (taint_is_high(b.label) && b.implicit);
+    Taint {
+        label,
+        implicit: taint_is_high(label) && implicit,
+    }
+}
+
+/// Store a value under a control context: `label = v ⊔ ctx`. If the
+/// High-ness comes from `ctx` (the value itself was Low) the flow is
+/// implicit; otherwise the value's own implicit-ness is inherited.
+fn taint_store(v: Taint, ctx: domain::Label) -> Taint {
+    let label = domain::label_join(v.label, ctx);
+    let from_ctx = taint_is_high(ctx) && !taint_is_high(v.label);
+    let implicit = from_ctx || (taint_is_high(v.label) && v.implicit);
+    Taint {
+        label,
+        implicit: taint_is_high(label) && implicit,
+    }
+}
+
+/// The taint stack-effect of one operator (see the module banner for
+/// the scope rationale). `Scrub` is the sound catch-all.
+enum TaintEff {
+    /// Push a provably-Low value (a constant).
+    PushLow,
+    /// Push the shadow label of a local.
+    PushLocal(u32),
+    /// Pop a value and store it (joined with the control context) into a
+    /// local; `keep` (for `local.tee`) leaves the value's data taint on
+    /// the stack.
+    StoreLocal { idx: u32, keep: bool },
+    /// Pop `n` operands, push their join (pure data flow). `n >= 1`.
+    Reduce(u8),
+    /// Pop one operand, discard it.
+    Drop,
+    /// No stack effect.
+    Nop,
+    /// Open an empty-typed `block` (control context unchanged).
+    OpenBlock,
+    /// Open an empty-typed `if`: pop the condition, raise the context.
+    OpenIf,
+    /// `else` — the alternate arm stays under the raised context.
+    Else,
+    /// `end` — close the innermost control frame, restoring its context.
+    End,
+    /// `return` / `unreachable` — stop the walk.
+    Stop,
+    /// Anything unmodelled: conservatively raise the whole taint state
+    /// to High (sound) and stop precise tracking.
+    Scrub,
+}
+
+fn taint_effect(op: &Operator<'_>) -> TaintEff {
+    match op {
+        Operator::I32Const { .. }
+        | Operator::I64Const { .. }
+        | Operator::F32Const { .. }
+        | Operator::F64Const { .. } => TaintEff::PushLow,
+
+        Operator::LocalGet { local_index } => TaintEff::PushLocal(*local_index),
+        Operator::LocalSet { local_index } => TaintEff::StoreLocal {
+            idx: *local_index,
+            keep: false,
+        },
+        Operator::LocalTee { local_index } => TaintEff::StoreLocal {
+            idx: *local_index,
+            keep: true,
+        },
+
+        Operator::Drop => TaintEff::Drop,
+        Operator::Nop => TaintEff::Nop,
+
+        // `select` pops two values + a condition and pushes one. Joining
+        // all three folds the (implicit) dependence on the condition into
+        // the result's data taint — sound and precise here.
+        Operator::Select | Operator::TypedSelect { .. } => TaintEff::Reduce(3),
+
+        // Binary numeric / bitwise / comparison operators: pop 2, push 1.
+        Operator::I32Add
+        | Operator::I32Sub
+        | Operator::I32Mul
+        | Operator::I32DivS
+        | Operator::I32DivU
+        | Operator::I32RemS
+        | Operator::I32RemU
+        | Operator::I32And
+        | Operator::I32Or
+        | Operator::I32Xor
+        | Operator::I32Shl
+        | Operator::I32ShrS
+        | Operator::I32ShrU
+        | Operator::I32Rotl
+        | Operator::I32Rotr
+        | Operator::I32Eq
+        | Operator::I32Ne
+        | Operator::I32LtS
+        | Operator::I32LtU
+        | Operator::I32GtS
+        | Operator::I32GtU
+        | Operator::I32LeS
+        | Operator::I32LeU
+        | Operator::I32GeS
+        | Operator::I32GeU
+        | Operator::I64Add
+        | Operator::I64Sub
+        | Operator::I64Mul
+        | Operator::I64DivS
+        | Operator::I64DivU
+        | Operator::I64RemS
+        | Operator::I64RemU
+        | Operator::I64And
+        | Operator::I64Or
+        | Operator::I64Xor
+        | Operator::I64Shl
+        | Operator::I64ShrS
+        | Operator::I64ShrU
+        | Operator::I64Rotl
+        | Operator::I64Rotr
+        | Operator::I64Eq
+        | Operator::I64Ne
+        | Operator::I64LtS
+        | Operator::I64LtU
+        | Operator::I64GtS
+        | Operator::I64GtU
+        | Operator::I64LeS
+        | Operator::I64LeU
+        | Operator::I64GeS
+        | Operator::I64GeU => TaintEff::Reduce(2),
+
+        // Unary numeric / test / conversion operators: pop 1, push 1.
+        Operator::I32Eqz
+        | Operator::I64Eqz
+        | Operator::I32Clz
+        | Operator::I32Ctz
+        | Operator::I32Popcnt
+        | Operator::I64Clz
+        | Operator::I64Ctz
+        | Operator::I64Popcnt
+        | Operator::I32WrapI64
+        | Operator::I64ExtendI32S
+        | Operator::I64ExtendI32U
+        | Operator::I32Extend8S
+        | Operator::I32Extend16S
+        | Operator::I64Extend8S
+        | Operator::I64Extend16S
+        | Operator::I64Extend32S => TaintEff::Reduce(1),
+
+        // Structured control — only the empty (no value) block type is
+        // modelled precisely; a value-producing block/if would perturb
+        // the stack-depth model, so it degrades (sound).
+        Operator::Block { blockty } => match blockty {
+            wasmparser::BlockType::Empty => TaintEff::OpenBlock,
+            _ => TaintEff::Scrub,
+        },
+        Operator::If { blockty } => match blockty {
+            wasmparser::BlockType::Empty => TaintEff::OpenIf,
+            _ => TaintEff::Scrub,
+        },
+        Operator::Else => TaintEff::Else,
+        Operator::End => TaintEff::End,
+        Operator::Return | Operator::Unreachable => TaintEff::Stop,
+
+        _ => TaintEff::Scrub,
+    }
+}
+
+/// Run the taint / noninterference walk over one function body
+/// (FEAT-009). Seeds the parameter labels from the policy, propagates
+/// labels (and the implicit-flow control context) through the body, and
+/// pushes a `TaintFinding` for every declared Low result that carries
+/// the High label at exit.
+fn run_taint_analysis(
+    func: &DefinedFunc<'_>,
+    policy: &TaintPolicy,
+    emit_diagnostics: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+    findings: &mut Vec<TaintFinding>,
+) {
+    // Seed local labels: declared High params → High (explicit source);
+    // every other param and all declared locals → Low.
+    let mut t_locals: Vec<Taint> =
+        Vec::with_capacity(func.params.len() + func.declared_locals.len());
+    for i in 0..func.params.len() {
+        if policy.high_params.contains(&(i as u32)) {
+            t_locals.push(Taint {
+                label: domain::label_top(),
+                implicit: false,
+            });
+        } else {
+            t_locals.push(Taint::low());
+        }
+    }
+    for _ in &func.declared_locals {
+        t_locals.push(Taint::low());
+    }
+
+    let mut t_stack: Vec<Taint> = Vec::new();
+    let mut ctx: domain::Label = domain::label_bottom();
+    let mut frames: Vec<domain::Label> = Vec::new();
+    let mut degraded = false;
+
+    let mut pc: u32 = 0;
+    for op in &func.ops {
+        if degraded {
+            pc = pc.saturating_add(1);
+            continue;
+        }
+        match taint_effect(op) {
+            TaintEff::PushLow => t_stack.push(Taint::low()),
+            TaintEff::PushLocal(idx) => {
+                let v = t_locals.get(idx as usize).copied().unwrap_or(Taint {
+                    label: domain::label_top(),
+                    implicit: false,
+                });
+                t_stack.push(v);
+            }
+            TaintEff::StoreLocal { idx, keep } => {
+                let v = t_stack.pop().unwrap_or(Taint {
+                    label: domain::label_top(),
+                    implicit: false,
+                });
+                let stored = taint_store(v, ctx);
+                if let Some(slot) = t_locals.get_mut(idx as usize) {
+                    *slot = stored;
+                }
+                if keep {
+                    t_stack.push(v);
+                }
+            }
+            TaintEff::Reduce(n) => {
+                let mut acc = Taint::low();
+                for _ in 0..n {
+                    let x = t_stack.pop().unwrap_or(Taint {
+                        label: domain::label_top(),
+                        implicit: false,
+                    });
+                    acc = taint_join(acc, x);
+                }
+                t_stack.push(acc);
+            }
+            TaintEff::Drop => {
+                let _ = t_stack.pop();
+            }
+            TaintEff::Nop => {}
+            TaintEff::OpenBlock => frames.push(ctx),
+            TaintEff::OpenIf => {
+                let cond = t_stack.pop().unwrap_or(Taint {
+                    label: domain::label_top(),
+                    implicit: false,
+                });
+                frames.push(ctx);
+                ctx = domain::label_join(ctx, cond.label);
+            }
+            TaintEff::Else => {}
+            TaintEff::End => {
+                if let Some(saved) = frames.pop() {
+                    ctx = saved;
+                }
+            }
+            TaintEff::Stop => break,
+            TaintEff::Scrub => {
+                if emit_diagnostics {
+                    diagnostics.push(Diagnostic {
+                        severity: DiagnosticSeverity::Info,
+                        func_index: func.abs_index,
+                        pc,
+                        message: format!(
+                            "taint: operator {} not modelled — taint state conservatively \
+                             raised to High (sound, FEAT-009)",
+                            op_name(op)
+                        ),
+                    });
+                }
+                for slot in t_locals.iter_mut() {
+                    *slot = Taint {
+                        label: domain::label_top(),
+                        implicit: false,
+                    };
+                }
+                t_stack.clear();
+                ctx = domain::label_top();
+                degraded = true;
+            }
+        }
+        pc = pc.saturating_add(1);
+    }
+
+    // Exit: the function results are the top `n_results` of the value
+    // stack (in order). If the body degraded or left an under-full stack
+    // (e.g. an early `return` / `unreachable`), every result is High —
+    // sound.
+    let n_results = func.results.len();
+    let mut result_taints: Vec<Taint> = Vec::with_capacity(n_results);
+    if !degraded && t_stack.len() >= n_results {
+        let start = t_stack.len() - n_results;
+        for t in &t_stack[start..] {
+            result_taints.push(*t);
+        }
+    } else {
+        for _ in 0..n_results {
+            result_taints.push(Taint {
+                label: domain::label_top(),
+                implicit: false,
+            });
+        }
+    }
+
+    // The exit pc is the function body's terminating `end`.
+    let exit_pc = func.ops.len().saturating_sub(1) as u32;
+    for &res_idx in &policy.low_results {
+        if let Some(t) = result_taints.get(res_idx as usize) {
+            if taint_is_high(t.label) {
+                let kind = if t.implicit {
+                    TaintFindingKind::HighResultImplicit
+                } else {
+                    TaintFindingKind::HighResultExplicit
+                };
+                let flow = if t.implicit { "implicit" } else { "explicit" };
+                findings.push(TaintFinding {
+                    func_index: func.abs_index,
+                    pc: exit_pc,
+                    kind,
+                    source_label: SecurityLabel::High,
+                    sink_label: SecurityLabel::Low,
+                    message: format!(
+                        "noninterference violation: result {res_idx} of function \
+                         {} is declared Low but carries High via an {flow} flow",
+                        func.abs_index
+                    ),
+                });
+                if emit_diagnostics {
+                    diagnostics.push(Diagnostic {
+                        severity: DiagnosticSeverity::Warning,
+                        func_index: func.abs_index,
+                        pc: exit_pc,
+                        message: format!(
+                            "taint: High→Low {flow} flow — result {res_idx} of function {} \
+                             leaks a declared High source (FEAT-009 / AC-007)",
+                            func.abs_index
+                        ),
+                    });
+                }
+            }
+        }
+    }
+}
+
 fn op_name(op: &Operator<'_>) -> &'static str {
     match op {
         Operator::Unreachable => "unreachable",

--- a/crates/scry-analyzer/wit/scry.wit
+++ b/crates/scry-analyzer/wit/scry.wit
@@ -102,8 +102,44 @@ interface analyzer {
         message: string,
     }
 
+    /// A confidentiality label (FEAT-009, v0.8). Declared locally in
+    /// the scry interface — structurally the two-point lattice
+    /// `low ⊑ high` exported by `pulseengine:wasm-lattice/domain` as
+    /// `label`, but declared here (not `use`d) so the scry exported
+    /// interface does not re-export the lattice's `label` type through
+    /// the WAC composition — the same decision taken for
+    /// `region-pointer-payload` vs the lattice's `region`. Conversion
+    /// is trivial (same two cases) and performed inside the analyzer.
+    enum security-label {
+        /// Provably public.
+        low,
+        /// May depend on a declared secret source (sound top).
+        high,
+    }
+
+    /// The declared information-flow policy for an analyze call
+    /// (FEAT-009): which function parameters are High (secret)
+    /// sources and which function results are Low (public) sinks.
+    /// Applied per analyzed function — each function's parameter
+    /// labels are seeded `high` for the indices in `high-params`
+    /// (`low` otherwise), and at function exit a result slot whose
+    /// index is in `low-results` carrying the `high` label is a
+    /// noninterference violation. An empty policy (no high-params)
+    /// taints nothing and reports nothing.
+    record taint-policy {
+        /// Parameter indices treated as High sources on every
+        /// analyzed function's entry.
+        high-params: list<u32>,
+        /// Result indices required to remain Low at function exit.
+        low-results: list<u32>,
+    }
+
     /// v0.1 analyzer configuration. Kept narrow; v0.2+ will add
     /// fields for region-memory parameters, octagon thresholds, etc.
+    /// v0.8 (FEAT-009) adds the optional `taint-policy`: when present
+    /// the analyzer runs the taint/noninterference domain alongside
+    /// the interval/region analysis; when absent (`none`) behaviour
+    /// is exactly as before.
     record analysis-config {
         /// Maximum number of fixpoint iterations per loop header
         /// before widening kicks in. Default if not set by the
@@ -112,6 +148,9 @@ interface analyzer {
         /// Whether to emit diagnostics for unsupported instructions
         /// (default true). Useful to suppress noise in tests.
         emit-diagnostics: bool,
+        /// Optional information-flow policy (FEAT-009). `none` disables
+        /// the taint domain (default, fully backward-compatible).
+        taint-policy: option<taint-policy>,
     }
 
     /// Soundness classification of a single call-graph edge.
@@ -249,6 +288,43 @@ interface analyzer {
     /// `component-provenance` map when the fused module carried one. All
     /// fields are additive over the earlier shape — consumers that only
     /// read `invariants` / `diagnostics` keep working.
+    /// How a noninterference finding's High value reached a Low sink
+    /// (FEAT-009, v0.8).
+    enum taint-finding-kind {
+        /// The Low-declared result carries the High label via an
+        /// explicit data flow (a High source value computed through
+        /// arithmetic / copies into the result).
+        high-result-explicit,
+        /// The Low-declared result carries the High label via an
+        /// implicit flow — assigned under a control-context tainted
+        /// High (inside a branch whose guard depended on a secret).
+        /// This is the case that distinguishes a sound noninterference
+        /// analysis from plain explicit-flow taint.
+        high-result-implicit,
+    }
+
+    /// One noninterference finding (FEAT-009): a declared Low sink that
+    /// carries the High label, i.e. a sound information-flow violation
+    /// under termination-insensitive assumptions. Soundness (REQ-001,
+    /// AC-007): every concrete High→Low flow is covered — the absence
+    /// of any finding implies noninterference. False alarms are
+    /// possible; missed real flows are not.
+    record taint-finding {
+        /// Function whose result violates the policy.
+        func-index: u32,
+        /// Program-counter offset of the violating site (the function
+        /// `end` for a result-at-exit finding).
+        pc: u32,
+        /// How the High value reached the Low sink.
+        kind: taint-finding-kind,
+        /// Label of the offending value (always `high` for a finding).
+        source-label: security-label,
+        /// Declared label of the sink it reached (always `low`).
+        sink-label: security-label,
+        /// Human-readable description (which result index, etc.).
+        message: string,
+    }
+
     record analysis-result {
         invariants: invariant-bundle,
         diagnostics: list<diagnostic>,
@@ -263,6 +339,10 @@ interface analyzer {
         /// the analyzed module carried a well-formed
         /// `component-provenance` custom section emitted by meld.
         provenance: option<component-provenance>,
+        /// Noninterference findings (FEAT-009): one per declared Low
+        /// sink that carries the High label. Empty when no
+        /// `taint-policy` was configured or no violation was found.
+        taint-findings: list<taint-finding>,
     }
 
     /// Reasons an analyze call can fail without producing a partial

--- a/crates/scry-host-tests/Cargo.toml
+++ b/crates/scry-host-tests/Cargo.toml
@@ -49,3 +49,8 @@ scry-provenance = { path = "../scry-provenance" }
 # `component-provenance` custom section and walk it back out with the
 # exact API the analyzer's pre-pass uses (Parser + CustomSection).
 wasmparser = { workspace = true }
+
+# FEAT-009: native falsification of the shipped security-label lattice
+# (the same scry-taint crate wasm-lattice's WIT `label-*` exports
+# delegate to) in tests/taint.rs.
+scry-taint = { path = "../scry-taint" }

--- a/crates/scry-host-tests/tests/contract.rs
+++ b/crates/scry-host-tests/tests/contract.rs
@@ -54,6 +54,28 @@ struct AnalysisResult {
     // Skipped when None so a v0.6-shaped document still validates.
     #[serde(skip_serializing_if = "Option::is_none")]
     provenance: Option<ComponentProvenance>,
+    // FEAT-009: optional in the contract (WIT `list<taint-finding>`;
+    // empty when no policy/violation). Additive — a v0.7 document with
+    // no taint-findings still validates.
+    #[serde(rename = "taint-findings", skip_serializing_if = "Vec::is_empty")]
+    taint_findings: Vec<TaintFinding>,
+}
+
+/// FEAT-009 — serde mirror of WIT `taint-finding`. The `kind`,
+/// `source-label`, and `sink-label` enums are modelled as strings; the
+/// schema's enum constraint is what pins their legal values.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct TaintFinding {
+    func_index: u32,
+    pc: u32,
+    /// "high-result-explicit" | "high-result-implicit".
+    kind: String,
+    /// Always "high" for a finding.
+    source_label: String,
+    /// Always "low" for a finding.
+    sink_label: String,
+    message: String,
 }
 
 #[derive(Serialize)]
@@ -287,6 +309,18 @@ fn representative_result() -> AnalysisResult {
                 },
             ],
         }),
+        // FEAT-009: a representative noninterference finding — function
+        // 3's Low-declared result carries High via an implicit flow.
+        taint_findings: vec![TaintFinding {
+            func_index: 3,
+            pc: 7,
+            kind: "high-result-implicit".to_string(),
+            source_label: "high".to_string(),
+            sink_label: "low".to_string(),
+            message: "result 0 of function 3 is declared Low but carries High via an \
+                      implicit flow"
+                .to_string(),
+        }],
     }
 }
 
@@ -514,5 +548,68 @@ fn provenance_is_optional_and_tight() {
     assert!(
         !validator.is_valid(&bad),
         "additionalProperties on component-provenance must be rejected"
+    );
+}
+
+/// FEAT-009: the optional `taint-findings` field is backward-compatible
+/// and tightly typed. A v0.7-shaped document with no taint-findings
+/// still validates; a well-formed finding validates; malformed findings
+/// (bad enum, missing field, additionalProperties) are rejected.
+#[test]
+fn taint_findings_optional_and_tight() {
+    let validator = compile();
+
+    // With taint-findings (the representative value carries one).
+    let with_tf = serde_json::to_value(representative_result()).unwrap();
+    assert!(
+        with_tf.get("taint-findings").is_some(),
+        "representative value must carry taint-findings"
+    );
+    assert!(
+        validator.is_valid(&with_tf),
+        "a value WITH taint-findings must validate"
+    );
+
+    // Without taint-findings — a v0.7-shaped document. Backward compat.
+    let mut without = with_tf.clone();
+    without.as_object_mut().unwrap().remove("taint-findings");
+    assert!(
+        validator.is_valid(&without),
+        "a v0.7 document with no taint-findings must still validate (backward compat)"
+    );
+
+    // Malformed: an unknown `kind` enum value.
+    let mut bad = with_tf.clone();
+    bad["taint-findings"][0]["kind"] = serde_json::json!("high-result-sideways");
+    assert!(
+        !validator.is_valid(&bad),
+        "an unknown taint-finding-kind must be rejected"
+    );
+
+    // Malformed: an illegal security-label value.
+    let mut bad = with_tf.clone();
+    bad["taint-findings"][0]["source-label"] = serde_json::json!("secret");
+    assert!(
+        !validator.is_valid(&bad),
+        "an illegal security-label must be rejected"
+    );
+
+    // Malformed: a missing required field.
+    let mut bad = with_tf.clone();
+    bad["taint-findings"][0]
+        .as_object_mut()
+        .unwrap()
+        .remove("message");
+    assert!(
+        !validator.is_valid(&bad),
+        "a taint-finding missing `message` must be rejected"
+    );
+
+    // Malformed: an unexpected property on the closed taint-finding.
+    let mut bad = with_tf.clone();
+    bad["taint-findings"][0]["bogus"] = serde_json::json!(true);
+    assert!(
+        !validator.is_valid(&bad),
+        "additionalProperties on taint-finding must be rejected"
     );
 }

--- a/crates/scry-host-tests/tests/taint.rs
+++ b/crates/scry-host-tests/tests/taint.rs
@@ -1,0 +1,118 @@
+//! FEAT-009 (AC-007) host-side falsifier for the security-label (taint)
+//! lattice.
+//!
+//! The lattice algebra ships inside the `wasm-lattice` Wasm component,
+//! whose WIT `label-*` exports delegate to the pure `scry-taint` crate.
+//! Because the live `analyze()` round-trip is still gated by the
+//! wac_compose / wasmtime-45 root-import limitation (see
+//! `tests/soundness.rs`), we falsify the *exact shipped lattice code*
+//! here on the native cargo path by exercising `scry-taint` directly —
+//! the same crate the component compiles in. This is the taint analogue
+//! of `tests/provenance.rs`.
+//!
+//! Kill-criterion (v0.8): the label lattice obeys its algebraic laws AND
+//! forward propagation never moves *down* the lattice — i.e. `join` is an
+//! upper bound and `high` (⊤) is absorbing. If either fails, taint could
+//! under-approximate secret dependence and "absence of a finding implies
+//! noninterference" would be unsound. All laws are checked EXHAUSTIVELY:
+//! the lattice has height 1, so 2ⁿ input tuples cover it completely.
+
+use scry_taint::{Label, bottom, is_bottom, join, leq, meet, top};
+
+const ALL: [Label; 2] = [Label::Low, Label::High];
+
+#[test]
+fn extrema_are_low_and_high() {
+    assert_eq!(bottom(), Label::Low, "⊥ is low (public)");
+    assert_eq!(top(), Label::High, "⊤ is high (secret)");
+    assert!(is_bottom(bottom()));
+    assert!(!is_bottom(top()));
+}
+
+#[test]
+fn join_is_logical_or_meet_is_logical_and() {
+    // join: high iff either operand high (the forward-taint rule).
+    assert_eq!(join(Label::Low, Label::Low), Label::Low);
+    assert_eq!(join(Label::Low, Label::High), Label::High);
+    assert_eq!(join(Label::High, Label::Low), Label::High);
+    assert_eq!(join(Label::High, Label::High), Label::High);
+    // meet: low iff either operand low.
+    assert_eq!(meet(Label::Low, Label::Low), Label::Low);
+    assert_eq!(meet(Label::Low, Label::High), Label::Low);
+    assert_eq!(meet(Label::High, Label::Low), Label::Low);
+    assert_eq!(meet(Label::High, Label::High), Label::High);
+}
+
+#[test]
+fn order_is_the_chain_low_below_high() {
+    assert!(leq(Label::Low, Label::Low));
+    assert!(leq(Label::Low, Label::High));
+    assert!(leq(Label::High, Label::High));
+    // The single dropped pair — the whole point of the lattice.
+    assert!(!leq(Label::High, Label::Low), "high must NOT be ⊑ low");
+}
+
+#[test]
+fn lattice_axioms_hold_exhaustively() {
+    for a in ALL {
+        // idempotence
+        assert_eq!(join(a, a), a);
+        assert_eq!(meet(a, a), a);
+        // identities
+        assert_eq!(join(bottom(), a), a, "⊥ ⊔ a = a");
+        assert_eq!(meet(top(), a), a, "⊤ ⊓ a = a");
+        for b in ALL {
+            // commutativity
+            assert_eq!(join(a, b), join(b, a));
+            assert_eq!(meet(a, b), meet(b, a));
+            // absorption
+            assert_eq!(join(a, meet(a, b)), a);
+            assert_eq!(meet(a, join(a, b)), a);
+            // order ⟺ join/meet consistency
+            assert_eq!(leq(a, b), join(a, b) == b);
+            assert_eq!(leq(a, b), meet(a, b) == a);
+            for c in ALL {
+                // associativity
+                assert_eq!(join(join(a, b), c), join(a, join(b, c)));
+                assert_eq!(meet(meet(a, b), c), meet(a, meet(b, c)));
+            }
+        }
+    }
+}
+
+/// The soundness-critical property for taint over-approximation: a value
+/// derived from operands is at least as secret as each operand, and
+/// `high` is absorbing. This is exactly what guarantees the analyzer's
+/// forward propagation can only ADD taint — so a Low result is provably
+/// independent of every High source (REQ-001 / AC-007).
+#[test]
+fn join_is_an_upper_bound_and_high_is_absorbing() {
+    for a in ALL {
+        for b in ALL {
+            assert!(leq(a, join(a, b)), "a ⊑ a⊔b");
+            assert!(leq(b, join(a, b)), "b ⊑ a⊔b");
+        }
+        // High absorbs: once secret, always secret under join.
+        assert_eq!(join(Label::High, a), Label::High);
+    }
+}
+
+/// `leq` is a genuine partial order (reflexive, antisymmetric,
+/// transitive) — the property the analyzer relies on when comparing
+/// labels at structured-control merge points.
+#[test]
+fn leq_is_a_partial_order() {
+    for a in ALL {
+        assert!(leq(a, a), "reflexive");
+        for b in ALL {
+            if leq(a, b) && leq(b, a) {
+                assert_eq!(a, b, "antisymmetric");
+            }
+            for c in ALL {
+                if leq(a, b) && leq(b, c) {
+                    assert!(leq(a, c), "transitive");
+                }
+            }
+        }
+    }
+}

--- a/crates/scry-taint/BUILD.bazel
+++ b/crates/scry-taint/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+# scry-taint — the pure security-label lattice (low ⊑ high) for the
+# FEAT-009 taint / noninterference domain. Mirrors scry-provenance:
+# a dependency-free crate that cross-compiles to wasm32-wasip2 (where
+# wasm-lattice delegates its WIT `label-*` exports to it) AND native
+# (where scry-host-tests falsifies the lattice laws). The shipped
+# lattice code is therefore exactly the natively-falsified code.
+
+rust_library(
+    name = "scry_taint",
+    srcs = ["src/lib.rs"],
+    crate_name = "scry_taint",
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    tags = ["feat-009"],
+)
+
+rust_test(
+    name = "scry_taint_test",
+    crate = ":scry_taint",
+    edition = "2024",
+    tags = ["feat-009"],
+)

--- a/crates/scry-taint/Cargo.toml
+++ b/crates/scry-taint/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "scry-taint"
+description = "Pure security-label lattice (low ⊑ high) for scry's taint / noninterference domain (FEAT-009, AC-007)."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+# Pure library. Intentionally zero dependencies: the same source
+# compiles both into the wasm32-wasip2 wasm-lattice component
+# (#![no_std], where it backs the WIT `label-*` exports) and natively
+# into the scry-host-tests harness, so the lattice laws are
+# mechanically falsifiable on the native cargo path even while the live
+# component `analyze()` round-trip stays blocked by the wac-compose /
+# wasmtime-45 limitation. Mirrors scry-provenance.
+[lib]
+path = "src/lib.rs"
+
+[dependencies]

--- a/crates/scry-taint/src/lib.rs
+++ b/crates/scry-taint/src/lib.rs
@@ -1,0 +1,237 @@
+//! scry-taint — the pure security-label lattice for scry's taint /
+//! noninterference domain (FEAT-009, v0.8).
+//!
+//! This crate holds the *algebra* of the two-point confidentiality
+//! lattice `low ⊑ high` and nothing else: no Wasm parsing, no WIT
+//! bindings, no I/O. It is the taint analogue of [`scry-provenance`]:
+//! a pure, dependency-free crate that compiles to BOTH `wasm32-wasip2`
+//! (where `wasm-lattice` delegates its WIT `label-*` exports to it, so
+//! the *shipped* lattice code is exactly this code) AND natively (where
+//! `scry-host-tests` falsifies the lattice laws against it).
+//!
+//! The lattice is the classic information-flow ordering:
+//!
+//! ```text
+//!        high   (⊤ — secret; "may depend on a declared High source")
+//!         |
+//!        low    (⊥ — public; "provably carries no secret")
+//! ```
+//!
+//! Forward taint propagation uses [`join`]: a value derived from two
+//! operands is secret iff either operand was. [`meet`] is provided for
+//! lattice completeness and the reduced-product combinator. The lattice
+//! has height 1, so its algebra is *exhaustively* falsifiable — every
+//! law below is checked over all 2ⁿ input tuples in the unit tests.
+//!
+//! Soundness role (REQ-001, AC-007): `high` is the sound top. When the
+//! analyzer cannot prove a value is public it must label it `high`;
+//! `join` never moves *down* the lattice, so taint can only ever
+//! over-approximate the true secret-dependence — the property that
+//! makes "absence of a finding implies noninterference" sound.
+
+#![cfg_attr(not(test), no_std)]
+
+/// A confidentiality label from the two-point lattice `low ⊑ high`.
+///
+/// `Low` is the bottom element (provably public); `High` is the top
+/// element (the sound over-approximation for any value that may depend
+/// on a declared secret source).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Label {
+    /// Bottom (⊥): provably public.
+    Low,
+    /// Top (⊤): may carry secret data.
+    High,
+}
+
+/// The bottom element of the lattice (`Low`; ⊥).
+#[inline]
+pub const fn bottom() -> Label {
+    Label::Low
+}
+
+/// The top element of the lattice (`High`; ⊤).
+#[inline]
+pub const fn top() -> Label {
+    Label::High
+}
+
+/// `a ⊑ b` — the chain order `low ⊑ high`.
+///
+/// True for every pair except `high ⊑ low`. Equivalent to
+/// `join(a, b) == b` (checked exhaustively in the tests), the standard
+/// consistency law between a lattice's order and its join.
+#[inline]
+pub const fn leq(a: Label, b: Label) -> bool {
+    // The only non-related pair (the only place the chain fails) is
+    // a = High, b = Low.
+    !matches!((a, b), (Label::High, Label::Low))
+}
+
+/// `a ⊔ b` — least upper bound. `High` iff either operand is `High`.
+///
+/// This is the forward taint-propagation rule: the abstract value
+/// produced from two operands is secret iff either input was.
+#[inline]
+pub const fn join(a: Label, b: Label) -> Label {
+    match (a, b) {
+        (Label::Low, Label::Low) => Label::Low,
+        _ => Label::High,
+    }
+}
+
+/// `a ⊓ b` — greatest lower bound. `Low` iff either operand is `Low`.
+#[inline]
+pub const fn meet(a: Label, b: Label) -> Label {
+    match (a, b) {
+        (Label::High, Label::High) => Label::High,
+        _ => Label::Low,
+    }
+}
+
+/// `true` iff `x` is the bottom element (`Low`). Mirrors the
+/// `is-bottom` query the interval domain exposes, for symmetry.
+#[inline]
+pub const fn is_bottom(x: Label) -> bool {
+    matches!(x, Label::Low)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All elements of the (tiny) lattice — the basis for exhaustive
+    /// law checking.
+    const ALL: [Label; 2] = [Label::Low, Label::High];
+
+    #[test]
+    fn extrema_are_low_and_high() {
+        assert_eq!(bottom(), Label::Low);
+        assert_eq!(top(), Label::High);
+        assert!(is_bottom(bottom()));
+        assert!(!is_bottom(top()));
+    }
+
+    #[test]
+    fn join_truth_table() {
+        assert_eq!(join(Label::Low, Label::Low), Label::Low);
+        assert_eq!(join(Label::Low, Label::High), Label::High);
+        assert_eq!(join(Label::High, Label::Low), Label::High);
+        assert_eq!(join(Label::High, Label::High), Label::High);
+    }
+
+    #[test]
+    fn meet_truth_table() {
+        assert_eq!(meet(Label::Low, Label::Low), Label::Low);
+        assert_eq!(meet(Label::Low, Label::High), Label::Low);
+        assert_eq!(meet(Label::High, Label::Low), Label::Low);
+        assert_eq!(meet(Label::High, Label::High), Label::High);
+    }
+
+    #[test]
+    fn leq_truth_table() {
+        assert!(leq(Label::Low, Label::Low));
+        assert!(leq(Label::Low, Label::High));
+        assert!(!leq(Label::High, Label::Low)); // the only false case
+        assert!(leq(Label::High, Label::High));
+    }
+
+    // ── Lattice axioms, checked exhaustively over ALL × ALL(× ALL) ──
+
+    #[test]
+    fn join_and_meet_are_commutative() {
+        for a in ALL {
+            for b in ALL {
+                assert_eq!(join(a, b), join(b, a), "join commutativity {a:?} {b:?}");
+                assert_eq!(meet(a, b), meet(b, a), "meet commutativity {a:?} {b:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn join_and_meet_are_associative() {
+        for a in ALL {
+            for b in ALL {
+                for c in ALL {
+                    assert_eq!(join(join(a, b), c), join(a, join(b, c)));
+                    assert_eq!(meet(meet(a, b), c), meet(a, meet(b, c)));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn join_and_meet_are_idempotent() {
+        for a in ALL {
+            assert_eq!(join(a, a), a);
+            assert_eq!(meet(a, a), a);
+        }
+    }
+
+    #[test]
+    fn absorption_laws_hold() {
+        for a in ALL {
+            for b in ALL {
+                assert_eq!(join(a, meet(a, b)), a, "a ⊔ (a ⊓ b) = a");
+                assert_eq!(meet(a, join(a, b)), a, "a ⊓ (a ⊔ b) = a");
+            }
+        }
+    }
+
+    #[test]
+    fn bottom_and_top_are_identities() {
+        for a in ALL {
+            assert_eq!(join(bottom(), a), a, "⊥ ⊔ a = a");
+            assert_eq!(meet(top(), a), a, "⊤ ⊓ a = a");
+            assert_eq!(join(top(), a), top(), "⊤ ⊔ a = ⊤");
+            assert_eq!(meet(bottom(), a), bottom(), "⊥ ⊓ a = ⊥");
+        }
+    }
+
+    /// The defining consistency law between the order and the join:
+    /// `a ⊑ b  ⟺  a ⊔ b = b` (equivalently `a ⊓ b = a`). This is the
+    /// property the analyzer relies on when it compares labels at
+    /// fixpoint merge points.
+    #[test]
+    fn leq_is_consistent_with_join_and_meet() {
+        for a in ALL {
+            for b in ALL {
+                assert_eq!(leq(a, b), join(a, b) == b, "leq⟺join {a:?} {b:?}");
+                assert_eq!(leq(a, b), meet(a, b) == a, "leq⟺meet {a:?} {b:?}");
+            }
+        }
+    }
+
+    /// `leq` is a partial order: reflexive, antisymmetric, transitive.
+    #[test]
+    fn leq_is_a_partial_order() {
+        for a in ALL {
+            assert!(leq(a, a), "reflexive");
+        }
+        for a in ALL {
+            for b in ALL {
+                if leq(a, b) && leq(b, a) {
+                    assert_eq!(a, b, "antisymmetric");
+                }
+                for c in ALL {
+                    if leq(a, b) && leq(b, c) {
+                        assert!(leq(a, c), "transitive");
+                    }
+                }
+            }
+        }
+    }
+
+    /// Forward propagation never moves *down* the lattice — the
+    /// soundness-critical monotonicity that makes taint an
+    /// over-approximation: `a ⊑ join(a, b)` and `b ⊑ join(a, b)`.
+    #[test]
+    fn join_is_an_upper_bound() {
+        for a in ALL {
+            for b in ALL {
+                assert!(leq(a, join(a, b)));
+                assert!(leq(b, join(a, b)));
+            }
+        }
+    }
+}

--- a/crates/wasm-lattice/BUILD.bazel
+++ b/crates/wasm-lattice/BUILD.bazel
@@ -23,4 +23,11 @@ rust_wasm_component_bindgen(
     srcs = ["src/lib.rs"],
     profiles = ["release"],
     wit = ":wasm_lattice_wit",
+    # FEAT-009: the security-label (taint) lattice algebra lives in the
+    # pure first-party scry-taint crate (no external deps), cross-
+    # compiled to wasm32-wasip2; this component's WIT `label-*` exports
+    # delegate to it, so the shipped lattice code is exactly the code
+    # scry-host-tests falsifies natively. Mirrors scry-analyzer's dep on
+    # scry-provenance.
+    deps = ["//crates/scry-taint:scry_taint"],
 )

--- a/crates/wasm-lattice/Cargo.toml
+++ b/crates/wasm-lattice/Cargo.toml
@@ -15,3 +15,7 @@ bitflags = { workspace = true }
 
 # wit-bindgen is injected by rules_wasm_component's
 # rust_wasm_component_bindgen rule; not listed here.
+# FEAT-009: the wasm-lattice component delegates its WIT `label-*`
+# exports to this pure crate, so the shipped lattice code is exactly
+# the code scry-host-tests falsifies natively.
+scry-taint = { path = "../scry-taint" }

--- a/crates/wasm-lattice/src/lib.rs
+++ b/crates/wasm-lattice/src/lib.rs
@@ -9,10 +9,32 @@
 #![no_std]
 
 use wasm_lattice_component_bindings::exports::pulseengine::wasm_lattice::domain::{
-    Guest, Interval, Region,
+    Guest, Interval, Label, Region,
 };
 
 struct Component;
+
+// ── Security-label (taint) domain conversions (FEAT-009, v0.8) ──────
+//
+// The label lattice algebra lives in the pure `scry_taint` crate so the
+// code shipped in this wasm32-wasip2 component is *exactly* the code
+// scry-host-tests falsifies natively (the lattice-law tests). The only
+// logic local to this file is the trivial enum conversion between the
+// WIT-generated `Label` and `scry_taint::Label`.
+
+fn to_taint(l: Label) -> scry_taint::Label {
+    match l {
+        Label::Low => scry_taint::Label::Low,
+        Label::High => scry_taint::Label::High,
+    }
+}
+
+fn from_taint(l: scry_taint::Label) -> Label {
+    match l {
+        scry_taint::Label::Low => Label::Low,
+        scry_taint::Label::High => Label::High,
+    }
+}
 
 /// Bottom (empty) interval — the conventional encoding is { lo: 1, hi: 0 }.
 /// Any interval with `lo > hi` is considered bottom; the constructor
@@ -284,6 +306,32 @@ impl Guest for Component {
             region_id: a.region_id,
             offset: off,
         }
+    }
+
+    // ── Security-label (taint) domain (FEAT-009, v0.8) ─────────────
+    //
+    // Delegated to the pure `scry_taint` crate (see the conversion
+    // helpers above). The two-point lattice `low ⊑ high`: bottom =
+    // low, top = high, join = OR, meet = AND, leq = the chain order.
+
+    fn label_bottom() -> Label {
+        from_taint(scry_taint::bottom())
+    }
+
+    fn label_top() -> Label {
+        from_taint(scry_taint::top())
+    }
+
+    fn label_leq(a: Label, b: Label) -> bool {
+        scry_taint::leq(to_taint(a), to_taint(b))
+    }
+
+    fn label_join(a: Label, b: Label) -> Label {
+        from_taint(scry_taint::join(to_taint(a), to_taint(b)))
+    }
+
+    fn label_meet(a: Label, b: Label) -> Label {
+        from_taint(scry_taint::meet(to_taint(a), to_taint(b)))
     }
 }
 

--- a/crates/wasm-lattice/wit/wasm-lattice.wit
+++ b/crates/wasm-lattice/wit/wasm-lattice.wit
@@ -16,6 +16,12 @@
 // force scry.wit's `use` to track and ripple through composition.wac
 // (which we explicitly don't touch in this PR).
 //
+// v0.8 (FEAT-009) adds the security-label (taint) domain — a two-point
+// lattice `low ⊑ high` plus label-bottom/top/leq/join/meet — additive
+// over v0.3 in the same way. The analyzer lifts it pointwise over
+// values and the control-context to give termination-insensitive
+// noninterference (the Wanilla CCS 2025 technique, AC-007).
+//
 // Per DD-004, this is a separate component (not just a crate) so that
 // downstream tools (witness coverage-gap prediction, synth codegen
 // invariant generation) can depend on the lattice via WIT without
@@ -163,6 +169,56 @@ interface domain {
     /// region-ids differ). Required for fixpoint termination
     /// when region-tagged values flow into loop headers.
     region-widen: func(a: region, b: region) -> region;
+
+    // ── Security-label (taint) domain (FEAT-009, v0.8) ─────────────
+    //
+    // A two-point security lattice `low ⊑ high` (the classic
+    // confidentiality ordering: `high` is secret, `low` is public).
+    // The analyzer lifts this label pointwise over operand-stack and
+    // local abstract values (a "shadow" taint state threaded
+    // alongside the interval/region value) AND over the control-
+    // context (program-counter) label, so it tracks both explicit
+    // data flows and the implicit flows that make the result a
+    // termination-insensitive *noninterference* analysis (the Wanilla
+    // CCS 2025 technique, AC-007) rather than mere explicit-flow
+    // taint. The label domain composes WITH the interval and region
+    // domains; it does not replace them.
+    //
+    // The lattice is intentionally minimal (height 1) so its algebra
+    // is mechanically falsifiable in full: bottom = low, top = high,
+    // join = logical OR, meet = logical AND, and `leq` is the chain
+    // order low ⊑ low ⊑ high ⊑ high. Multi-principal / lattice-of-
+    // sets labels are a later FEAT-009 slice.
+
+    /// A confidentiality label drawn from the two-point lattice
+    /// `low ⊑ high`. `high` over-approximates "may depend on a
+    /// declared secret source"; `low` means "provably public".
+    enum label {
+        low,
+        high,
+    }
+
+    /// The bottom element of the label lattice (`low`; ⊥). A value
+    /// with no secret dependence carries this label.
+    label-bottom: func() -> label;
+
+    /// The top element of the label lattice (`high`; ⊤). The sound
+    /// over-approximation for any value that may carry secret data.
+    label-top: func() -> label;
+
+    /// `a ⊑ b` on labels — the chain order `low ⊑ high`. True unless
+    /// `a` is `high` and `b` is `low`.
+    label-leq: func(a: label, b: label) -> bool;
+
+    /// `a ⊔ b` — least upper bound (`high` iff either operand is
+    /// `high`). This is the propagation rule for a value derived from
+    /// two operands: the result is secret if either input was.
+    label-join: func(a: label, b: label) -> label;
+
+    /// `a ⊓ b` — greatest lower bound (`low` iff either operand is
+    /// `low`). Provided for lattice completeness / the reduced-product
+    /// combinator; the forward taint propagation uses `label-join`.
+    label-meet: func(a: label, b: label) -> label;
 }
 
 world wasm-lattice {

--- a/docs/invariant-schema-v1.md
+++ b/docs/invariant-schema-v1.md
@@ -212,3 +212,28 @@ wasmtime 45 rejects (see the module-level doc in
 plus its mechanical validation against a representative value; wiring a live
 component round-trip is gated on the compose-toolchain fix. The loom-side
 consumption of this contract is tracked as a separate cross-repo issue.
+
+## v0.8 addition — taint-findings (FEAT-009)
+
+v0.8 adds one additive, optional top-level property, `taint-findings`
+(WIT `analysis-result.taint-findings: list<taint-finding>`), plus the
+`taint-finding`, `taint-finding-kind`, and `security-label` `$defs`. It
+is the serialized form of the noninterference findings the taint domain
+([[FEAT-009]], AC-007) emits when an `analysis-config.taint-policy` is
+supplied. Each entry maps to one declared Low sink that carries the High
+label:
+
+| JSON field | WIT field | Meaning |
+|---|---|---|
+| `func-index` | `taint-finding.func-index` | Function whose result violates the policy |
+| `pc` | `taint-finding.pc` | Program-counter of the violating site (the function `end`) |
+| `kind` | `taint-finding.kind` | `high-result-explicit` or `high-result-implicit` (data vs control-context flow) |
+| `source-label` | `taint-finding.source-label` | `security-label` of the offending value (`high`) |
+| `sink-label` | `taint-finding.sink-label` | declared `security-label` of the sink (`low`) |
+| `message` | `taint-finding.message` | Human-readable description |
+
+`taint-findings` is **not** in the schema's `required` set, so a v0.7
+document with no taint findings still validates — the property is
+backward-compatible. The shape is pinned by
+`crates/scry-host-tests/tests/contract.rs`
+(`taint_findings_optional_and_tight`).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@
 | Version | Status | Capability |
 |---|---|---|
 | pre-v0.1 | shipped 2026-05-26 | research + requirements + design + safety-case as 56 rivet artifacts; `research-ext` local schema; PASS validate; README + this roadmap |
-| v0.1 → v0.7 | shipped 2026-05-27 … 2026-05-29 | the capability ladder below, built in dependency order: interval fixpoint (v0.1/v0.2) → Verus+Rocq proof toolchain (v0.2) → region memory + host-oracle harness (v0.3) → sound `call_indirect` call graph (v0.4) → compositional interprocedural summaries (v0.5) → loom invariant JSON contract (v0.6) → `component-provenance` typed meld↔scry boundary + invariant projection (v0.7, FEAT-002 provenance slice). See `CHANGELOG.md` for the per-release falsification kill-criteria. |
+| v0.1 → v0.8 | shipped 2026-05-27 … 2026-05-29 | the capability ladder below, built in dependency order: interval fixpoint (v0.1/v0.2) → Verus+Rocq proof toolchain (v0.2) → region memory + host-oracle harness (v0.3) → sound `call_indirect` call graph (v0.4) → compositional interprocedural summaries (v0.5) → loom invariant JSON contract (v0.6) → `component-provenance` typed meld↔scry boundary + invariant projection (v0.7, FEAT-002 provenance slice) → taint / termination-insensitive-noninterference domain (v0.8, FEAT-009: `low ⊑ high` label lattice + explicit & implicit-flow propagation + High→Low findings). See `CHANGELOG.md` for the per-release falsification kill-criteria. |
 
 ## Forward path
 

--- a/docs/taint-noninterference-v1.md
+++ b/docs/taint-noninterference-v1.md
@@ -1,0 +1,124 @@
+---
+id: DOC-TAINT-NONINTERFERENCE-V1
+type: spec
+status: draft
+title: scry taint / noninterference domain (v0.8)
+tags: [security, taint, noninterference, domain, v0.8]
+references: [FEAT-009, AC-007, REQ-001, FEAT-003, DD-008]
+---
+
+# scry taint / noninterference domain (v0.8)
+
+This document specifies scry's security-label (taint) domain, the v0.8
+deliverable of [[FEAT-009]] (the Wanilla-class noninterference analysis,
+[[AC-007]]). The domain composes *with* the interval and region domains —
+it does not replace them.
+
+## The lattice
+
+A two-point confidentiality lattice, the classic information-flow order:
+
+```text
+       high   (⊤ — secret; "may depend on a declared High source")
+        |
+       low    (⊥ — public; "provably carries no secret")
+```
+
+- `join` (⊔) = logical OR — the forward-taint rule: a value derived from
+  two operands is secret iff either operand was.
+- `meet` (⊓) = logical AND.
+- `leq` (⊑) = the chain `low ⊑ high` (false only for `high ⊑ low`).
+
+The algebra lives in the pure, dependency-free `crates/scry-taint` crate.
+Because the lattice has height 1, every algebraic law is checked
+**exhaustively** over its 2ⁿ input tuples. The `wasm-lattice` Wasm
+component's WIT `label-*` exports (`label-bottom`/`label-top`/`label-leq`/
+`label-join`/`label-meet`) delegate to that crate, so the shipped lattice
+code is exactly the natively-falsified code ([[DD-008]] dogfood; the
+reusable-domain story of [[FEAT-003]]).
+
+## Policy: sources and sinks
+
+The analysis is opt-in via `analysis-config.taint-policy`:
+
+| Field | Meaning |
+|---|---|
+| `high-params` | parameter indices treated as **High** sources, applied at each analyzed function's entry |
+| `low-results` | result indices required to remain **Low** at function exit |
+
+An empty policy taints nothing and reports nothing — behaviour is exactly
+as in v0.7.
+
+## Propagation
+
+A dedicated shadow-taint walk runs per function: a `security-label` per
+operand-stack slot and per local, threaded alongside the interval/region
+abstract value, plus a **control-context label** (`ctx`).
+
+- **Explicit flows.** Constants push `low`; `local.get` pushes the local's
+  label; arithmetic / bitwise / comparison / conversion operators push the
+  join of their operands; `local.set` / `local.tee` store `join(value,
+  ctx)`.
+- **Implicit flows.** Unlike the interval pass (which scrubs to top on all
+  control flow), the taint walk interprets *empty-typed* structured
+  `if` / `else` / `block` / `end`: at an `if` the condition's label raises
+  `ctx` for the dominated region, so an assignment inside a secret-guarded
+  branch becomes High even when the assigned value is a constant. This is
+  what makes the result a sound **termination-insensitive noninterference**
+  analysis rather than mere explicit-flow taint.
+- **Conservative fallback.** Any unmodelled operator — `loop` (needs a
+  taint fixpoint), `br*`, value-typed blocks, `call*`, memory and global
+  ops — raises the whole taint state to High (the sound top) and stops
+  precise tracking. Raising can only *add* taint, so a flow is never
+  missed.
+
+## Findings
+
+At function exit the result labels are the top of the value stack. For
+each `low-results` index whose label is High, scry emits a `taint-finding`
+(`func-index`, `pc`, `kind`, `source-label`, `sink-label`, `message`) and
+a `Warning` diagnostic. `kind` distinguishes `high-result-explicit` from
+`high-result-implicit`. Findings are surfaced on the additive
+`analysis-result.taint-findings` field and the matching `taint-findings`
+block of the v1 invariant contract (see `docs/invariant-schema-v1.md`).
+
+## scry ⇄ taint data flow
+
+```mermaid
+flowchart LR
+  subgraph cfg[analysis-config]
+    P[taint-policy: high-params / low-results]
+  end
+  M[Wasm module] --> A[scry analyzer]
+  P --> A
+  A -->|"per fn: shadow taint walk\nlabel-join via WIT boundary"| W[wasm-lattice label domain]
+  W --> A
+  A -->|"Low result carries High"| F[taint-findings + diagnostics]
+```
+
+## Soundness and the falsifiable kill-criterion
+
+Soundness ([[REQ-001]], [[AC-007]]): `high` is the sound top, `join`
+never moves down the lattice, and every unmodelled construct raises to
+High — so forward propagation can only *over*-approximate secret
+dependence. Therefore a result proven `low` is independent of every
+declared High source, and **the absence of a finding implies
+noninterference** (under termination-insensitive assumptions). False
+alarms are possible; missed real flows are not.
+
+Kill-criterion: the label lattice obeys its algebraic laws **and** `join`
+is an upper bound with `high` absorbing. Falsified exhaustively in
+`crates/scry-taint` (12 tests) and `crates/scry-host-tests/tests/taint.rs`
+(6 tests); the `taint-finding` contract shape is pinned in
+`crates/scry-host-tests/tests/contract.rs`.
+
+## Deferred (a later FEAT-009 slice)
+
+Tainted store/load tracking through linear memory (memory as a sink),
+multi-principal / lattice-of-sets labels, value-sensitive declassification,
+unstructured-control implicit flows (`loop` taint fixpoint, `br_table`
+post-dominator analysis), and the Wanilla shared-benchmark differential
+corpus (FEAT-009 AC#2). As with [[FEAT-008]], the live `analyze()`
+round-trip stays gated by the wac_compose / wasmtime-45 root-import
+limitation, so the lattice and finding shapes are falsified natively
+rather than via a live component call.

--- a/spar/scry.aadl
+++ b/spar/scry.aadl
@@ -150,6 +150,49 @@ public
       Data_Size => 16 MByte;  -- list of (fused-idx, component-id, orig-idx) entries
   end ComponentProvenance;
 
+  data SecurityLabel
+    -- v0.8 (FEAT-009 / AC-007): a two-point security label from the
+    -- lattice low ⊑ high, exported by the LatticeProcess as part of
+    -- the taint/noninterference domain (label-bottom = low,
+    -- label-top = high, plus label-leq / label-join / label-meet).
+    -- The AnalyzerProcess lifts this label pointwise over operand-
+    -- stack and local values (a "shadow" taint state threaded
+    -- alongside the interval/region abstract value) and over the
+    -- control-context (program-counter) label, giving the implicit-
+    -- flow tracking that makes the result termination-insensitive
+    -- noninterference rather than mere explicit-flow taint. The
+    -- label composes WITH the interval and region domains rather
+    -- than replacing them.
+    properties
+      Data_Size => 1 Bytes;  -- a single low/high enum tag
+  end SecurityLabel;
+
+  data TaintPolicy
+    -- v0.8 (FEAT-009): the declared information-flow policy carried
+    -- into an analyze request — which function parameters are High
+    -- sources and which function results are Low sinks. Sourced from
+    -- the AnalysisConfig (additive config field). The AnalyzerProcess
+    -- seeds each analyzed function's parameter labels from the policy
+    -- and, at function exit, reports a noninterference violation when
+    -- a result slot declared Low carries the High label.
+    properties
+      Data_Size => 4 KByte;  -- lists of high-param / low-result indices
+  end TaintPolicy;
+
+  data TaintFindings
+    -- v0.8 (FEAT-009): the set of noninterference findings the
+    -- AnalyzerProcess emits — one TaintFinding per High→Low flow
+    -- reaching a declared Low sink (with the originating func index,
+    -- program-counter offset, and the source/sink labels). Emitted
+    -- alongside the InvariantBundle. Soundness (REQ-001, AC-007):
+    -- every concrete High→Low flow under termination-insensitive
+    -- assumptions is covered — the absence of a finding implies
+    -- noninterference; false alarms are possible, missed real flows
+    -- are not.
+    properties
+      Data_Size => 4 MByte;  -- list of TaintFinding records
+  end TaintFindings;
+
   -- ══════════════════════════════════════════════════════════════════
   -- Threads — one per component's primary worker
   -- ══════════════════════════════════════════════════════════════════
@@ -194,6 +237,11 @@ public
       -- when the analyzed fused module carried a `component-provenance`
       -- custom section.
       provenance_out:  out event data port ComponentProvenance;
+      -- v0.8 (FEAT-009): the declared information-flow policy (High
+      -- sources / Low sinks) carried in, and the noninterference
+      -- findings emitted out.
+      taint_policy_in:    in event data port TaintPolicy;
+      taintfindings_out:  out event data port TaintFindings;
       -- Connection to LatticeOps. Modelled as a port pair; in the
       -- Component Model this is a WIT cross-component import.
       lattice_call_out: out event data port;
@@ -238,6 +286,8 @@ public
       callgraph_out:   out event data port CallGraph;
       summaries_out:   out event data port FunctionSummaries;
       provenance_out:  out event data port ComponentProvenance;
+      taint_policy_in:    in event data port TaintPolicy;
+      taintfindings_out:  out event data port TaintFindings;
       lattice_call_out: out event data port;
       lattice_result_in: in event data port Interval;
   end AnalyzerProcess;
@@ -253,6 +303,8 @@ public
       c_callgraph:     port analyzer_thread.callgraph_out -> callgraph_out;
       c_summaries:     port analyzer_thread.summaries_out -> summaries_out;
       c_provenance:    port analyzer_thread.provenance_out -> provenance_out;
+      c_taint_policy:  port taint_policy_in -> analyzer_thread.taint_policy_in;
+      c_taintfindings: port analyzer_thread.taintfindings_out -> taintfindings_out;
       c_lattice_call:  port analyzer_thread.lattice_call_out -> lattice_call_out;
       c_lattice_result: port lattice_result_in -> analyzer_thread.lattice_result_in;
   end AnalyzerProcess.IntervalV01;
@@ -270,6 +322,8 @@ public
       callgraph_out:   out event data port CallGraph;
       summaries_out:   out event data port FunctionSummaries;
       provenance_out:  out event data port ComponentProvenance;
+      taint_policy_in:    in event data port TaintPolicy;
+      taintfindings_out:  out event data port TaintFindings;
   end Scry;
 
   system implementation Scry.V01
@@ -289,6 +343,8 @@ public
       s_callgraph:     port analyzer.callgraph_out -> callgraph_out;
       s_summaries:     port analyzer.summaries_out -> summaries_out;
       s_provenance:    port analyzer.provenance_out -> provenance_out;
+      s_taint_policy:  port taint_policy_in -> analyzer.taint_policy_in;
+      s_taintfindings: port analyzer.taintfindings_out -> taintfindings_out;
       -- Internal cross-component wiring (analyzer → lattice)
       s_lattice_call:  port analyzer.lattice_call_out -> lattice.op_in;
       s_lattice_result: port lattice.op_out -> analyzer.lattice_result_in;


### PR DESCRIPTION
## v0.8.0 — FEAT-009 taint / noninterference domain (Wanilla-class, AC-007)

Adds scry's security-label (taint) domain: a two-point lattice `low ⊑ high`
lifted pointwise over values and the control-context, giving a sound
**termination-insensitive noninterference** analysis that composes with
(does not replace) the interval and region domains.

### What's in it
- **`crates/scry-taint`** — new pure, zero-dependency crate holding the
  label-lattice algebra. Compiles to `wasm32-wasip2` (where `wasm-lattice`'s
  WIT `label-*` exports delegate to it, so shipped == falsified code) and
  natively. 12 exhaustive law tests.
- **`wasm-lattice`** — `label` + `label-bottom/top/leq/join/meet` on the
  `pulseengine:wasm-lattice/domain` interface, dogfooded over WIT (DD-008).
- **`scry-analyzer`** — opt-in taint pass via `analysis-config.taint-policy`
  (`high-params` sources / `low-results` sinks). A shadow-taint walk
  propagates labels through the operand stack + locals and interprets
  structured `if`/`else`/`block`/`end` to raise a control-context label,
  capturing **implicit flows**; any unmodelled op conservatively raises to
  High (sound). Emits a `taint-finding` per Low-declared result carrying
  High at exit, on the new additive `analysis-result.taint-findings`.
  `SCRY_VERSION` → 0.8.0.
- **Contract** — additive `taint-findings` + `taint-finding`/`-kind` +
  `security-label` `$defs` in `scry-invariants-v1` (backward-compatible).
- **spar/rivet/docs** — `SecurityLabel`/`TaintPolicy`/`TaintFindings` AADL
  data + ports; FEAT-009 `proposed`→`draft` with the narrow v0.8 scope;
  `docs/taint-noninterference-v1.md`; invariant-schema + roadmap updated.
- **CI** — clippy + test gates for `scry-taint`.

### Falsifiable kill-criterion
The label lattice obeys its algebraic laws AND forward propagation never
moves *down* the lattice (`join` is an upper bound; `high` is absorbing) —
so a Low result is provably independent of every High source and "absence
of a finding implies noninterference" is sound. Checked exhaustively in
`crates/scry-taint` and `crates/scry-host-tests/tests/taint.rs`; the
`taint-finding` contract shape is pinned in `tests/contract.rs`.

### Deferred (later FEAT-009 slice)
Tainted memory store/load (memory as a sink), multi-principal labels,
declassification, unstructured-control implicit flows (`loop` taint
fixpoint, `br_table`), and the Wanilla shared-benchmark corpus (AC#2).

### Verified locally
`bazel build //:scry` green + `wasm-tools validate`; scry-taint 12 /
scry-provenance 9 / host-tests contract 6 + taint 6 + provenance 6;
clippy `-D warnings` clean; `cargo fmt` clean; rivet PASS (0 warnings);
`spar parse` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
