### PR TITLE
fix(release): exclude wasm cdylib crates from default-members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,25 @@ members = [
     "crates/scry-analyze-core",
     "crates/scry-host-tests",
 ]
+# `wasm-lattice` and `scry-analyzer` are the Wasm-component crates
+# (`crate-type = ["cdylib"]`, `#![no_std]`; `scry-analyzer` additionally
+# `export!`s the rules_wasm_component-generated
+# `scry_analyzer_component_bindings`, which only exist under the Bazel wasm
+# build — see DD-009). Neither can be compiled by a native host `cargo build`
+# (no panic handler / unresolved bindings crate). They stay in `members` so
+# Bazel's crate_universe.from_cargo still resolves their deps, but are excluded
+# from `default-members`, so a bare `cargo build` — e.g. the one the witness
+# compliance release action runs at the workspace root — skips them instead of
+# failing. The remaining crates are plain rlibs that build natively. Native CI
+# jobs already build specific crates with explicit `-p`/`--package`.
+default-members = [
+    "crates/scry-provenance",
+    "crates/scry-taint",
+    "crates/scry-octagon",
+    "crates/scry-interval",
+    "crates/scry-analyze-core",
+    "crates/scry-host-tests",
+]
 
 [workspace.package]
 version = "0.1.0"


### PR DESCRIPTION
## Summary

The v1.6.0 release run's **MC/DC evidence bundle** job (added in #38) failed. The core *Build, sign, and release* job succeeded — v1.6.0's signed `wasm32-wasip2` component + SBOMs published fine — but the supplementary MC/DC evidence bundle was lost.

**Root cause:** the witness `compliance@v0.30.0` action runs a bare `cargo build --release` at the workspace root. With no `-p` filter that builds *all* workspace members, including the two Wasm-component crates that **cannot** compile on the host:
- `scry-analyzer` — `export!`s `scry_analyzer_component_bindings`, a crate generated only by the Bazel `rules_wasm_component` build (DD-009) → `E0433 unresolved module`.
- `wasm-lattice` — `#![no_std]` `cdylib` → `#[panic_handler] required` / `unwinding panics not supported without std` on the host target.

## Fix

Keep both `cdylib` crates in `members` (Bazel's `crate_universe.from_cargo` must still resolve their deps) but add a `default-members` list of the six host-buildable rlib crates, so a bare `cargo build` skips the wasm-only crates.

- Native CI jobs already use explicit `--package`, so they are unaffected.
- `Cargo.lock` and the Bazel build are unchanged (`crate_universe` resolves over `members`, not `default-members`).
- The `//:scry` genrule still builds `scry-analyzer` via `rules_wasm_component`.

## Verification

- `cargo build --release` at the root now succeeds (builds the 6 rlibs, skips the 2 cdylibs).
- `cargo metadata` still lists all 8 workspace members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)