### PR TITLE
refactor(crates): rename Wasm-component crates into the scry-sai-* namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,17 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
   trick — so `use scry_interval` and the Bazel target paths are unchanged.
   Internal path deps now carry `version` so `cargo publish` rewrites them to the
   crates.io coordinate.
-- **Wasm-component crates** (`wasm-lattice`, `scry-analyzer`) are being migrated
-  to the `scry-sai-*` namespace + self-contained `wit_bindgen::generate!`
-  bindings so they build and publish under plain `cargo` as well as Bazel — in a
-  follow-up PR (it touches the `//:scry` composition and needs full CI
-  re-validation). Until then they remain `publish = false` and ship as signed
-  `.wasm` release assets. The `scry-host-tests` and `scry-mcdc` harnesses remain
-  unpublished.
+- **Wasm-component crates renamed** into the namespace: `wasm-lattice` →
+  `scry-sai-lattice`, `scry-analyzer` → `scry-sai-analyzer` (`[package] name`
+  only — `[lib] name`, directories, and Bazel targets unchanged). They remain
+  `publish = false` and ship as signed `.wasm` release assets: they are `cdylib`
+  Wasm components built from Bazel-generated WIT bindings, so a host
+  `cargo publish` cannot build them and a `cargo add` consumer cannot use a
+  cdylib component (the witness precedent — publish the libraries, ship the
+  component). Making them genuine crates.io libraries would require a
+  `wit_bindgen::generate!` binding refactor that touches the shipped `//:scry`
+  composition for no consumer benefit; deferred. The `scry-host-tests` and
+  `scry-mcdc` harnesses remain unpublished.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,13 +1824,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scry-analyzer"
-version = "1.9.0"
-dependencies = [
- "scry-sai-core",
-]
-
-[[package]]
 name = "scry-host-tests"
 version = "1.9.0"
 dependencies = [
@@ -1845,6 +1838,13 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wat",
+]
+
+[[package]]
+name = "scry-sai-analyzer"
+version = "1.9.0"
+dependencies = [
+ "scry-sai-core",
 ]
 
 [[package]]
@@ -1863,6 +1863,15 @@ dependencies = [
 [[package]]
 name = "scry-sai-interval"
 version = "1.9.0"
+
+[[package]]
+name = "scry-sai-lattice"
+version = "1.9.0"
+dependencies = [
+ "bitflags",
+ "scry-sai-octagon",
+ "scry-sai-taint",
+]
 
 [[package]]
 name = "scry-sai-octagon"
@@ -2475,15 +2484,6 @@ checksum = "2271adb766023046af314460f1fae02cc34ea16d736d93404d3b65be44270923"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.250.0",
-]
-
-[[package]]
-name = "wasm-lattice"
-version = "1.9.0"
-dependencies = [
- "bitflags",
- "scry-sai-octagon",
- "scry-sai-taint",
 ]
 
 [[package]]

--- a/crates/scry-analyzer/Cargo.toml
+++ b/crates/scry-analyzer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "scry-analyzer"
+name = "scry-sai-analyzer"
 description = "scry interval-domain abstract interpreter as a Wasm component."
 version.workspace = true
 edition.workspace = true
@@ -15,6 +15,7 @@ authors.workspace = true
 publish = false
 
 [lib]
+name = "scry_analyzer"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/crates/wasm-lattice/Cargo.toml
+++ b/crates/wasm-lattice/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wasm-lattice"
+name = "scry-sai-lattice"
 description = "Interval-domain abstract-domain library as a Wasm component."
 version.workspace = true
 edition.workspace = true
@@ -16,6 +16,7 @@ authors.workspace = true
 publish = false
 
 [lib]
+name = "wasm_lattice"
 crate-type = ["cdylib"]
 
 [dependencies]


### PR DESCRIPTION
## Summary

Completes the **`scry-sai-*`** namespace across the whole workspace (part 2 of 2): `wasm-lattice → scry-sai-lattice`, `scry-analyzer → scry-sai-analyzer`. Same witness DEC-034 trick — rename only the Cargo `[package] name`; keep `[lib] name` (`wasm_lattice` / `scry_analyzer`), the directories, and the Bazel targets unchanged, so **`//:scry` builds exactly as before**. Nothing depends on these two as cargo deps, so the rename is fully isolated.

## Publishing status (unchanged)
These stay `publish = false` and continue shipping as **signed `.wasm` release assets**. They are `cdylib` Wasm components built from Bazel-generated WIT bindings → a host `cargo publish` can't build them, and a `cargo add scry-sai-analyzer` consumer can't use a cdylib component. This matches the **witness precedent** (publish the libraries, ship the component).

**Deliberately deferred:** making them genuine crates.io libraries would require a `wit_bindgen::generate!` binding refactor that swaps the `rust_wasm_component_bindgen` rule on the path that builds the *shipped* `//:scry` — high risk (CI-only validation), for **no consumer benefit**. Flagged for an explicit decision rather than done speculatively.

## Result: full namespace
| crates.io package | publishes? |
|---|---|
| `scry-sai-interval`, `scry-sai-taint`, `scry-sai-octagon`, `scry-sai-provenance`, `scry-sai-core` | ✅ yes (libraries) |
| `scry-sai-lattice`, `scry-sai-analyzer` | ships as `.wasm` (`publish = false`) |
| `scry-host-tests`, `scry-mcdc` | internal harnesses (unpublished) |

## Verification
- bare `cargo build --release`, pure-crate tests (5+24), `rivet validate` clean.
- Bazel `//:scry` unaffected (target names unchanged) — confirmed by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)