### PR TITLE
v1.14.0 (FEAT-024/025): scry-viz — static-HTML AnalysisResult visualization + self-analysis dogfood

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,3 +301,22 @@ jobs:
           path: ${{ github.workspace }}/mcdc-viz-site
           if-no-files-found: error
           retention-days: 14
+      # FEAT-025 dogfood: run scry on its OWN compiled module (the analyzer
+      # core, already built above as scry_mcdc.wasm) and render the analysis
+      # with scry-viz (FEAT-024). "scry visualizing scry." This is also a
+      # robustness oracle — a panic / error analyzing a real, large,
+      # compiler-emitted module turns the build red, where the tiny fixtures
+      # cannot reach.
+      - name: Dogfood — scry-viz on scry's own module (FEAT-025)
+        run: |
+          cargo run --release -p scry-sai-viz -- \
+            crates/scry-mcdc/target/wasm32-wasip1/release/scry_mcdc.wasm \
+            -o "${{ github.workspace }}/scry-self-analysis.html" \
+            --title "scry analyzing scry (scry_mcdc.wasm)"
+      - name: Upload scry self-analysis
+        uses: actions/upload-artifact@v4
+        with:
+          name: scry-self-analysis
+          path: ${{ github.workspace }}/scry-self-analysis.html
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/publish-to-crates-io.yml
+++ b/.github/workflows/publish-to-crates-io.yml
@@ -1,8 +1,10 @@
 # Publishes the scry pure-library crates to crates.io on every `v*` tag push,
 # in parallel with release.yml (signed wasm component + SBOMs + MC/DC evidence).
 #
-# Publishes only the reusable libraries — scry-sai-interval, scry-sai-taint,
-# scry-sai-octagon, scry-sai-provenance, scry-sai-core. The Wasm-component crates
+# Publishes the reusable libraries — scry-sai-interval, scry-sai-taint,
+# scry-sai-octagon, scry-sai-provenance, scry-sai-core — plus the scry-sai-viz
+# tool (binary + library; FEAT-024), which consumes scry-sai-core to render an
+# AnalysisResult. The Wasm-component crates
 # (wasm-lattice, scry-analyzer) and the test / MC-DC harnesses are
 # `publish = false` and ship as signed `.wasm` release assets instead (the
 # witness precedent: publish the libs, ship the component).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.14.0] — 2026-06-20
+
+Headline: **scry-viz — a static-HTML visualization of scry's own analysis
+output (FEAT-024) — plus a self-analysis dogfood (FEAT-025).** scry already
+ships a static-site evidence artifact for MC/DC truth tables (witness-viz);
+this release adds the analyzer's own analogue: turn an `AnalysisResult` into a
+single self-contained HTML page a human can audit, and run it on scry's *own*
+compiled module in CI.
+
+### Added — FEAT-024 (REQ-013)
+
+- New crate **`scry-sai-viz`** (library `scry_viz` + binary `scry-viz`), a
+  plain `std` host tool that consumes `scry-sai-core` and renders an
+  `AnalysisResult` as a self-contained HTML page — no server, no JavaScript, no
+  external assets. Renders: a summary (module SHA-256, schema, worst-case
+  shadow-stack bound, counts); a functions table (reachable-from-exports? ·
+  recursive? · params · frame · max stack); the call graph (caller · pc ·
+  direct/indirect · resolved targets · soundness tag); diagnostics; and the
+  per-program-point invariants — `locals` AND the FEAT-023 **operand stack**
+  (bottom → top). A singleton interval renders as a bare constant, the full
+  domain as `⊤`, an empty operand stack as an explicit `(empty)`.
+- `scry-viz <module.wasm|module.wat> [-o out.html] [--title NAME]` CLI.
+- Published to crates.io (`cargo install scry-sai-viz`).
+
+### Added — FEAT-025 (dogfood)
+
+- CI step (in the existing MC/DC job) runs `scry-viz` on scry's own compiled
+  module (`scry_mcdc.wasm`) and uploads the resulting **`scry-self-analysis`**
+  HTML artifact. "scry visualizing scry." This is also a robustness oracle: a
+  panic or error analyzing a real, large, compiler-emitted module turns the
+  build red, where the tiny hand-written fixtures cannot reach. (Verified
+  locally: 548 functions, 423 call edges, 4326 program points, no panic.)
+
+### Soundness
+
+- `scry-viz` is a **faithful rendering**: it re-derives nothing and asserts
+  nothing beyond what the `AnalysisResult` already states. Each value shown is a
+  verbatim projection of an analyzer field. An empty operand-stack renders as
+  `(empty)` — the analyzer's honest "no info here" — never a claim that the
+  concrete stack is empty. Attacker-influenced strings (diagnostic messages,
+  schema URL, module name) are HTML-escaped.
+
+### Falsification statement
+
+If `scry-viz` displays a value that is NOT a verbatim projection of an
+`AnalysisResult` field — i.e. it re-derives, rounds, or over-states any
+analyzer output — this release's faithful-rendering claim is false. The native
+tests pin the constant-on-stack, empty-stack, and HTML-escaping cases; the
+dogfood CI step is the live no-panic oracle on a real module.
+
 ## [1.13.0] — 2026-06-20
 
 Headline: **per-program-point abstract operand-stack output (FEAT-023),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,6 +1886,14 @@ name = "scry-sai-taint"
 version = "1.13.0"
 
 [[package]]
