### PR TITLE
v1.13 (FEAT-023): per-program-point abstract operand-stack output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.0] — 2026-06-20
+
+Headline: **per-program-point abstract operand-stack output (FEAT-023),
+driven by the synth collaboration (#54 item 1).** A backend / code-generation
+consumer maps Wasm's transient value-stack onto SSA temps / selected
+instructions and wants the same constant / range facts scry already proves for
+locals. scry's `Interp` already models the operand stack soundly over the
+interval domain; this release EXPOSES that state on each program point — no new
+analysis. Consumed as the crates.io **library** `scry-sai-core`.
+
+### Added — FEAT-023 (REQ-012)
+
+- `ProgramPoint.operand_stack: Vec<AbstractValue>` — the abstract operand-stack
+  at each emitted pc, in stack order (bottom → top). Additive field on a 1.x
+  struct (SemVer-compatible, per the field-stability commitment to synth). The
+  WIT `program-point` mirror is unchanged this slice (library-only surface).
+- fixture-18-operand-stack + native `feat023_operand_stack_constants`: a
+  `i32.const 42; i32.const 7; i32.add` sequence yields program points whose
+  stack top is the singleton 42 (after the first const) and 49 (after the add),
+  with a depth-2 `[42, 7]` stack in between — proving order/depth are preserved.
+
+### Soundness
+
+- Each listed stack slot over-approximates the concrete value at that slot under
+  the interval domain (identical to the per-local contract). At a program point
+  reached only via write-set havoc (a not-precisely-modelled region), scry emits
+  an **empty** operand-stack rather than a stale one — honest silence over a
+  false claim. Listing fewer slots than the true height is sound (a vacuous
+  claim about the omitted top slots); the only forbidden case is a slot whose
+  abstract value does not contain the concrete value.
+
+### Falsification statement
+
+If scry reports an `operand_stack` slot whose interval does NOT contain the
+concrete value that Wasm's value-stack holds at that pc in some execution, this
+release's soundness claim is false. The native `feat023_operand_stack_constants`
+test pins the singleton-constant case; the empty-stack-at-havoc rule is the
+conservative guard for the unmodelled case.
+
 ## [1.12.0] — 2026-06-20
 
 Headline: **reachable-from-exports output for downstream consumers (FEAT-022

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1842,14 +1842,14 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-core"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "scry-sai-interval",
  "scry-sai-octagon",
@@ -1862,11 +1862,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "1.12.0"
+version = "1.13.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1875,15 +1875,15 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "1.12.0"
+version = "1.13.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "1.12.0"
+version = "1.13.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "1.12.0"
+version = "1.13.0"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "1.12.0"
+version = "1.13.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -633,6 +633,42 @@ artifacts:
       - type: traces-to
         target: FEAT-022
 
+  - id: REQ-012
+    type: requirement
+    title: "Downstream consumers get the sound abstract operand-stack at each program point"
+    status: proposed
+    description: >
+      The analysis-result shall expose, per emitted program point, the abstract
+      OPERAND-STACK (the transient value-stack) in stack order (bottom → top),
+      not only the locals. A code-generation / backend consumer (synth, collab
+      issue #54 item 1) maps these transient temps onto SSA values / selected
+      instructions and wants the same constant / range facts scry already
+      proves for locals — e.g. a known singleton on the stack top is the
+      operand-stack analogue of a constant local.
+
+      Soundness contract (what enters the consumer's TCB): each listed stack
+      slot OVER-APPROXIMATES the concrete value at that slot under the interval
+      domain (identical to the per-local contract). Listing FEWER slots than
+      the true height is sound (a vacuous claim about the omitted top slots);
+      listing a slot whose abstract value does NOT contain the concrete value
+      is the only unsoundness, and is forbidden. At a point reached only via a
+      not-precisely-modelled region (write-set havoc), scry emits an EMPTY
+      operand-stack rather than a stale one — honest silence over a false claim.
+
+      Library-only surface: synth consumes `scry-sai-core` as a crate and reads
+      `ProgramPoint.operand_stack: Vec<AbstractValue>` directly (the WIT
+      `program-point` mirror is unchanged; a later slice may surface it for
+      non-Rust consumers).
+    tags: [interop, invariants, operand-stack, soundness, v1.x]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-001
+      - type: traces-to
+        target: FEAT-023
+
   # ──────────────────────────────────────────────────────────────────────
   # Feature ladder v1.1 → v2.0.  status: proposed (provisional until built).
   #
@@ -1164,6 +1200,46 @@ artifacts:
         target: FEAT-007
       - type: traces-to
         target: FEAT-021
+      - type: traces-to
+        target: G-005
+
+  - id: FEAT-023
+    type: feature
+    title: "v1.x — Per-program-point abstract operand-stack output (synth backend, collab #54)"
+    status: proposed
+    description: >
+      Surface the abstract OPERAND-STACK (transient value-stack) on every
+      emitted `ProgramPoint`, alongside the existing per-local invariants. A
+      backend / code-generation consumer (synth, collab issue #54 item 1) maps
+      these transient temps onto SSA values / selected instructions and wants
+      the same constant / range facts scry already proves for locals. scry's
+      `Interp` already models the operand stack soundly over the interval domain
+      (push on const/load/arith, pop on consume, save/restore at block/loop
+      boundaries); FEAT-023 just EXPOSES that state — no new analysis.
+
+      CONSUMPTION PATH (per collab #51/#54): library-only. synth reads
+      `ProgramPoint.operand_stack: Vec<AbstractValue>` (bottom → top) off the
+      `scry-sai-core` `AnalysisResult` directly. The WIT `program-point` mirror
+      is unchanged this slice (a later slice may surface it for non-Rust
+      consumers). Additive field on a 1.x struct — SemVer-compatible per the
+      field-stability commitment to synth.
+
+      Soundness (REQ-012): each listed slot over-approximates the concrete value
+      at that slot under the interval domain. At a point reached only via
+      write-set havoc (a not-precisely-modelled region), scry emits an EMPTY
+      operand-stack rather than a stale one — honest silence over a false claim.
+    tags: [capability, interop, invariants, operand-stack, v1.x]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given a Core Wasm module, When scry analyzes it, Then each emitted program-point carries an operand-stack list of abstract values in stack order (bottom → top)."
+        - "Given a function pushing a known constant (i32.const 42), When scry analyzes it, Then a program point's operand-stack top is the singleton interval [42,42] — the operand-stack analogue of a constant local — and stack depth/order are preserved (a two-const sequence yields a depth-2 stack [42,7])."
+        - "Given a program point reached only via a not-precisely-modelled region (write-set havoc), When scry emits it, Then its operand-stack is EMPTY (a vacuous, sound claim) rather than a stale, potentially-unsound snapshot."
+    links:
+      - type: satisfies
+        target: REQ-012
+      - type: traces-to
+        target: FEAT-016
       - type: traces-to
         target: G-005
 

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "1.12.0" }
+scry-sai-interval = { path = "../scry-interval", version = "1.13.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,14 +43,14 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "1.12.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "1.12.0" }
+scry-sai-taint = { path = "../scry-taint", version = "1.13.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "1.13.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "1.12.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "1.13.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/README.md
+++ b/crates/scry-analyze-core/README.md
@@ -44,6 +44,13 @@ for e in &r.call_graph {
 let has_cycle = r.function_summaries.iter().any(|s| s.recursive); // honest-fail gate
 let reachable = &r.reachable_from_exports; // sound superset; prune anything absent
 let stack = r.stack_usage.max_stack_bytes;  // Bytes(n) | Unbounded | Unknown
+
+for p in &r.invariants.points {
+    // Per (func, pc): p.locals (per-local invariants) AND p.operand_stack —
+    // the abstract value-stack in stack order (bottom → top). A backend maps
+    // these onto SSA temps; a singleton interval is a known constant.
+    let _stack_top = p.operand_stack.last();
+}
 # Ok::<(), scry_analyze_core::AnalyzeError>(())
 ```
 

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -111,12 +111,19 @@ pub struct LocalInvariant {
     pub value: AbstractValue,
 }
 
-/// Mirror of WIT `program-point`. All locals at one pc in one function.
+/// Mirror of WIT `program-point`. The abstract state at one pc in one function.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProgramPoint {
     pub func_index: u32,
     pub pc: u32,
     pub locals: Vec<LocalInvariant>,
+    /// FEAT-023: the abstract operand-stack at this pc, in stack order
+    /// (bottom → top). The transient value-stack state a backend maps onto
+    /// SSA temps / selected instructions. Core-only for now (the WIT
+    /// `program-point` mirror still carries only `locals`; a later slice
+    /// surfaces it for non-Rust consumers). Sound over the same interval
+    /// domain as `locals`.
+    pub operand_stack: Vec<AbstractValue>,
 }
 
 /// Mirror of WIT `invariant-bundle`. The full per-module invariant bundle.
@@ -378,7 +385,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "1.12.0";
+const SCRY_VERSION: &str = "1.13.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).
@@ -698,6 +705,13 @@ fn snapshot_locals(locals: &[AbstractValue]) -> Vec<LocalInvariant> {
             value: clone_value(v),
         })
         .collect()
+}
+
+/// FEAT-023: snapshot the abstract operand-stack (bottom → top) for a
+/// `ProgramPoint`. The values are the same sound abstract values as the
+/// locals; no octagon reduction (the octagon is over locals, not stack slots).
+fn snapshot_stack(stack: &[AbstractValue]) -> Vec<AbstractValue> {
+    stack.iter().map(clone_value).collect()
 }
 
 /// `AbstractValue` derives no Copy/Clone in the generated bindings (it
@@ -1949,6 +1963,7 @@ impl Interp<'_, '_> {
                         func_index: self.func_index,
                         pc: pc as u32,
                         locals: snapshot_locals(&reduce_locals(&ctx.locals, &ctx.octagon)),
+                        operand_stack: snapshot_stack(&ctx.operand_stack),
                     });
                 }
                 pc = next;
@@ -1968,6 +1983,7 @@ impl Interp<'_, '_> {
                         func_index: self.func_index,
                         pc: pc as u32,
                         locals: snapshot_locals(&reduce_locals(&ctx.locals, &ctx.octagon)),
+                        operand_stack: snapshot_stack(&ctx.operand_stack),
                     });
                 }
                 pc = next;
@@ -2025,6 +2041,7 @@ impl Interp<'_, '_> {
                     func_index: self.func_index,
                     pc: pc as u32,
                     locals: snapshot_locals(&reduce_locals(&ctx.locals, &ctx.octagon)),
+                    operand_stack: snapshot_stack(&ctx.operand_stack),
                 });
             }
             if stop {
@@ -2397,6 +2414,14 @@ impl Interp<'_, '_> {
                 func_index: self.func_index,
                 pc: end as u32,
                 locals: snapshot_locals(&ctx.locals),
+                // FEAT-023: havoc does NOT model the region's operand-stack
+                // effect (a non-empty block type leaves result values our model
+                // never simulated). `ctx.operand_stack` is therefore stale here,
+                // so we emit an EMPTY stack — a vacuous, trivially-sound claim
+                // ("no operand-stack info at this pc") rather than a
+                // precise-looking-but-unsound one. Locals stay meaningful: they
+                // were soundly widened to ⊤ above.
+                operand_stack: Vec::new(),
             });
         }
     }
@@ -4311,6 +4336,7 @@ mod tests {
                     local_index: 0,
                     value: av.clone(),
                 }],
+                operand_stack: alloc::vec![av.clone()],
             }],
         };
         let res = AnalysisResult {
@@ -4674,6 +4700,61 @@ mod tests {
         assert_eq!(
             sorted, res.reachable_from_exports,
             "set is sorted + deduped"
+        );
+    }
+
+    /// FEAT-023: the abstract operand-stack is surfaced on each `ProgramPoint`
+    /// and is sound over the same interval domain as the locals. In
+    /// fixture-18, `i32.const 42; i32.const 7; i32.add` produces program points
+    /// whose stack top is the singleton 42 (after the first const) and 49
+    /// (after the add) — so a consumer can read a known constant off the stack
+    /// top, the operand-stack analogue of a constant local.
+    #[test]
+    fn feat023_operand_stack_constants() {
+        let res = analyze_fixture("fixture-18-operand-stack.wat");
+        let points = &res.invariants.points;
+        assert!(!points.is_empty(), "fixture-18 must emit program points");
+
+        // The singleton constant on top of the stack after `i32.const 42`.
+        let saw_42 = points.iter().any(|p| {
+            matches!(
+                p.operand_stack.last(),
+                Some(AbstractValue::I32Interval(iv)) if iv.lo == 42 && iv.hi == 42
+            )
+        });
+        assert!(
+            saw_42,
+            "a program point's operand-stack top must be the constant 42"
+        );
+
+        // The add result 42 + 7 = 49, again a singleton, on the stack top.
+        let saw_49 = points.iter().any(|p| {
+            matches!(
+                p.operand_stack.last(),
+                Some(AbstractValue::I32Interval(iv)) if iv.lo == 49 && iv.hi == 49
+            )
+        });
+        assert!(
+            saw_49,
+            "the i32.add result 49 must appear as a singleton on the operand-stack top"
+        );
+
+        // Soundness/shape: at the point holding [42,7] the stack has depth 2
+        // (bottom → top), confirming bottom-to-top ordering is preserved.
+        let saw_depth2 = points.iter().any(|p| {
+            p.operand_stack.len() == 2
+                && matches!(
+                    p.operand_stack.first(),
+                    Some(AbstractValue::I32Interval(iv)) if iv.lo == 42 && iv.hi == 42
+                )
+                && matches!(
+                    p.operand_stack.last(),
+                    Some(AbstractValue::I32Interval(iv)) if iv.lo == 7 && iv.hi == 7
+                )
+        });
+        assert!(
+            saw_depth2,
+            "after the second const the stack is [42, 7] bottom → top"
         );
     }
 

--- a/crates/scry-analyzer/test-fixtures/README.md
+++ b/crates/scry-analyzer/test-fixtures/README.md
@@ -85,6 +85,7 @@ than working around it here.
 | `fixture-15-stack-alloca.wat`     | v1.10 (FEAT-021 slice-1) shadow-stack soundness regression: const frame + dynamic alloca → UNKNOWN, never the under-counted constant (clean-room finding) |
 | `fixture-16-stack-measured.wat`  | v1.11 (FEAT-021 slice-2b) LIVE kill-criterion: self-measuring chain (frames 32/16) → reported bytes(48) >= wasmtime-measured peak 48 |
 | `fixture-17-reachability.wat`    | v1.12 (FEAT-022 slice-1) reachable-from-exports: exported→callee included, dead function excluded (sound superset) |
+| `fixture-18-operand-stack.wat`   | v1.13 (FEAT-023) per-pc abstract operand-stack: `42; 7; +` → stack top singleton 42 then 49, depth-2 `[42,7]` between (order/depth preserved, sound) |
 
 ## Adding fixtures
 

--- a/crates/scry-analyzer/test-fixtures/fixture-18-operand-stack.wat
+++ b/crates/scry-analyzer/test-fixtures/fixture-18-operand-stack.wat
@@ -1,0 +1,20 @@
+;; fixture-18-operand-stack — FEAT-023 (operand-stack invariants).
+;;
+;; A backend (synth) wants the abstract VALUE-STACK state at each pc, not just
+;; the locals — the transient temps a register allocator / instruction selector
+;; maps onto. scry's `Interp` already models the operand stack soundly over the
+;; interval domain; FEAT-023 just surfaces it on each `ProgramPoint`.
+;;
+;; `$stack_const` pushes two constants and adds them. At the emitted program
+;; points the abstract operand-stack is, in stack order (bottom → top):
+;;   after `i32.const 42`  →  [ [42,42] ]
+;;   after `i32.const 7`   →  [ [42,42], [7,7] ]
+;;   after `i32.add`       →  [ [49,49] ]
+;; so a consumer reads a known singleton off the stack top — the operand-stack
+;; analogue of a constant local. Sound: every entry over-approximates the
+;; concrete slot (here exactly, the constants being singletons).
+(module
+  (func $stack_const (export "run") (result i32)
+    i32.const 42
+    i32.const 7
+    i32.add))


### PR DESCRIPTION
## What

Surfaces the abstract **operand-stack** (the transient value-stack) on every emitted `ProgramPoint`, in stack order (bottom → top), alongside the existing per-local invariants.

Driven by the synth collaboration (**#54 item 1**): a backend / code-generation consumer maps Wasm's transient value-stack onto SSA temps / selected instructions and wants the same constant / range facts scry already proves for locals — a singleton interval on the stack top is the operand-stack analogue of a constant local.

scry's `Interp` **already** models the operand stack soundly over the interval domain (push on const/load/arith, pop on consume, save/restore at block/loop boundaries). This PR just **exposes** that state — no new analysis.

## Consumption path (library-only)

Per collab #51/#54, synth consumes `scry-sai-core` as a crate and reads `ProgramPoint.operand_stack: Vec<AbstractValue>` directly. The WIT `program-point` mirror is **unchanged** this slice (a later slice may surface it for non-Rust consumers). Additive field on a 1.x struct — SemVer-compatible, per the field-stability commitment to synth.

## Soundness (REQ-012)

Each listed slot over-approximates the concrete value at that slot under the interval domain (identical to the per-local contract).

- The **three precise emission sites** — the two guard peepholes (`try_guard_brif`/`try_guard_brif_rel`, both **net-zero** operand-stack effect, so the live stack is coherent there) and the straight-line post-`interpret_op` site — snapshot the live `ctx.operand_stack`.
- The **write-set-havoc site** emits an **empty** operand-stack rather than a stale one: havoc does not model the region's stack effect (a non-empty block type leaves result values our model never simulated), so honest silence beats a false claim. Locals stay meaningful (soundly widened to ⊤).

## Traceability + tests

- rivet: **REQ-012** (new requirement) + **FEAT-023** (`satisfies` REQ-012). `rivet validate` PASS.
- fixture-18-operand-stack + native `feat023_operand_stack_constants`: `i32.const 42; i32.const 7; i32.add` → a point whose stack top is the singleton `[42,42]` (after the first const) and `[49,49]` (after the add), with a depth-2 `[42, 7]` stack in between (order/depth preserved). 13/13 core tests pass.
- Lockstep version bump 1.12.0 → 1.13.0 (workspace + `SCRY_VERSION` + path-dep versions); CHANGELOG with falsification statement.

## Falsification statement

If scry reports an `operand_stack` slot whose interval does **not** contain the concrete value Wasm's value-stack holds at that pc in some execution, this release's soundness claim is false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)