### PR TITLE
FEAT-021 slice-2a: surface shadow-stack bound in WIT + component host oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added — FEAT-021 slice-2a (shadow-stack bound surfaced in WIT)
+
+- **`stack-usage` is now part of the analyzer's WIT result** (`scry.wit`): a
+  `stack-bound` variant (`bytes(u64)` / `unbounded` / `unknown`), a
+  `function-stack` record (per-function frame + subtree max), and a
+  `stack-usage` record (`sp-global`, `functions`, `max-stack-bytes`) added to
+  `analysis-result`. The component wrapper converts the core `StackUsage` to
+  the WIT shape. Additive (no existing field changed); the dynamic-`Val` host
+  decoders match fields by name, so prior consumers are unaffected.
+- **Host oracle through the composed component** (`scry-host-tests`):
+  `fixture_12_stack_bound_via_component` analyzes the chain fixture via the
+  *shipped* `//:scry` component and asserts `max-stack-bytes = bytes(56)`;
+  `fixture-13` → `unbounded`, `fixture-14` → `unknown`. This proves the bound
+  flows end-to-end through the real artifact, not just the native crate.
+  (slice-2b adds the runtime `__stack_pointer`-peak measurement + the
+  `peak ≤ bound` cross-assertion — the kill-criterion fully live.)
+
 ## [1.10.0] — 2026-06-17
 
 Headline: **worst-case shadow-stack bound — the AbsInt StackAnalyzer analogue