+name = "scry-sai-viz"
+version = "1.13.0"
+dependencies = [
+ "scry-sai-core",
+ "wat",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1842,14 +1842,14 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-core"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "scry-sai-interval",
  "scry-sai-octagon",
@@ -1862,11 +1862,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "1.13.0"
+version = "1.14.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1875,19 +1875,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "1.13.0"
+version = "1.14.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "1.13.0"
+version = "1.14.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "1.13.0"
+version = "1.14.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "scry-sai-core",
  "wat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/scry-interval",
     "crates/scry-analyze-core",
     "crates/scry-host-tests",
+    "crates/scry-viz",
 ]
 # `wasm-lattice` and `scry-analyzer` are the Wasm-component crates
 # (`crate-type = ["cdylib"]`, `#![no_std]`; `scry-analyzer` additionally
@@ -48,6 +49,7 @@ default-members = [
     "crates/scry-interval",
     "crates/scry-analyze-core",
     "crates/scry-host-tests",
+    "crates/scry-viz",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "1.13.0"
+version = "1.14.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -669,6 +669,39 @@ artifacts:
       - type: traces-to
         target: FEAT-023
 
+  - id: REQ-013
+    type: requirement
+    title: "scry's analysis output is inspectable as a static, shareable visualization"
+    status: proposed
+    description: >
+      A scry `AnalysisResult` shall be renderable as a self-contained static
+      artifact (no server, no JavaScript, no external assets) that a human can
+      open and audit — the analyzer's own analogue of the witness-viz MC/DC
+      truth-table site. The artifact surfaces the analysis a reviewer/consumer
+      cares about: per-function shadow-stack bound, reachability and recursion
+      flags, the call graph (incl. call_indirect resolved-target sets +
+      soundness tag), diagnostics, and the per-program-point invariants
+      (locals AND the FEAT-023 operand-stack).
+
+      Soundness posture (what enters NO TCB): the visualization is a FAITHFUL
+      RENDERING — it re-derives nothing and asserts nothing beyond what the
+      `AnalysisResult` states. Each value shown is a verbatim projection of an
+      analyzer field; an empty operand-stack is rendered as an explicit
+      "(empty)" (the analyzer's honest "no info here"), never as a claim that
+      the concrete stack is empty. Attacker-influenced strings (diagnostic
+      messages, schema URL, module name) are HTML-escaped.
+    tags: [interop, visualization, tooling, evidence, v1.x]
+    fields:
+      priority: could
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-001
+      - type: traces-to
+        target: FEAT-024
+      - type: traces-to
+        target: FEAT-023
+
   # ──────────────────────────────────────────────────────────────────────
   # Feature ladder v1.1 → v2.0.  status: proposed (provisional until built).
   #
@@ -1240,6 +1273,80 @@ artifacts:
         target: REQ-012
       - type: traces-to
         target: FEAT-016
+      - type: traces-to
+        target: G-005
+
+  - id: FEAT-024
+    type: feature
+    title: "v1.x — scry-viz: static-HTML visualization of an AnalysisResult"
+    status: proposed
+    description: >
+      A `std` host tool + library (`scry-sai-viz`) that turns a scry
+      `AnalysisResult` into a single self-contained HTML page — no server, no
+      JavaScript, no external assets — mirroring the witness-viz static-site
+      evidence pattern, but for the analyzer's OWN output. Consumes
+      `scry-sai-core` as a crate (plain-Rust types, no WIT/component).
+
+      The page renders: a header (module sha256, schema, headline counts); a
+      functions table (reachable-from-exports? · recursive? · params · frame ·
+      worst-case stack — merging stack-usage / function-summaries /
+      reachable-from-exports); the call graph (caller · pc · direct/indirect ·
+      resolved targets · soundness); diagnostics; and the per-program-point
+      invariants (locals AND the FEAT-023 operand-stack, bottom → top). A
+      singleton interval renders as a bare constant; the full domain as ⊤; an
+      empty operand-stack as an explicit "(empty)".
+
+      Staged smallest-sound-first:
+        slice-1 — a pure `render_html(&AnalysisResult, title) -> String` in the
+          `scry-sai-viz` library, with native unit tests (constant on the stack
+          shows verbatim; empty stack shows "(empty)"; untrusted text escaped;
+          no panic on empty module). Plus a `scry-viz` CLI that analyzes a
+          .wasm/.wat and writes the page.
+        slice-2 — (optional) call-graph diagram (Mermaid/Graphviz) and
+          cross-links between points / functions / edges.
+    tags: [capability, visualization, tooling, evidence, v1.x]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given an AnalysisResult, When scry-viz renders it, Then the output is a single self-contained HTML document (no external assets) containing the functions table, call graph, diagnostics, and per-program-point invariants incl. the operand stack."
+        - "Given a program point with a known constant on the operand stack, When rendered, Then the constant appears verbatim (singleton interval as a bare value); given an empty operand stack, Then it renders as an explicit \"(empty)\" — never re-deriving or over-stating any value."
+        - "Given an AnalysisResult containing attacker-influenced strings (diagnostic messages, schema URL, module name), When rendered, Then those strings are HTML-escaped."
+    links:
+      - type: satisfies
+        target: REQ-013
+      - type: depends-on
+        target: FEAT-023
+      - type: traces-to
+        target: G-005
+
+  - id: FEAT-025
+    type: feature
+    title: "v1.x — Dogfood: scry analyzes its own compiled module in CI (self-analysis artifact)"
+    status: proposed
+    description: >
+      Roll scry out on OUR OWN artifacts: run `analyze()` (and scry-viz) on
+      scry's own compiled Core Wasm module as part of the build. Tiny
+      hand-written fixtures exercise specific transfer functions; a real,
+      large, compiler-emitted module (scry's own analyzer core, already built
+      for the MC/DC harness as `scry_mcdc.wasm`) is a robustness oracle they
+      cannot reach — it catches panics, pathological blow-ups, and unsound
+      corner cases on production-shaped code.
+
+      Staged smallest-sound-first:
+        slice-1 — a CI step (in the existing MC/DC job, which already builds
+          `scry_mcdc.wasm`) that runs `scry-viz` on that module and uploads the
+          resulting self-analysis HTML as an artifact. "scry visualizing scry."
+        slice-2 — (optional) a gated robustness assertion: analysis of the
+          self-module succeeds (no panic, well-formed bundle, every interval
+          lo ≤ hi, call graph non-empty), promoted to a live gate once stable.
+    tags: [capability, dogfood, ci, robustness, v1.x]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given scry's own compiled Core Wasm module, When CI runs scry-viz on it, Then a self-analysis HTML artifact is produced and uploaded (build fails if rendering panics or errors)."
+    links:
+      - type: depends-on
+        target: FEAT-024
       - type: traces-to
         target: G-005
 

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "1.13.0" }
+scry-sai-interval = { path = "../scry-interval", version = "1.14.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,14 +43,14 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "1.13.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "1.13.0" }
+scry-sai-taint = { path = "../scry-taint", version = "1.14.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "1.14.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "1.13.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "1.14.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -385,7 +385,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "1.13.0";
+const SCRY_VERSION: &str = "1.14.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).

--- a/crates/scry-mcdc/Cargo.lock
+++ b/crates/scry-mcdc/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-core"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "scry-sai-interval",
  "scry-sai-octagon",
@@ -89,19 +89,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "1.12.0"
+version = "1.13.0"
 
 [[package]]
 name = "scry-sai-octagon"
-version = "1.12.0"
+version = "1.13.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "1.12.0"
+version = "1.13.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "1.12.0"
+version = "1.13.0"
 
 [[package]]
 name = "sha2"

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "1.13.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "1.14.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "scry-sai-viz"
+description = "Static-HTML visualization of a scry (scry-sai-core) AnalysisResult — functions, call graph, diagnostics, and per-program-point invariants (locals + operand stack)."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords = ["wasm", "static-analysis", "visualization", "verification"]
+categories = ["development-tools", "visualization", "wasm"]
+
+[lib]
+name = "scry_viz"
+path = "src/lib.rs"
+
+[[bin]]
+name = "scry-viz"
+path = "src/main.rs"
+
+[dependencies]
+# The only dependency: the published analyzer library. scry-viz is a plain
+# `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
+# render them — no WIT, no component, no wasmtime.
+scry-sai-core = { path = "../scry-analyze-core", version = "1.13.0" }
+# Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
+# .wasm); host-only, same dep the test harness uses.
+wat = { workspace = true }

--- a/crates/scry-viz/README.md
+++ b/crates/scry-viz/README.md
@@ -1,0 +1,58 @@
+# scry-sai-viz
+
+Static-HTML visualization of a [scry](https://github.com/pulseengine/scry)
+`AnalysisResult` — the analyzer's own analogue of the witness-viz MC/DC
+truth-table site, but for scry's static-analysis output.
+
+Part of [scry](https://pulseengine.eu): a sound Wasm static analyzer. This is
+a plain `std` host tool (binary `scry-viz` + library `scry_viz`) that consumes
+the published analyzer library [`scry-sai-core`](https://crates.io/crates/scry-sai-core)
+— no WIT, no component, no `wasmtime`.
+
+## What it renders
+
+A single self-contained HTML page (no server, no JavaScript, no external
+assets) with:
+
+- **Summary** — module SHA-256, schema, worst-case shadow-stack bound,
+  stack-pointer global, and headline counts.
+- **Functions** — per function: reachable-from-exports? · recursive? · params ·
+  shadow-stack frame · worst-case stack.
+- **Call graph** — caller · pc · `call`/`call_indirect` · resolved target set ·
+  soundness tag.
+- **Diagnostics** — severity · `fn:pc` · message.
+- **Program points** — for each visited `(func, pc)`, the abstract `locals`
+  *and* the abstract **operand stack** (bottom → top). A singleton interval
+  shows as a bare constant (`i32 42`), the full domain as `⊤`, and an empty
+  operand stack as an explicit `(empty)`.
+
+## Usage
+
+```bash
+cargo install scry-sai-viz
+scry-viz module.wasm                 # writes module.html
+scry-viz module.wat -o report.html   # .wat is assembled in-process
+scry-viz module.wasm --title "my firmware"
+```
+
+Library:
+
+```rust
+use scry_analyze_core::{analyze, AnalysisConfig};
+
+let result = analyze(wasm_bytes, AnalysisConfig::default())?;
+let html = scry_viz::render_html(&result, "my-module");
+std::fs::write("report.html", html)?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Soundness posture
+
+scry-viz is a **faithful rendering**: it re-derives nothing and asserts nothing
+beyond what the `AnalysisResult` already states. Every value shown is a verbatim
+projection of an analyzer field. An empty operand-stack renders as `(empty)` —
+the analyzer's honest "no operand-stack info here" (e.g. at a write-set-havoc
+point), never a claim that the concrete stack is empty. Attacker-influenced
+strings (diagnostic messages, schema URL, module name) are HTML-escaped.
+
+License: MIT OR Apache-2.0.

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -104,6 +104,16 @@ fn render_functions(s: &mut String, r: &AnalysisResult) {
         "<table><thead><tr><th>func</th><th>reachable</th><th>recursive</th>\
          <th>params</th><th>frame</th><th>max stack</th></tr></thead><tbody>",
     );
+    // The `reachable` column reads `reachable_from_exports` via binary_search,
+    // which is only correct if that vector is sorted ascending — which scry's
+    // `compute_reachable_from_exports` guarantees (sort_unstable + dedup, per
+    // its doc + analyzer test). Defend our own correctness against an upstream
+    // regression: a future change that returned it unsorted would silently
+    // mis-render reachability, so we self-check in debug/test builds.
+    debug_assert!(
+        r.reachable_from_exports.is_sorted(),
+        "reachable_from_exports must be sorted ascending for binary_search"
+    );
     // Union of every function index we know something about, ascending.
     let mut indices: Vec<u32> = r
         .function_summaries

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -1,0 +1,404 @@
+//! # scry-viz — static-HTML visualization of a scry `AnalysisResult`
+//!
+//! scry already follows a "static-site evidence" pattern for MC/DC truth
+//! tables (witness-viz, a CI artifact you can open from `file://`). `scry-viz`
+//! is the analogue for the analyzer's *own* output: it turns an
+//! [`scry_analyze_core::AnalysisResult`] into a single self-contained HTML page
+//! a human can audit — no server, no JavaScript, no external assets.
+//!
+//! The page renders, in order:
+//!   * a header with the module SHA-256, schema, and headline counts;
+//!   * a **functions** table (reachable-from-exports? · recursive? · shadow-stack
+//!     frame · worst-case stack), merging [`StackUsage`], [`FunctionSummary`],
+//!     and `reachable_from_exports`;
+//!   * the **call graph** (caller · pc · direct/indirect · resolved targets ·
+//!     soundness tag);
+//!   * **diagnostics** (severity · func:pc · message);
+//!   * the **per-program-point invariants** — for each visited `(func, pc)`,
+//!     the abstract `locals` AND the abstract `operand_stack` (FEAT-023), in
+//!     stack order bottom → top.
+//!
+//! ## Soundness posture
+//!
+//! `scry-viz` is a faithful *rendering*: it re-derives nothing and asserts
+//! nothing beyond what the `AnalysisResult` already states. Every value shown
+//! is a verbatim projection of an analyzer field. An empty operand-stack at a
+//! program point is shown as the literal "(empty)" — it is the analyzer's
+//! honest "no operand-stack info here" (e.g. a write-set-havoc point), not a
+//! claim that the concrete stack is empty.
+
+use core::fmt::Write as _;
+
+use scry_analyze_core::{
+    AbstractValue, AnalysisResult, CallEdge, Diagnostic, DiagnosticSeverity, FunctionStack,
+    Interval, ProgramPoint, Region, SoundnessTag, StackBound,
+};
+
+/// Render a complete, self-contained HTML document for `result`.
+///
+/// `title` is shown in the page `<title>` and `<h1>` — typically the analyzed
+/// module's name. The returned `String` is the entire document (UTF-8); write
+/// it to a `.html` file and open it directly.
+pub fn render_html(result: &AnalysisResult, title: &str) -> String {
+    let mut s = String::with_capacity(8 * 1024);
+    let _ = write!(s, "{}", DOCTYPE_AND_HEAD_OPEN);
+    let _ = write!(s, "<title>scry-viz — {}</title>", esc(title));
+    let _ = write!(s, "{}", STYLE);
+    s.push_str("</head><body>");
+
+    let _ = write!(s, "<h1>scry analysis — {}</h1>", esc(title));
+    render_header(&mut s, result);
+    render_functions(&mut s, result);
+    render_call_graph(&mut s, &result.call_graph);
+    render_diagnostics(&mut s, &result.diagnostics);
+    render_points(&mut s, &result.invariants.points);
+
+    s.push_str(
+        "<footer>Rendered by scry-viz · a faithful projection of the \
+        analyzer output (nothing re-derived). MIT OR Apache-2.0.</footer>",
+    );
+    s.push_str("</body></html>");
+    s
+}
+
+fn render_header(s: &mut String, r: &AnalysisResult) {
+    let points = r.invariants.points.len();
+    let reachable = r.reachable_from_exports.len();
+    let recursive = r.function_summaries.iter().filter(|f| f.recursive).count();
+    s.push_str("<section class=\"summary\"><h2>Summary</h2><dl>");
+    kv(s, "module sha256", &r.invariants.module_sha256);
+    kv(s, "schema", &r.invariants.schema);
+    kv(
+        s,
+        "worst-case shadow stack",
+        &stack_bound(&r.stack_usage.max_stack_bytes),
+    );
+    kv(
+        s,
+        "stack-pointer global",
+        &match r.stack_usage.sp_global {
+            Some(g) => format!("global {g}"),
+            None => "none (no shadow stack)".to_string(),
+        },
+    );
+    kv(
+        s,
+        "functions (summarized)",
+        &r.function_summaries.len().to_string(),
+    );
+    kv(s, "reachable from exports", &reachable.to_string());
+    kv(s, "recursive functions", &recursive.to_string());
+    kv(s, "call-graph edges", &r.call_graph.len().to_string());
+    kv(s, "diagnostics", &r.diagnostics.len().to_string());
+    kv(s, "program points", &points.to_string());
+    s.push_str("</dl></section>");
+}
+
+fn render_functions(s: &mut String, r: &AnalysisResult) {
+    s.push_str("<section><h2>Functions</h2>");
+    if r.function_summaries.is_empty() && r.stack_usage.functions.is_empty() {
+        s.push_str("<p class=\"empty\">No functions.</p></section>");
+        return;
+    }
+    s.push_str(
+        "<table><thead><tr><th>func</th><th>reachable</th><th>recursive</th>\
+         <th>params</th><th>frame</th><th>max stack</th></tr></thead><tbody>",
+    );
+    // Union of every function index we know something about, ascending.
+    let mut indices: Vec<u32> = r
+        .function_summaries
+        .iter()
+        .map(|f| f.func_index)
+        .chain(r.stack_usage.functions.iter().map(|f| f.func_index))
+        .collect();
+    indices.sort_unstable();
+    indices.dedup();
+    for idx in indices {
+        let summary = r.function_summaries.iter().find(|f| f.func_index == idx);
+        let stack: Option<&FunctionStack> =
+            r.stack_usage.functions.iter().find(|f| f.func_index == idx);
+        let reachable = r.reachable_from_exports.binary_search(&idx).is_ok();
+        let recursive = summary.map(|f| f.recursive).unwrap_or(false);
+        let params = summary
+            .map(|f| f.param_count.to_string())
+            .unwrap_or_else(|| "?".into());
+        let frame = stack
+            .map(|f| stack_bound(&f.frame))
+            .unwrap_or_else(|| "?".into());
+        let maxs = stack
+            .map(|f| stack_bound(&f.max_stack))
+            .unwrap_or_else(|| "?".into());
+        let _ = write!(
+            s,
+            "<tr><td>{idx}</td><td>{}</td><td>{}</td><td>{params}</td>\
+             <td>{frame}</td><td>{maxs}</td></tr>",
+            yesno(reachable),
+            yesno(recursive),
+        );
+    }
+    s.push_str("</tbody></table></section>");
+}
+
+fn render_call_graph(s: &mut String, edges: &[CallEdge]) {
+    s.push_str("<section><h2>Call graph</h2>");
+    if edges.is_empty() {
+        s.push_str("<p class=\"empty\">No call edges.</p></section>");
+        return;
+    }
+    s.push_str(
+        "<table><thead><tr><th>caller</th><th>pc</th><th>kind</th>\
+         <th>resolved targets</th><th>soundness</th></tr></thead><tbody>",
+    );
+    for e in edges {
+        let targets = if e.resolved_targets.is_empty() {
+            "(none)".to_string()
+        } else {
+            e.resolved_targets
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let sound = match e.soundness {
+            SoundnessTag::Sound => "<span class=\"ok\">sound</span>",
+            SoundnessTag::UnsoundFallback => "<span class=\"warn\">unsound-fallback</span>",
+        };
+        let _ = write!(
+            s,
+            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{sound}</td></tr>",
+            e.caller_func,
+            e.pc,
+            if e.indirect { "call_indirect" } else { "call" },
+            esc(&targets),
+        );
+    }
+    s.push_str("</tbody></table></section>");
+}
+
+fn render_diagnostics(s: &mut String, diags: &[Diagnostic]) {
+    s.push_str("<section><h2>Diagnostics</h2>");
+    if diags.is_empty() {
+        s.push_str("<p class=\"empty\">No diagnostics.</p></section>");
+        return;
+    }
+    s.push_str("<ul class=\"diags\">");
+    for d in diags {
+        let (cls, label) = match d.severity {
+            DiagnosticSeverity::Info => ("info", "info"),
+            DiagnosticSeverity::Warning => ("warn", "warning"),
+            DiagnosticSeverity::UnsoundnessFallback => ("err", "unsoundness-fallback"),
+        };
+        let _ = write!(
+            s,
+            "<li class=\"{cls}\"><span class=\"sev\">{label}</span> \
+             <code>fn{}:{}</code> {}</li>",
+            d.func_index,
+            d.pc,
+            esc(&d.message),
+        );
+    }
+    s.push_str("</ul></section>");
+}
+
+fn render_points(s: &mut String, points: &[ProgramPoint]) {
+    s.push_str("<section><h2>Program points</h2>");
+    if points.is_empty() {
+        s.push_str("<p class=\"empty\">No program points.</p></section>");
+        return;
+    }
+    s.push_str(
+        "<table><thead><tr><th>func</th><th>pc</th><th>locals</th>\
+         <th>operand stack (bottom → top)</th></tr></thead><tbody>",
+    );
+    for p in points {
+        let locals = if p.locals.is_empty() {
+            "(none)".to_string()
+        } else {
+            p.locals
+                .iter()
+                .map(|l| format!("L{}={}", l.local_index, abstract_value(&l.value)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        // FEAT-023: the abstract operand stack. Empty is shown as "(empty)" —
+        // the analyzer's honest "no operand-stack info here", not a claim that
+        // the concrete stack is empty.
+        let stack = if p.operand_stack.is_empty() {
+            "<span class=\"empty\">(empty)</span>".to_string()
+        } else {
+            p.operand_stack
+                .iter()
+                .map(abstract_value)
+                .collect::<Vec<_>>()
+                .join(" · ")
+        };
+        let _ = write!(
+            s,
+            "<tr><td>{}</td><td>{}</td><td><code>{}</code></td>\
+             <td><code>{}</code></td></tr>",
+            p.func_index,
+            p.pc,
+            esc(&locals),
+            stack,
+        );
+    }
+    s.push_str("</tbody></table></section>");
+}
+
+// ── value formatting ─────────────────────────────────────────────────────
+
+/// Render an [`AbstractValue`] compactly. A singleton interval `[n,n]` shows as
+/// `n` (a known constant); a wider interval as `[lo,hi]`.
+fn abstract_value(v: &AbstractValue) -> String {
+    match v {
+        AbstractValue::I32Interval(iv) => format!("i32 {}", interval(iv)),
+        AbstractValue::I64Interval(iv) => format!("i64 {}", interval(iv)),
+        AbstractValue::RegionPointer(Region { region_id, offset }) => {
+            format!("region#{region_id}+{}", interval(offset))
+        }
+        AbstractValue::Unknown => "⊤".to_string(),
+    }
+}
+
+fn interval(iv: &Interval) -> String {
+    if iv.lo == iv.hi {
+        iv.lo.to_string()
+    } else {
+        format!("[{}, {}]", iv.lo, iv.hi)
+    }
+}
+
+fn stack_bound(b: &StackBound) -> String {
+    match b {
+        StackBound::Bytes(n) => format!("{n} bytes"),
+        StackBound::Unbounded => "unbounded".to_string(),
+        StackBound::Unknown => "unknown".to_string(),
+    }
+}
+
+fn yesno(b: bool) -> &'static str {
+    if b {
+        "<span class=\"ok\">yes</span>"
+    } else {
+        "<span class=\"muted\">no</span>"
+    }
+}
+
+fn kv(s: &mut String, k: &str, v: &str) {
+    let _ = write!(s, "<dt>{}</dt><dd>{}</dd>", esc(k), esc(v));
+}
+
+/// Minimal HTML-text escaping for the few attacker-influenced strings we render
+/// (diagnostic messages, schema URL). Covers the five significant characters.
+fn esc(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for c in raw.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+const DOCTYPE_AND_HEAD_OPEN: &str = "<!DOCTYPE html><html lang=\"en\"><head>\
+    <meta charset=\"utf-8\"><meta name=\"viewport\" \
+    content=\"width=device-width, initial-scale=1\">";
+
+const STYLE: &str = "<style>\
+    :root{--fg:#1a1a1a;--muted:#777;--ok:#0a7d33;--warn:#b35900;--err:#b00020;\
+    --line:#e0e0e0;--bg:#fff;--code:#f4f4f6}\
+    body{font:14px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;\
+    color:var(--fg);background:var(--bg);margin:0 auto;max-width:1100px;padding:24px}\
+    h1{font-size:22px}h2{font-size:17px;margin-top:32px;border-bottom:2px solid var(--line);\
+    padding-bottom:4px}\
+    table{border-collapse:collapse;width:100%;margin:8px 0;font-size:13px}\
+    th,td{text-align:left;padding:5px 9px;border-bottom:1px solid var(--line);vertical-align:top}\
+    th{background:#fafafa;font-weight:600}\
+    code{background:var(--code);padding:1px 4px;border-radius:3px;font-size:12px}\
+    dl{display:grid;grid-template-columns:max-content 1fr;gap:2px 16px;margin:8px 0}\
+    dt{color:var(--muted)}dd{margin:0;font-variant-numeric:tabular-nums}\
+    .ok{color:var(--ok);font-weight:600}.warn{color:var(--warn);font-weight:600}\
+    .err{color:var(--err);font-weight:600}.muted,.empty{color:var(--muted)}\
+    .diags{list-style:none;padding:0}.diags li{padding:4px 0;border-bottom:1px solid var(--line)}\
+    .sev{font-size:11px;text-transform:uppercase;font-weight:700;margin-right:6px}\
+    .info .sev{color:var(--muted)}.warn .sev{color:var(--warn)}.err .sev{color:var(--err)}\
+    footer{margin-top:40px;color:var(--muted);font-size:12px}\
+    </style>";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scry_analyze_core::{AnalysisConfig, analyze};
+
+    fn analyze_wat(src: &str) -> AnalysisResult {
+        let bytes = wat::parse_str(src).expect("assemble wat");
+        analyze(bytes, AnalysisConfig::default()).expect("analyze")
+    }
+
+    #[test]
+    fn renders_operand_stack_constants() {
+        // The FEAT-023 showcase: a known constant on the operand stack must
+        // appear verbatim in the rendered page.
+        let r = analyze_wat(
+            "(module (func (export \"run\") (result i32) \
+             i32.const 42 i32.const 7 i32.add))",
+        );
+        let html = render_html(&r, "demo");
+        assert!(html.starts_with("<!DOCTYPE html>"), "is an HTML document");
+        assert!(html.contains("Program points"), "has the points section");
+        // The singleton constants from the operand stack are projected verbatim.
+        assert!(
+            html.contains("operand stack"),
+            "labels the operand-stack column"
+        );
+        assert!(
+            html.contains("i32 42"),
+            "the constant 42 appears on the stack"
+        );
+        assert!(
+            html.contains("i32 49"),
+            "the i32.add result 49 appears on the stack"
+        );
+    }
+
+    #[test]
+    fn renders_empty_operand_stack_honestly() {
+        // `local.get 0; local.set 0` drains the stack, so the point emitted
+        // after `local.set` has an empty operand stack — it must render as
+        // "(empty)", not be silently dropped or mislabelled.
+        let r = analyze_wat(
+            "(module (func (export \"run\") (param i32) \
+             local.get 0 local.set 0))",
+        );
+        let html = render_html(&r, "drain");
+        assert!(
+            html.contains("(empty)"),
+            "empty operand stack rendered honestly"
+        );
+    }
+
+    #[test]
+    fn escapes_untrusted_text() {
+        // Diagnostic/schema strings must be HTML-escaped, never injected raw.
+        let r = analyze_wat("(module (func (export \"run\") nop))");
+        let html = render_html(&r, "<script>alert(1)</script>");
+        assert!(
+            !html.contains("<script>alert(1)</script>"),
+            "title is escaped"
+        );
+        assert!(html.contains("&lt;script&gt;"), "escaped form present");
+    }
+
+    #[test]
+    fn no_panic_on_empty_module() {
+        let r = analyze_wat("(module)");
+        let html = render_html(&r, "empty");
+        assert!(html.contains("No functions.") || html.contains("Functions"));
+        assert!(html.ends_with("</html>"));
+    }
+}

--- a/crates/scry-viz/src/main.rs
+++ b/crates/scry-viz/src/main.rs
@@ -1,0 +1,113 @@
+//! `scry-viz` CLI — analyze a Core Wasm module and write a static HTML page.
+//!
+//! ```text
+//! scry-viz <input.wasm|input.wat> [-o output.html] [--title NAME]
+//! ```
+//!
+//! Accepts either a binary `.wasm` module or a `.wat` text module (assembled
+//! in-process). With no `-o`, writes `<input-stem>.html` next to the input.
+//! Exit codes: 0 ok, 2 usage error, 3 analysis error, 4 I/O error.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use scry_analyze_core::{AnalysisConfig, analyze};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match run(&args) {
+        Ok(out) => {
+            eprintln!("scry-viz: wrote {}", out.display());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("scry-viz: {}", e.msg);
+            ExitCode::from(e.code)
+        }
+    }
+}
+
+struct CliError {
+    msg: String,
+    code: u8,
+}
+
+fn err(code: u8, msg: impl Into<String>) -> CliError {
+    CliError {
+        msg: msg.into(),
+        code,
+    }
+}
+
+fn run(args: &[String]) -> Result<PathBuf, CliError> {
+    let mut input: Option<PathBuf> = None;
+    let mut output: Option<PathBuf> = None;
+    let mut title: Option<String> = None;
+
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "-h" | "--help" => {
+                return Err(err(
+                    2,
+                    "usage: scry-viz <input.wasm|input.wat> [-o output.html] [--title NAME]",
+                ));
+            }
+            "-o" | "--output" => {
+                output = Some(PathBuf::from(
+                    it.next().ok_or_else(|| err(2, "-o needs a path"))?,
+                ));
+            }
+            "--title" => {
+                title = Some(
+                    it.next()
+                        .ok_or_else(|| err(2, "--title needs a value"))?
+                        .clone(),
+                );
+            }
+            other if other.starts_with('-') => {
+                return Err(err(2, format!("unknown flag: {other}")));
+            }
+            other => {
+                if input.is_some() {
+                    return Err(err(2, "more than one input given"));
+                }
+                input = Some(PathBuf::from(other));
+            }
+        }
+    }
+
+    let input = input.ok_or_else(|| err(2, "no input module given (see --help)"))?;
+    let bytes = read_module(&input)?;
+    let title = title.unwrap_or_else(|| {
+        input
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "module".to_string())
+    });
+
+    let result = analyze(
+        bytes,
+        AnalysisConfig {
+            emit_diagnostics: true,
+            ..Default::default()
+        },
+    )
+    .map_err(|e| err(3, format!("analysis failed: {e:?}")))?;
+
+    let html = scry_viz::render_html(&result, &title);
+    let out = output.unwrap_or_else(|| input.with_extension("html"));
+    std::fs::write(&out, html).map_err(|e| err(4, format!("writing {}: {e}", out.display())))?;
+    Ok(out)
+}
+
+/// Read a module, assembling `.wat`/`.wast` text to bytes; otherwise treat the
+/// file as raw `.wasm`.
+fn read_module(path: &Path) -> Result<Vec<u8>, CliError> {
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    if ext == "wat" || ext == "wast" {
+        wat::parse_file(path).map_err(|e| err(4, format!("assembling {}: {e}", path.display())))
+    } else {
+        std::fs::read(path).map_err(|e| err(4, format!("reading {}: {e}", path.display())))
+    }
+}

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -42,8 +42,11 @@ const CRATES_TO_PUBLISH: &[(&str, &str)] = &[
     ("scry-taint", "scry-sai-taint"),
     ("scry-octagon", "scry-sai-octagon"),
     ("scry-provenance", "scry-sai-provenance"),
-    // Depends on all four leaves — publish last.
+    // Depends on all four leaves — publish before its own consumers.
     ("scry-analyze-core", "scry-sai-core"),
+    // Depends on scry-sai-core — publish last. The `scry-viz` binary/library
+    // (FEAT-024) consumes the analyzer library to render an AnalysisResult.
+    ("scry-viz", "scry-sai-viz"),
 ];
 
 struct Krate {


### PR DESCRIPTION
## What

Two connected pieces, requested in the same breath ("rolled out ourselves to have in our tests, and … the visualization and how this would work"):

### FEAT-024 — `scry-viz` (the visualization)
A new `std` crate **`scry-sai-viz`** (library `scry_viz` + binary `scry-viz`) that turns a scry `AnalysisResult` into a **single self-contained HTML page** — no server, no JavaScript, no external assets. The analyzer's own analogue of the witness-viz MC/DC static site. Consumes `scry-sai-core` as a library (plain-Rust types; no WIT/component/wasmtime).

Renders: a **summary** (module SHA-256, schema, worst-case shadow-stack bound, counts); a **functions** table (reachable-from-exports? · recursive? · params · frame · max stack); the **call graph** (caller · pc · direct/indirect · resolved targets · soundness tag); **diagnostics**; and the **per-program-point invariants** — `locals` AND the FEAT-023 **operand stack** (bottom → top). A singleton interval renders as a bare constant, the full domain as `⊤`, an empty operand stack as an explicit `(empty)`.

```
scry-viz module.wasm                 # writes module.html
scry-viz module.wat -o report.html   # .wat assembled in-process
```

### FEAT-025 — self-analysis dogfood
A CI step (in the existing MC/DC job, which already builds `scry_mcdc.wasm`) runs `scry-viz` on scry's **own** compiled module and uploads the **`scry-self-analysis`** HTML artifact. "scry visualizing scry." It is also a **robustness oracle** — a panic or error analyzing a real, large, compiler-emitted module turns the build red, where the tiny fixtures cannot reach.

Verified locally: **548 functions · 423 call edges · 4326 program points · no panic** (2.2 MB page).

## Soundness posture (REQ-013)

`scry-viz` is a **faithful rendering** — it re-derives nothing and asserts nothing beyond what the `AnalysisResult` already states. Each value shown is a verbatim projection of an analyzer field; an empty operand-stack renders as `(empty)` (the analyzer's honest "no info"), never a claim the concrete stack is empty. Attacker-influenced strings (diagnostic messages, schema URL, module name) are HTML-escaped.

## Traceability + tests

- rivet: **REQ-013** + **FEAT-024** (`satisfies`, `depends-on` FEAT-023) + **FEAT-025** (`depends-on` FEAT-024). `rivet validate` PASS (0 warnings).
- 4 native lib tests: constant on stack shown verbatim; empty stack shown `(empty)`; untrusted text HTML-escaped; no panic on empty module.
- Published to crates.io: `scry-sai-viz` wired LAST in `scripts/publish.rs` (after `scry-sai-core`, its dep).
- Lockstep version bump 1.13.0 → **1.14.0**; CHANGELOG with falsification statement.

## Falsification statement

If `scry-viz` displays a value that is not a verbatim projection of an `AnalysisResult` field — i.e. it re-derives, rounds, or over-states any analyzer output — this release's faithful-rendering claim is false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)