### PR TITLE
docs: add README for every crate (crates.io rendering)

### DIFF
--- a/crates/scry-analyze-core/README.md
+++ b/crates/scry-analyze-core/README.md
@@ -1,0 +1,22 @@
+# scry-sai-core
+
+The pure, bindgen-free **analyzer core** of
+[scry](https://github.com/pulseengine/scry) — a sound static analyzer for
+WebAssembly. The reusable engine behind the `scry-sai-*` (Sound Abstract
+Interpretation) family.
+
+`#![no_std]` and free of WIT/component bindings, it holds scry's real analysis
+decisions over the Wasm Core Model: the `wasmparser` parse, the structured-CFG
+interval + region-memory fixpoint (with loop widening/narrowing and the octagon
+relational product), the call graph (direct + over-approximated `call_indirect`)
+with Tarjan-SCC condensation and bottom-up summaries, the taint
+(noninterference) walk, and the FEAT-021 worst-case shadow-stack bound. Results
+are plain Rust types (`AnalysisResult`: invariants, call graph, summaries,
+taint findings, stack usage).
+
+This is the exact code the shipped `scry.wasm` component runs (it is a thin
+canonical-ABI wrapper around this crate) and that `witness` instruments for
+MC/DC. Depends on the pure `scry-sai-interval` / `-taint` / `-octagon` /
+`-provenance` domain crates. Imported as `scry_analyze_core`.
+
+License: MIT OR Apache-2.0.

--- a/crates/scry-analyzer/README.md
+++ b/crates/scry-analyzer/README.md
@@ -1,0 +1,14 @@
+# scry-sai-analyzer (`scry-analyzer`)
+
+[scry](https://github.com/pulseengine/scry)'s sound WebAssembly analyzer as a
+**Wasm component** — the shipped `scry.wasm` (`//:scry`). A thin canonical-ABI
+wrapper that exposes the `pulseengine:scry/analyzer` `analyze` function over the
+pure [`scry-sai-core`](https://crates.io/crates/scry-sai-core) engine.
+
+This crate is a `cdylib` Wasm component (built via Bazel `rules_wasm_component`),
+**not** a crates.io library: it ships as a signed `.wasm` release asset with
+SBOMs and a sigil attestation. To use scry as a Rust library, depend on
+`scry-sai-core`; to run the analyzer, load the released component in a
+WASIp2 host.
+
+License: MIT OR Apache-2.0.

--- a/crates/scry-interval/README.md
+++ b/crates/scry-interval/README.md
@@ -1,0 +1,20 @@
+# scry-sai-interval
+
+The **interval abstract domain** for [scry](https://github.com/pulseengine/scry) —
+a sound static analyzer for WebAssembly. Part of the `scry-sai-*` (Sound
+Abstract Interpretation) family.
+
+A pure, `#![no_std]`, dependency-free crate holding the *algebra* of the interval
+lattice over `i32`/`i64` and region pointers: `join` (⊔), `meet` (⊓), `widen`
+(ascending-chain termination), `leq` (the Galois order ⊑), `top`/`bottom`, and
+the constant + arithmetic transfer functions. All arithmetic is saturating —
+a bound never silently wraps.
+
+It compiles both natively and to `wasm32` (the shipped scry analyzer component
+links exactly this code), and its soundness (γ-based over-approximation) is
+mechanized admit-free in Rocq (`proofs/rocq/Soundness.v`).
+
+Consumed by [`scry-sai-core`](https://crates.io/crates/scry-sai-core); the Rust
+crate is imported as `scry_interval`.
+
+License: MIT OR Apache-2.0.

--- a/crates/scry-octagon/README.md
+++ b/crates/scry-octagon/README.md
@@ -1,0 +1,19 @@
+# scry-sai-octagon
+
+The **octagon relational abstract domain** for
+[scry](https://github.com/pulseengine/scry) (Miné, HOSC 2006). Part of the
+`scry-sai-*` (Sound Abstract Interpretation) family.
+
+A pure, `#![no_std]`, dependency-free Difference-Bound-Matrix implementation of
+constraints `±x ± y ≤ c`: `close` (Floyd–Warshall) and `strong_close` (Miné
+tight closure), `join`/`meet`/`widen`/`narrow`/`leq`, plus the analyzer-facing
+transfers — `forget` (sound havoc on write), `assign_const`/`assign_copy`/
+`assign_add_const` (incl. the in-place increment that carries a relation across
+a loop), `add_diff`/`set_upper`/`set_lower`, and `bound_of` (project a variable
+to an integer interval). All arithmetic is saturating and INF-absorbing.
+
+scry carries this domain alongside intervals through its loop fixpoint, so a
+counter bounded by a *variable* relation (`i < n`) stays bounded. Falsified by
+γ-sweep tests against the concrete semantics. Imported as `scry_octagon`.
+
+License: MIT OR Apache-2.0.

--- a/crates/scry-provenance/README.md
+++ b/crates/scry-provenance/README.md
@@ -1,0 +1,16 @@
+# scry-sai-provenance
+
+The **component-provenance boundary** between
+[meld](https://pulseengine.eu) and [scry](https://github.com/pulseengine/scry).
+Part of the `scry-sai-*` (Sound Abstract Interpretation) family.
+
+A pure, `#![no_std]`, dependency-free crate: encode / decode / project the
+`component-origin` map that meld emits in a fused Core Wasm module's custom
+section, so scry can attribute a fused-module function back to its originating
+component instance. The round-trip is the contract that lets scry report
+findings in component-level terms.
+
+Compiles natively and to `wasm32` (the shipped scry component links this code).
+Imported as `scry_provenance`.
+
+License: MIT OR Apache-2.0.

--- a/crates/scry-taint/README.md
+++ b/crates/scry-taint/README.md
@@ -1,0 +1,16 @@
+# scry-sai-taint
+
+The **security-label (taint) lattice** for [scry](https://github.com/pulseengine/scry)'s
+noninterference analysis. Part of the `scry-sai-*` (Sound Abstract
+Interpretation) family.
+
+A pure, `#![no_std]`, dependency-free crate: the two-point `Low ⊑ High` lattice
+with its `join`, used by scry's information-flow / noninterference pass to track
+whether a `High` (secret) value can reach a `Low` (public) sink. Forward
+propagation never moves down the lattice — the algebraic kill-criterion is
+exhaustively checked.
+
+Compiles natively and to `wasm32` (the shipped scry component links this code).
+Imported as `scry_taint`.
+
+License: MIT OR Apache-2.0.

--- a/crates/wasm-lattice/README.md
+++ b/crates/wasm-lattice/README.md
@@ -1,0 +1,14 @@
+# scry-sai-lattice (`wasm-lattice`)
+
+The interval/relational abstract-domain algebra exposed as a **Wasm component**
+(the `pulseengine:wasm-lattice/domain` WIT interface) — the DD-008 cross-component
+"dogfood" of [scry](https://github.com/pulseengine/scry)'s domains.
+
+This crate is a `cdylib` Wasm component (built via Bazel `rules_wasm_component`),
+**not** a crates.io library: it ships as a signed `.wasm` release asset. The
+reusable algebra it delegates to is published as the pure
+[`scry-sai-interval`](https://crates.io/crates/scry-sai-interval) /
+[`scry-sai-octagon`](https://crates.io/crates/scry-sai-octagon) /
+[`scry-sai-taint`](https://crates.io/crates/scry-sai-taint) crates.
+
+License: MIT OR Apache-2.0.


### PR DESCRIPTION
## Summary

The published `scry-sai-*` libraries had no README, so their crates.io pages render bare. This adds a concise `README.md` to every crate. Cargo auto-detects `README.md`, so it ships in the `.crate` and renders on crates.io **at the next publish** (no Cargo.toml change, no version bump).

## Coverage
- **Published libraries**: `scry-sai-interval`, `scry-sai-taint`, `scry-sai-octagon`, `scry-sai-provenance`, `scry-sai-core` — what each is, how it's imported (the unchanged `scry_*` lib name), the soundness posture, links to repo + sibling crates.
- **Component crates** (`wasm-lattice` → `scry-sai-lattice`, `scry-analyzer` → `scry-sai-analyzer`): brief READMEs noting they ship as signed `.wasm` assets, not crates.io libraries (pointing to `scry-sai-core` for library use).

Docs-only; inert to the build. Takes effect on the next release publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)