--- a/crates/scry-analyzer/src/lib.rs
+++ b/crates/scry-analyzer/src/lib.rs
@@ -75,6 +75,34 @@ fn taint_policy_to_core(p: wit::TaintPolicy) -> ac::TaintPolicy {
 
 // ───────────────────────── core → WIT (outputs) ────────────────────────
 
+fn stack_bound_to_wit(b: ac::StackBound) -> wit::StackBound {
+    match b {
+        ac::StackBound::Bytes(n) => wit::StackBound::Bytes(n),
+        ac::StackBound::Unbounded => wit::StackBound::Unbounded,
+        ac::StackBound::Unknown => wit::StackBound::Unknown,
+    }
+}
+
+fn function_stack_to_wit(f: ac::FunctionStack) -> wit::FunctionStack {
+    wit::FunctionStack {
+        func_index: f.func_index,
+        frame: stack_bound_to_wit(f.frame),
+        max_stack: stack_bound_to_wit(f.max_stack),
+    }
+}
+
+fn stack_usage_to_wit(s: ac::StackUsage) -> wit::StackUsage {
+    wit::StackUsage {
+        sp_global: s.sp_global,
+        functions: s
+            .functions
+            .into_iter()
+            .map(function_stack_to_wit)
+            .collect(),
+        max_stack_bytes: stack_bound_to_wit(s.max_stack_bytes),
+    }
+}
+
 fn result_to_wit(r: ac::AnalysisResult) -> wit::AnalysisResult {
     wit::AnalysisResult {
         invariants: bundle_to_wit(r.invariants),
@@ -91,6 +119,7 @@ fn result_to_wit(r: ac::AnalysisResult) -> wit::AnalysisResult {
             .into_iter()
             .map(taint_finding_to_wit)
             .collect(),
+        stack_usage: stack_usage_to_wit(r.stack_usage),
     }
 }
 

--- a/crates/scry-analyzer/src/lib.rs
+++ b/crates/scry-analyzer/src/lib.rs
@@ -94,11 +94,7 @@ fn function_stack_to_wit(f: ac::FunctionStack) -> wit::FunctionStack {
 fn stack_usage_to_wit(s: ac::StackUsage) -> wit::StackUsage {
     wit::StackUsage {
         sp_global: s.sp_global,
-        functions: s
-            .functions
-            .into_iter()
-            .map(function_stack_to_wit)
-            .collect(),
+        functions: s.functions.into_iter().map(function_stack_to_wit).collect(),
         max_stack_bytes: stack_bound_to_wit(s.max_stack_bytes),
     }
 }

--- a/crates/scry-analyzer/wit/scry.wit
+++ b/crates/scry-analyzer/wit/scry.wit
@@ -341,6 +341,37 @@ interface analyzer {
         message: string,
     }
 
+    /// A worst-case shadow-stack bound (FEAT-021). `bytes` is a sound finite
+    /// over-approximation; `unbounded` marks a recursion SCC; `unknown` marks
+    /// an unrecognised / dynamic frame. Both `unbounded` and `unknown` mean
+    /// "no finite bound proven" — never treated as zero.
+    variant stack-bound {
+        bytes(u64),
+        unbounded,
+        unknown,
+    }
+
+    /// Per-function shadow-stack facts (FEAT-021): the function's own frame
+    /// and its whole-subtree worst case (this frame plus the deepest reachable
+    /// callee chain).
+    record function-stack {
+        func-index: u32,
+        frame: stack-bound,
+        max-stack: stack-bound,
+    }
+
+    /// Worst-case shadow-stack usage of the module (FEAT-021): the deepest
+    /// weighted path through the call graph, each function weighted by the
+    /// frame its prologue subtracts from the `__stack_pointer` global. Guest
+    /// shadow-stack only (host/WASI frames are out of scope).
+    record stack-usage {
+        /// The identified `__stack_pointer` global, or absent if the module
+        /// has no shadow stack / it could not be identified.
+        sp-global: option<u32>,
+        functions: list<function-stack>,
+        max-stack-bytes: stack-bound,
+    }
+
     record analysis-result {
         invariants: invariant-bundle,
         diagnostics: list<diagnostic>,
@@ -359,6 +390,9 @@ interface analyzer {
         /// sink that carries the High label. Empty when no
         /// `taint-policy` was configured or no violation was found.
         taint-findings: list<taint-finding>,
+        /// Worst-case shadow-stack bound (FEAT-021): per-function frames and
+        /// the module's `max-stack-bytes`.
+        stack-usage: stack-usage,
     }
 
     /// Reasons an analyze call can fail without producing a partial

--- a/crates/scry-host-tests/tests/soundness.rs
+++ b/crates/scry-host-tests/tests/soundness.rs
@@ -265,6 +265,14 @@ struct InvariantBundle {
 /// invariant bundle. Bails (with anyhow context) on any failure at
 /// any stage — instantiate, link, call, or `analyze-error` return.
 fn run_analyzer(component_bytes_path: &Path, module_bytes: &[u8]) -> Result<InvariantBundle> {
+    parse_analysis_result(invoke_analyze(component_bytes_path, module_bytes)?)
+}
+
+/// Invoke the composed component's `analyze` and return the raw
+/// `result<analysis-result, analyze-error>` `Val` for the caller to decode
+/// (the invariant bundle via [`parse_analysis_result`], or the FEAT-021
+/// shadow-stack bound via [`analyze_stack_usage`]).
+fn invoke_analyze(component_bytes_path: &Path, module_bytes: &[u8]) -> Result<Val> {
     let engine = component_engine()?;
     let component = Component::from_file(&engine, component_bytes_path)
         .anyhow()
@@ -399,7 +407,54 @@ fn run_analyzer(component_bytes_path: &Path, module_bytes: &[u8]) -> Result<Inva
         .next()
         .ok_or_else(|| anyhow!("analyze() returned no results"))?;
 
-    parse_analysis_result(ret)
+    Ok(ret)
+}
+
+/// FEAT-021: decode `analysis-result.stack-usage.max-stack-bytes` from the raw
+/// analyze result `Val` into a small view. Mirrors `parse_analysis_result`'s
+/// navigation, then reads the `stack-bound` variant.
+#[derive(Debug, PartialEq, Eq)]
+enum StackBoundView {
+    Bytes(u64),
+    Unbounded,
+    Unknown,
+}
+
+fn parse_stack_bound(v: Val) -> Result<StackBoundView> {
+    match v {
+        Val::Variant(case, payload) => match (case.as_str(), payload) {
+            ("bytes", Some(p)) => match *p {
+                Val::U64(n) => Ok(StackBoundView::Bytes(n)),
+                other => bail!("stack-bound bytes payload not u64: {other:?}"),
+            },
+            ("unbounded", _) => Ok(StackBoundView::Unbounded),
+            ("unknown", _) => Ok(StackBoundView::Unknown),
+            (other, _) => bail!("unexpected stack-bound case: {other}"),
+        },
+        other => bail!("stack-bound was not a variant: {other:?}"),
+    }
+}
+
+fn analyze_stack_usage(component_bytes_path: &Path, module_bytes: &[u8]) -> Result<StackBoundView> {
+    let ret = invoke_analyze(component_bytes_path, module_bytes)?;
+    let inner = match ret {
+        Val::Result(Ok(Some(payload))) => *payload,
+        Val::Result(Err(Some(err))) => {
+            bail!("analyze returned analyze-error: {}", display_val(&err))
+        }
+        other => bail!("analyze did not return Ok(analysis-result): {other:?}"),
+    };
+    let fields = expect_record(inner, "analysis-result")?;
+    let su = pop_field(&fields, "stack-usage").ok_or_else(|| {
+        anyhow!(
+            "analysis-result missing `stack-usage`; got: {:?}",
+            field_names(&fields)
+        )
+    })?;
+    let su_fields = expect_record(su, "stack-usage")?;
+    let max = pop_field(&su_fields, "max-stack-bytes")
+        .ok_or_else(|| anyhow!("stack-usage missing `max-stack-bytes`"))?;
+    parse_stack_bound(max)
 }
 
 /// Decode the top-level `result<analysis-result, analyze-error>`
@@ -1010,4 +1065,62 @@ fn feat013_live_analyze_gate() {
         "FEAT013_GATE_OK live analyze() ran on the self-contained component: {} program points",
         bundle.points.len()
     );
+}
+
+// ── FEAT-021 slice-2a: the shadow-stack bound through the composed component ──
+
+/// fixture-12: a 3-deep call chain (frames 16/32/8). The COMPOSED component's
+/// `analysis-result.stack-usage.max-stack-bytes` must equal the worst-case
+/// path sum, 56 bytes — proving the bound flows end-to-end through the shipped
+/// artifact, not just the native analyzer crate.
+#[test]
+fn fixture_12_stack_bound_via_component() -> Result<()> {
+    let comp_path = component_path();
+    if component_missing_skip(&comp_path) {
+        return Ok(());
+    }
+    let wat_path = fixtures_dir().join("fixture-12-stack-chain.wat");
+    let module_bytes = wat::parse_file(&wat_path)
+        .with_context(|| format!("assemble fixture {}", wat_path.display()))?;
+    let bound = analyze_stack_usage(&comp_path, &module_bytes)
+        .context("[fixture-12] decode stack-usage from composed component")?;
+    assert_eq!(
+        bound,
+        StackBoundView::Bytes(56),
+        "[fixture-12] worst-case shadow-stack via the component must be 56 bytes"
+    );
+    eprintln!("scry-host-tests: fixture-12 max-stack-bytes via component = bytes(56)");
+    Ok(())
+}
+
+/// fixture-13: self-recursion → the component must report `unbounded`.
+#[test]
+fn fixture_13_stack_recursion_via_component() -> Result<()> {
+    let comp_path = component_path();
+    if component_missing_skip(&comp_path) {
+        return Ok(());
+    }
+    let wat_path = fixtures_dir().join("fixture-13-stack-recursion.wat");
+    let module_bytes = wat::parse_file(&wat_path)
+        .with_context(|| format!("assemble fixture {}", wat_path.display()))?;
+    let bound = analyze_stack_usage(&comp_path, &module_bytes)
+        .context("[fixture-13] decode stack-usage")?;
+    assert_eq!(bound, StackBoundView::Unbounded, "[fixture-13] recursion → unbounded");
+    Ok(())
+}
+
+/// fixture-14: dynamic frame → the component must report `unknown`.
+#[test]
+fn fixture_14_stack_dynamic_via_component() -> Result<()> {
+    let comp_path = component_path();
+    if component_missing_skip(&comp_path) {
+        return Ok(());
+    }
+    let wat_path = fixtures_dir().join("fixture-14-stack-dynamic.wat");
+    let module_bytes = wat::parse_file(&wat_path)
+        .with_context(|| format!("assemble fixture {}", wat_path.display()))?;
+    let bound = analyze_stack_usage(&comp_path, &module_bytes)
+        .context("[fixture-14] decode stack-usage")?;
+    assert_eq!(bound, StackBoundView::Unknown, "[fixture-14] dynamic frame → unknown");
+    Ok(())
 }

--- a/crates/scry-host-tests/tests/soundness.rs
+++ b/crates/scry-host-tests/tests/soundness.rs
@@ -1105,7 +1105,11 @@ fn fixture_13_stack_recursion_via_component() -> Result<()> {
         .with_context(|| format!("assemble fixture {}", wat_path.display()))?;
     let bound = analyze_stack_usage(&comp_path, &module_bytes)
         .context("[fixture-13] decode stack-usage")?;
-    assert_eq!(bound, StackBoundView::Unbounded, "[fixture-13] recursion → unbounded");
+    assert_eq!(
+        bound,
+        StackBoundView::Unbounded,
+        "[fixture-13] recursion → unbounded"
+    );
     Ok(())
 }
 
@@ -1121,6 +1125,10 @@ fn fixture_14_stack_dynamic_via_component() -> Result<()> {
         .with_context(|| format!("assemble fixture {}", wat_path.display()))?;
     let bound = analyze_stack_usage(&comp_path, &module_bytes)
         .context("[fixture-14] decode stack-usage")?;
-    assert_eq!(bound, StackBoundView::Unknown, "[fixture-14] dynamic frame → unknown");
+    assert_eq!(
+        bound,
+        StackBoundView::Unknown,
+        "[fixture-14] dynamic frame → unknown"
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Surfaces the FEAT-021 worst-case shadow-stack bound in the analyzer's **WIT result**, so it's consumable through the *shipped* `//:scry` component — and proves it flows end-to-end with a host test. **No version bump**: slice-2b (the runtime `__stack_pointer`-peak oracle) lands with this as the combined **v1.11.0** slice-2 release, avoiding a redundant republish of the identical pure libs.

## Changes
- **`scry.wit`** (additive): `stack-bound` variant (`bytes(u64)`/`unbounded`/`unknown`), `function-stack` record, `stack-usage` record (`sp-global`, `functions`, `max-stack-bytes`), added to `analysis-result`. Round-trips under `wasm-tools`.
- **Wrapper** (`scry-analyzer`): `stack_bound_to_wit` / `function_stack_to_wit` / `stack_usage_to_wit`, wired into `result_to_wit`.
- **Host oracle** (`scry-host-tests`): `run_analyzer` refactored to expose the raw result `Val` (`invoke_analyze`); `analyze_stack_usage` decodes `stack-usage.max-stack-bytes`; tests analyze the stack fixtures via the **composed component** and assert `bytes(56)` / `unbounded` / `unknown`.

## Why additive / low-risk
Existing host decoders match result fields **by name** (`pop_field`), so the new `stack-usage` field doesn't disturb them — existing soundness/octagon/taint host tests stay green. Host-test code compiles locally; only the component assertions need a built `//:scry` (CI runs `bazel build //:scry` first).

## Verification
WIT round-trips locally; `scry-host-tests` compiles; `scry-sai-core` tests (10) green; `cargo build --release` clean; `rivet validate` PASS. Bazel `//:scry` (component rebuild with the new WIT) is the key CI check.

## Next
slice-2b: self-measuring fixtures + the runtime `__stack_pointer`-peak measurement + `peak ≤ bound` cross-assertion (kill-criterion fully live), then cut **v1.11.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)