### PR TITLE
v1.16.0 (FEAT-027): human-readable function names + structure in output & dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.16.0] — 2026-06-21
+
+Headline: **human-readable function names + structure in the analysis output
+and the dashboard (FEAT-027).** `func 42` becomes `$compute` / `"run"` /
+`env.malloc`, and the dashboard groups invariants by function with cross-links.
+
+### Added — FEAT-027 (REQ-013)
+
+- **Core (`scry-sai-core`):** `AnalysisResult.function_meta: Vec<FunctionMeta>`
+  — one entry per function index (imports + defined, sorted), each with a
+  best-effort `name` (resolved **custom `name` section → export name → import
+  `module.field` → `None`**), an `imported` flag, and `exports` names. Parsed
+  from the wasm `name` custom section (best-effort; malformed entries skipped)
+  plus the import/export sections. A library win for any consumer (synth's
+  footprint report reads `$compute`, not `func 42`). Library-only — the WIT
+  mirror is unchanged; the wasm wrapper ignores the field.
+- **Viz (`scry-sai-viz`):** the Functions table gains **name** + **kind badges**
+  (import / `export "run"` / defined) + a per-function **program-point count**;
+  rows are anchored. The **call graph** resolves caller/target indices to named
+  links (`1 compute → 2 helper`) that jump to the function's row. **Program
+  points are grouped into per-function anchored subsections** ("where they
+  sit") instead of one flat table. All names are HTML-escaped.
+
+### Posture
+
+- Additive 1.x field (SemVer-compatible). The viz remains a faithful rendering;
+  names are a verbatim projection of the `name`/export/import sections, never
+  inferred.
+
 ## [1.15.0] — 2026-06-21
 
 Headline: **the scry verification dashboard is published to GitHub Pages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1842,14 +1842,14 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-core"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "scry-sai-interval",
  "scry-sai-octagon",
@@ -1862,11 +1862,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "1.15.0"
+version = "1.16.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1875,19 +1875,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "1.15.0"
+version = "1.16.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "1.15.0"
+version = "1.16.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "1.15.0"
+version = "1.16.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "scry-sai-core",
  "wat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "1.15.0"
+version = "1.16.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -1397,6 +1397,43 @@ artifacts:
       - type: traces-to
         target: G-005
 
+  - id: FEAT-027
+    type: feature
+    title: "v1.x — Human-readable function metadata (names + kind) on AnalysisResult, surfaced in scry-viz"
+    status: proposed
+    description: >
+      Resolve every function index to human-readable metadata so consumers can
+      show `$compute` instead of `func 1`. A library capability (helps synth's
+      footprint report too), surfaced in the visualization (FEAT-024).
+
+      Core (`scry-sai-core`): an additive `AnalysisResult.function_meta:
+      Vec<FunctionMeta>` (one per index, imports + defined, sorted). Each
+      `FunctionMeta` carries a best-effort `name` resolved in priority order —
+      custom `name` section → export name → import `module.field` → `None` — an
+      `imported` flag, and the `exports` names. Parsed from the `name` custom
+      section (best-effort; malformed entries skipped) plus the import/export
+      sections already read. Library-only (no WIT mirror change).
+
+      Viz rework (`scry-viz`): the Functions table gains name + kind badges
+      (import / export "x" / defined) + a per-function program-point count;
+      rows are anchored. The call graph resolves caller/target indices to named
+      links (`1 compute → 2 helper`). The program points are grouped into
+      per-function anchored subsections ("where they sit") instead of one flat
+      table. Names are HTML-escaped like all other untrusted text.
+    tags: [capability, visualization, interop, readability, v1.x]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given a module with a name section / exports / imports, When scry analyzes it, Then AnalysisResult.function_meta has one entry per function index (imports + defined, sorted) whose name resolves in priority order name-section → export → import, with imported flag and export names; a module with none yields name = None."
+        - "Given that metadata, When scry-viz renders it, Then function rows show the name + kind badges, the call graph shows named links to anchored function rows, and program points are grouped per function — and every rendered name is HTML-escaped."
+    links:
+      - type: satisfies
+        target: REQ-013
+      - type: depends-on
+        target: FEAT-024
+      - type: traces-to
+        target: G-005
+
   # ──────────────────────────────────────────────────────────────────────
   # Safety goal for the v2.0 qualification milestone.
   # ──────────────────────────────────────────────────────────────────────

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "1.15.0" }
+scry-sai-interval = { path = "../scry-interval", version = "1.16.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,14 +43,14 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "1.15.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "1.15.0" }
+scry-sai-taint = { path = "../scry-taint", version = "1.16.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "1.16.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "1.15.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "1.16.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -313,6 +313,29 @@ pub struct AnalysisResult {
     /// downstream consumer can soundly prune what is absent (REQ-011/SCRY-001).
     /// Sorted ascending. Core-only for now (slice-1b surfaces it in WIT).
     pub reachable_from_exports: Vec<u32>,
+    /// FEAT-027: human-readable metadata for every function index (imports +
+    /// defined), sorted by `func_index`. Names come from the custom `name`
+    /// section, else an export name, else an import `module.field`; `None`
+    /// when the module carries none (consumers fall back to the index). Lets a
+    /// consumer (synth's footprint report, scry-viz) show `$compute_stack` in
+    /// place of `func 42`. Library-only addition (not in the WIT mirror).
+    pub function_meta: Vec<FunctionMeta>,
+}
+
+/// FEAT-027: human-readable metadata for one function index.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FunctionMeta {
+    /// Absolute function index (imports occupy the low indices, then defined).
+    pub func_index: u32,
+    /// Best human-readable name, in priority order: custom `name` section →
+    /// first export name → import `module.field`. `None` when the module
+    /// carries no name for this index (fall back to the index).
+    pub name: Option<String>,
+    /// True when this index is an imported function.
+    pub imported: bool,
+    /// Export names for this function (empty when not exported). A function may
+    /// be exported under several names.
+    pub exports: Vec<String>,
 }
 
 /// Mirror of WIT `analyze-error`. Reasons an analyze call fails without a
@@ -385,7 +408,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "1.15.0";
+const SCRY_VERSION: &str = "1.16.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).
@@ -820,6 +843,17 @@ pub fn analyze(
     let mut exported_funcs: Vec<u32> = Vec::new();
     let mut start_func: Option<u32> = None;
 
+    // ── FEAT-027 human-readable function metadata ────────────────
+    // Names from three sources, resolved later in priority order:
+    // the custom `name` section (canonical debug names), else an
+    // export name, else an import "module.field". `import_func_meta`
+    // is indexed by import order (absolute index == position, since
+    // imports occupy the low indices); `export_names`/`name_section`
+    // are (abs-index, name) pairs.
+    let mut import_func_meta: Vec<String> = Vec::new();
+    let mut export_names: Vec<(u32, String)> = Vec::new();
+    let mut name_section: Vec<(u32, String)> = Vec::new();
+
     // ── FEAT-006 function-table state ────────────────────────────
     // The declared length of table index 0 (the funcref table a
     // `call_indirect` dispatches through). `table0_len` is the
@@ -882,6 +916,9 @@ pub fn analyze(
                         .map_err(|e| AnalyzeError::InvalidModule(format!("import section: {e}")))?;
                     if matches!(imp.ty, wasmparser::TypeRef::Func(_)) {
                         import_func_count = import_func_count.saturating_add(1);
+                        // FEAT-027: imported funcs occupy the low indices in
+                        // import order; record "module.field" as a fallback name.
+                        import_func_meta.push(alloc::format!("{}.{}", imp.module, imp.name));
                     }
                 }
             }
@@ -901,6 +938,8 @@ pub fn analyze(
                     })?;
                     if matches!(ex.kind, wasmparser::ExternalKind::Func) {
                         exported_funcs.push(ex.index);
+                        // FEAT-027: keep the export name for readable metadata.
+                        export_names.push((ex.index, alloc::string::String::from(ex.name)));
                     }
                 }
             }
@@ -1065,6 +1104,25 @@ pub fn analyze(
                         }
                     }
                 }
+            // FEAT-027: the standard `name` custom section maps function
+            // indices to human-readable names. Best-effort — a malformed
+            // entry is skipped, never an error (debug info is advisory).
+            Payload::CustomSection(reader) if reader.name() == "name" => {
+                let names = wasmparser::NameSectionReader::new(wasmparser::BinaryReader::new(
+                    reader.data(),
+                    reader.data_offset(),
+                ));
+                for subsection in names {
+                    let Ok(subsection) = subsection else { break };
+                    if let wasmparser::Name::Function(map) = subsection {
+                        for naming in map {
+                            let Ok(naming) = naming else { break };
+                            name_section
+                                .push((naming.index, alloc::string::String::from(naming.name)));
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -1449,6 +1507,14 @@ pub fn analyze(
         start_func,
     );
 
+    let function_meta = build_function_meta(
+        import_func_count,
+        function_type_indices.len() as u32,
+        &import_func_meta,
+        &export_names,
+        &name_section,
+    );
+
     Ok(AnalysisResult {
         invariants,
         diagnostics,
@@ -1458,7 +1524,50 @@ pub fn analyze(
         taint_findings,
         stack_usage,
         reachable_from_exports,
+        function_meta,
     })
+}
+
+/// FEAT-027: assemble per-function human-readable metadata for every index
+/// (imports + defined). Name priority: custom `name` section → first export
+/// name → import `module.field` → `None`.
+fn build_function_meta(
+    import_func_count: u32,
+    defined_func_count: u32,
+    import_func_meta: &[String],
+    export_names: &[(u32, String)],
+    name_section: &[(u32, String)],
+) -> Vec<FunctionMeta> {
+    let total = import_func_count.saturating_add(defined_func_count);
+    let mut out = Vec::with_capacity(total as usize);
+    for idx in 0..total {
+        let imported = idx < import_func_count;
+        let exports: Vec<String> = export_names
+            .iter()
+            .filter(|(i, _)| *i == idx)
+            .map(|(_, n)| n.clone())
+            .collect();
+        // Priority: name section → export name → import "module.field".
+        let name = name_section
+            .iter()
+            .find(|(i, _)| *i == idx)
+            .map(|(_, n)| n.clone())
+            .or_else(|| exports.first().cloned())
+            .or_else(|| {
+                if imported {
+                    import_func_meta.get(idx as usize).cloned()
+                } else {
+                    None
+                }
+            });
+        out.push(FunctionMeta {
+            func_index: idx,
+            name,
+            imported,
+            exports,
+        });
+    }
+    out
 }
 enum StepOutcome {
     Continue,
@@ -4357,6 +4466,7 @@ mod tests {
                 max_stack_bytes: StackBound::Bytes(0),
             },
             reachable_from_exports: alloc::vec![],
+            function_meta: alloc::vec![],
         };
         assert_eq!(res.invariants.points.len(), 1);
         assert!(matches!(rp, AbstractValue::RegionPointer(_)));
@@ -4756,6 +4866,69 @@ mod tests {
             saw_depth2,
             "after the second const the stack is [42, 7] bottom → top"
         );
+    }
+
+    /// FEAT-027: every function index resolves to human-readable metadata —
+    /// name (custom `name` section → export → import), imported flag, and
+    /// export names — so a consumer can show `$compute` for `func 1`.
+    #[test]
+    fn feat027_function_meta_names() {
+        let res = analyze_fixture("fixture-19-named-functions.wat");
+        let meta = &res.function_meta;
+        assert_eq!(
+            meta.len(),
+            3,
+            "one entry per function index (1 import + 2 defined)"
+        );
+
+        // func 0: imported $log. The name section name wins over the
+        // "env.log" import fallback.
+        assert_eq!(meta[0].func_index, 0);
+        assert!(meta[0].imported, "func 0 is imported");
+        assert_eq!(meta[0].name.as_deref(), Some("log"));
+        assert!(meta[0].exports.is_empty());
+
+        // func 1: defined $compute, exported "run".
+        assert!(!meta[1].imported, "func 1 is defined");
+        assert_eq!(meta[1].name.as_deref(), Some("compute"));
+        assert!(
+            meta[1].exports.iter().any(|e| e == "run"),
+            "func 1 is exported as \"run\""
+        );
+
+        // func 2: defined $helper, not exported.
+        assert!(!meta[2].imported);
+        assert_eq!(meta[2].name.as_deref(), Some("helper"));
+        assert!(meta[2].exports.is_empty());
+
+        // Sorted by func_index, one entry per index, no gaps.
+        for (i, m) in meta.iter().enumerate() {
+            assert_eq!(
+                m.func_index as usize, i,
+                "function_meta is index-ordered, gapless"
+            );
+        }
+    }
+
+    /// FEAT-027: a module with no name section, no exports, and no imports
+    /// yields metadata with `None` names — consumers fall back to the index.
+    #[test]
+    fn feat027_no_names_is_none() {
+        // wat emits a name section from `$id`s, so use a numerically-indexed
+        // module with no symbolic names / exports / imports.
+        let bytes = wat::parse_str("(module (func nop))").expect("assemble");
+        let res = analyze(
+            bytes,
+            AnalysisConfig {
+                widening_threshold: Some(3),
+                emit_diagnostics: true,
+                taint_policy: None,
+            },
+        )
+        .expect("analyze");
+        assert_eq!(res.function_meta.len(), 1);
+        assert_eq!(res.function_meta[0].name, None, "no name source → None");
+        assert!(!res.function_meta[0].imported);
     }
 
     /// FEAT-021 slice-2b: the self-measuring fixture (two mutable i32 globals:

--- a/crates/scry-analyzer/test-fixtures/fixture-19-named-functions.wat
+++ b/crates/scry-analyzer/test-fixtures/fixture-19-named-functions.wat
@@ -1,0 +1,24 @@
+;; fixture-19-named-functions — FEAT-027 (human-readable function metadata).
+;;
+;; A consumer (synth's footprint report, scry-viz) wants to show `$compute`
+;; instead of `func 1`. scry resolves a name for every function index from
+;; three sources, in priority order: the custom `name` section (the symbolic
+;; `$id`s below assemble into one), else an export name, else an import
+;; `module.field`.
+;;
+;;   func 0  $log     imported  → name "log"      (name section; import "env.log" is the fallback)
+;;   func 1  $compute defined   → name "compute", exported "run"
+;;   func 2  $helper  defined   → name "helper"   (called by $compute)
+;;
+;; So function_meta = [
+;;   {0, name:"log",     imported:true,  exports:[]},
+;;   {1, name:"compute", imported:false, exports:["run"]},
+;;   {2, name:"helper",  imported:false, exports:[]},
+;; ]
+(module
+  (import "env" "log" (func $log (param i32)))
+  (func $compute (export "run") (result i32)
+    call $helper
+    i32.const 7)
+  (func $helper
+    nop))

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "1.15.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "1.16.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }

--- a/crates/scry-viz/README.md
+++ b/crates/scry-viz/README.md
@@ -16,15 +16,19 @@ assets) with:
 
 - **Summary** — module SHA-256, schema, worst-case shadow-stack bound,
   stack-pointer global, and headline counts.
-- **Functions** — per function: reachable-from-exports? · recursive? · params ·
-  shadow-stack frame · worst-case stack.
-- **Call graph** — caller · pc · `call`/`call_indirect` · resolved target set ·
-  soundness tag.
+- **Functions** — per function: **name** (resolved from the wasm `name`
+  section / export / import) · **kind** badges (import · `export "run"` ·
+  defined) · reachable-from-exports? · recursive? · params · shadow-stack
+  frame · worst-case stack · program-point count. Rows are anchored.
+- **Call graph** — caller · pc · `call`/`call_indirect` · resolved targets ·
+  soundness tag. Caller and targets are **named links** (`1 compute →
+  2 helper`) that jump to the function's row.
 - **Diagnostics** — severity · `fn:pc` · message.
-- **Program points** — for each visited `(func, pc)`, the abstract `locals`
-  *and* the abstract **operand stack** (bottom → top). A singleton interval
-  shows as a bare constant (`i32 42`), the full domain as `⊤`, and an empty
-  operand stack as an explicit `(empty)`.
+- **Program points** — **grouped per function** under an anchored heading
+  (`func 1 · compute`): for each visited `pc`, the abstract `locals` *and* the
+  abstract **operand stack** (bottom → top). A singleton interval shows as a
+  bare constant (`i32 42`), the full domain as `⊤`, and an empty operand stack
+  as an explicit `(empty)`.
 
 ## Usage
 

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -30,9 +30,45 @@
 use core::fmt::Write as _;
 
 use scry_analyze_core::{
-    AbstractValue, AnalysisResult, CallEdge, Diagnostic, DiagnosticSeverity, FunctionStack,
-    Interval, ProgramPoint, Region, SoundnessTag, StackBound,
+    AbstractValue, AnalysisResult, Diagnostic, DiagnosticSeverity, FunctionMeta, FunctionStack,
+    Interval, Region, SoundnessTag, StackBound,
 };
+
+/// FEAT-027: metadata for one function index, if scry resolved any.
+fn fn_meta(r: &AnalysisResult, idx: u32) -> Option<&FunctionMeta> {
+    r.function_meta.iter().find(|m| m.func_index == idx)
+}
+
+/// A function reference as a link to its row in the Functions table, showing
+/// the resolved name when there is one: `42 $compute` (or just `42`).
+fn fn_link(r: &AnalysisResult, idx: u32) -> String {
+    match fn_meta(r, idx).and_then(|m| m.name.as_deref()) {
+        Some(n) => format!("<a href=\"#fn-{idx}\">{idx} <code>{}</code></a>", esc(n)),
+        None => format!("<a href=\"#fn-{idx}\">{idx}</a>"),
+    }
+}
+
+/// Kind badges for a function: `import`, `export "run"` (one per export), or a
+/// muted `defined` when neither.
+fn kind_badges(m: Option<&FunctionMeta>) -> String {
+    let mut out = String::new();
+    if let Some(m) = m {
+        if m.imported {
+            out.push_str("<span class=\"badge import\">import</span> ");
+        }
+        for ex in &m.exports {
+            let _ = write!(
+                out,
+                "<span class=\"badge export\">export \"{}\"</span> ",
+                esc(ex)
+            );
+        }
+    }
+    if out.is_empty() {
+        out.push_str("<span class=\"muted\">defined</span>");
+    }
+    out
+}
 
 /// Render a complete, self-contained HTML document for `result`.
 ///
@@ -49,9 +85,9 @@ pub fn render_html(result: &AnalysisResult, title: &str) -> String {
     let _ = write!(s, "<h1>scry analysis — {}</h1>", esc(title));
     render_header(&mut s, result);
     render_functions(&mut s, result);
-    render_call_graph(&mut s, &result.call_graph);
+    render_call_graph(&mut s, result);
     render_diagnostics(&mut s, &result.diagnostics);
-    render_points(&mut s, &result.invariants.points);
+    render_points(&mut s, result);
 
     s.push_str(
         "<footer>Rendered by scry-viz · a faithful projection of the \
@@ -146,13 +182,17 @@ fn render_header(s: &mut String, r: &AnalysisResult) {
 
 fn render_functions(s: &mut String, r: &AnalysisResult) {
     s.push_str("<section><h2>Functions</h2>");
-    if r.function_summaries.is_empty() && r.stack_usage.functions.is_empty() {
+    if r.function_summaries.is_empty()
+        && r.stack_usage.functions.is_empty()
+        && r.function_meta.is_empty()
+    {
         s.push_str("<p class=\"empty\">No functions.</p></section>");
         return;
     }
     s.push_str(
-        "<table><thead><tr><th>func</th><th>reachable</th><th>recursive</th>\
-         <th>params</th><th>frame</th><th>max stack</th></tr></thead><tbody>",
+        "<table><thead><tr><th>func</th><th>name</th><th>kind</th><th>reachable</th>\
+         <th>recursive</th><th>params</th><th>frame</th><th>max stack</th><th>points</th>\
+         </tr></thead><tbody>",
     );
     // The `reachable` column reads `reachable_from_exports` via binary_search,
     // which is only correct if that vector is sorted ascending — which scry's
@@ -164,16 +204,19 @@ fn render_functions(s: &mut String, r: &AnalysisResult) {
         r.reachable_from_exports.is_sorted(),
         "reachable_from_exports must be sorted ascending for binary_search"
     );
-    // Union of every function index we know something about, ascending.
+    // Union of every function index we know something about (FEAT-027 metadata
+    // covers imports too, which have no summary/stack entry), ascending.
     let mut indices: Vec<u32> = r
         .function_summaries
         .iter()
         .map(|f| f.func_index)
         .chain(r.stack_usage.functions.iter().map(|f| f.func_index))
+        .chain(r.function_meta.iter().map(|m| m.func_index))
         .collect();
     indices.sort_unstable();
     indices.dedup();
     for idx in indices {
+        let meta = fn_meta(r, idx);
         let summary = r.function_summaries.iter().find(|f| f.func_index == idx);
         let stack: Option<&FunctionStack> =
             r.stack_usage.functions.iter().find(|f| f.func_index == idx);
@@ -188,10 +231,26 @@ fn render_functions(s: &mut String, r: &AnalysisResult) {
         let maxs = stack
             .map(|f| stack_bound(&f.max_stack))
             .unwrap_or_else(|| "?".into());
+        let name = match meta.and_then(|m| m.name.as_deref()) {
+            Some(n) => format!("<code>{}</code>", esc(n)),
+            None => "<span class=\"muted\">—</span>".to_string(),
+        };
+        let n_points = r
+            .invariants
+            .points
+            .iter()
+            .filter(|p| p.func_index == idx)
+            .count();
+        let points_cell = if n_points > 0 {
+            format!("<a href=\"#pts-{idx}\">{n_points}</a>")
+        } else {
+            "<span class=\"muted\">0</span>".to_string()
+        };
         let _ = write!(
             s,
-            "<tr><td>{idx}</td><td>{}</td><td>{}</td><td>{params}</td>\
-             <td>{frame}</td><td>{maxs}</td></tr>",
+            "<tr id=\"fn-{idx}\"><td>{idx}</td><td>{name}</td><td>{}</td><td>{}</td>\
+             <td>{}</td><td>{params}</td><td>{frame}</td><td>{maxs}</td><td>{points_cell}</td></tr>",
+            kind_badges(meta),
             yesno(reachable),
             yesno(recursive),
         );
@@ -199,9 +258,9 @@ fn render_functions(s: &mut String, r: &AnalysisResult) {
     s.push_str("</tbody></table></section>");
 }
 
-fn render_call_graph(s: &mut String, edges: &[CallEdge]) {
+fn render_call_graph(s: &mut String, r: &AnalysisResult) {
     s.push_str("<section><h2>Call graph</h2>");
-    if edges.is_empty() {
+    if r.call_graph.is_empty() {
         s.push_str("<p class=\"empty\">No call edges.</p></section>");
         return;
     }
@@ -209,13 +268,15 @@ fn render_call_graph(s: &mut String, edges: &[CallEdge]) {
         "<table><thead><tr><th>caller</th><th>pc</th><th>kind</th>\
          <th>resolved targets</th><th>soundness</th></tr></thead><tbody>",
     );
-    for e in edges {
+    for e in &r.call_graph {
+        // FEAT-027: resolve caller + target indices to named links so an edge
+        // reads `1 $compute → 2 $helper`, and each end jumps to its row.
         let targets = if e.resolved_targets.is_empty() {
-            "(none)".to_string()
+            "<span class=\"muted\">(none)</span>".to_string()
         } else {
             e.resolved_targets
                 .iter()
-                .map(u32::to_string)
+                .map(|t| fn_link(r, *t))
                 .collect::<Vec<_>>()
                 .join(", ")
         };
@@ -225,11 +286,10 @@ fn render_call_graph(s: &mut String, edges: &[CallEdge]) {
         };
         let _ = write!(
             s,
-            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{sound}</td></tr>",
-            e.caller_func,
+            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{targets}</td><td>{sound}</td></tr>",
+            fn_link(r, e.caller_func),
             e.pc,
             if e.indirect { "call_indirect" } else { "call" },
-            esc(&targets),
         );
     }
     s.push_str("</tbody></table></section>");
@@ -260,49 +320,66 @@ fn render_diagnostics(s: &mut String, diags: &[Diagnostic]) {
     s.push_str("</ul></section>");
 }
 
-fn render_points(s: &mut String, points: &[ProgramPoint]) {
+fn render_points(s: &mut String, r: &AnalysisResult) {
+    let points = &r.invariants.points;
     s.push_str("<section><h2>Program points</h2>");
     if points.is_empty() {
         s.push_str("<p class=\"empty\">No program points.</p></section>");
         return;
     }
-    s.push_str(
-        "<table><thead><tr><th>func</th><th>pc</th><th>locals</th>\
-         <th>operand stack (bottom → top)</th></tr></thead><tbody>",
-    );
-    for p in points {
-        let locals = if p.locals.is_empty() {
-            "(none)".to_string()
-        } else {
-            p.locals
-                .iter()
-                .map(|l| format!("L{}={}", l.local_index, abstract_value(&l.value)))
-                .collect::<Vec<_>>()
-                .join(", ")
-        };
-        // FEAT-023: the abstract operand stack. Empty is shown as "(empty)" —
-        // the analyzer's honest "no operand-stack info here", not a claim that
-        // the concrete stack is empty.
-        let stack = if p.operand_stack.is_empty() {
-            "<span class=\"empty\">(empty)</span>".to_string()
-        } else {
-            p.operand_stack
-                .iter()
-                .map(abstract_value)
-                .collect::<Vec<_>>()
-                .join(" · ")
+    // FEAT-027: group the points BY function ("where they sit") instead of one
+    // flat table — each function gets an anchored subsection titled by its
+    // name, so the Functions table's points-count and the call graph link here.
+    let mut func_indices: Vec<u32> = points.iter().map(|p| p.func_index).collect();
+    func_indices.sort_unstable();
+    func_indices.dedup();
+    for idx in func_indices {
+        let heading = match fn_meta(r, idx).and_then(|m| m.name.as_deref()) {
+            Some(n) => format!("func {idx} · <code>{}</code>", esc(n)),
+            None => format!("func {idx}"),
         };
         let _ = write!(
             s,
-            "<tr><td>{}</td><td>{}</td><td><code>{}</code></td>\
-             <td><code>{}</code></td></tr>",
-            p.func_index,
-            p.pc,
-            esc(&locals),
-            stack,
+            "<h3 id=\"pts-{idx}\" class=\"fn-points\">{heading} \
+             <a class=\"backref\" href=\"#fn-{idx}\">↑ row</a></h3>",
         );
+        s.push_str(
+            "<table><thead><tr><th>pc</th><th>locals</th>\
+             <th>operand stack (bottom → top)</th></tr></thead><tbody>",
+        );
+        for p in points.iter().filter(|p| p.func_index == idx) {
+            let locals = if p.locals.is_empty() {
+                "(none)".to_string()
+            } else {
+                p.locals
+                    .iter()
+                    .map(|l| format!("L{}={}", l.local_index, abstract_value(&l.value)))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            // FEAT-023: the abstract operand stack. Empty is shown as "(empty)"
+            // — the analyzer's honest "no operand-stack info here", not a claim
+            // that the concrete stack is empty.
+            let stack = if p.operand_stack.is_empty() {
+                "<span class=\"empty\">(empty)</span>".to_string()
+            } else {
+                p.operand_stack
+                    .iter()
+                    .map(abstract_value)
+                    .collect::<Vec<_>>()
+                    .join(" · ")
+            };
+            let _ = write!(
+                s,
+                "<tr><td>{}</td><td><code>{}</code></td><td><code>{}</code></td></tr>",
+                p.pc,
+                esc(&locals),
+                stack,
+            );
+        }
+        s.push_str("</tbody></table>");
     }
-    s.push_str("</tbody></table></section>");
+    s.push_str("</section>");
 }
 
 // ── value formatting ─────────────────────────────────────────────────────
@@ -385,6 +462,13 @@ const STYLE: &str = "<style>\
     .ok{color:var(--ok);font-weight:600}.warn{color:var(--warn);font-weight:600}\
     .err{color:var(--err);font-weight:600}.muted,.empty{color:var(--muted)}\
     .diags{list-style:none;padding:0}.diags li{padding:4px 0;border-bottom:1px solid var(--line)}\
+    .badge{display:inline-block;font-size:11px;padding:1px 6px;border-radius:10px;\
+    border:1px solid var(--line);white-space:nowrap}\
+    .badge.import{background:#eef4ff;border-color:#cdd9f0}\
+    .badge.export{background:#eafaf0;border-color:#c5e8d2}\
+    h3.fn-points{font-size:14px;margin:22px 0 4px;scroll-margin-top:8px}\
+    tr[id^=\"fn-\"]{scroll-margin-top:8px}\
+    .backref{font-size:11px;font-weight:400;text-decoration:none;color:var(--muted)}\
     .cards{list-style:none;padding:0;display:grid;gap:12px;max-width:640px}\
     .cards li{border:1px solid var(--line);border-radius:6px;padding:14px 16px}\
     .cards a{font-size:16px;text-decoration:none}.cards a:hover{text-decoration:underline}\
@@ -502,6 +586,49 @@ mod tests {
             "no raw script tag from entry fields"
         );
         assert!(html.contains("&lt;script&gt;"), "escaped form present");
+    }
+
+    #[test]
+    fn renders_function_names_kinds_and_grouped_points() {
+        // FEAT-027: an imported $log, a defined+exported $compute calling
+        // $helper. The viz must show names, kind badges, named call-graph
+        // links, and per-function point groups.
+        let r = analyze_wat(
+            "(module (import \"env\" \"log\" (func $log (param i32))) \
+             (func $compute (export \"run\") (result i32) call $helper i32.const 7) \
+             (func $helper nop))",
+        );
+        let html = render_html(&r, "named");
+        // Names appear (from the name section).
+        assert!(html.contains("compute"), "defined function name shown");
+        assert!(html.contains("helper"), "callee name shown");
+        // Kind badges.
+        assert!(
+            html.contains("class=\"badge import\">import"),
+            "import badge"
+        );
+        assert!(html.contains("export \"run\""), "export badge with name");
+        // The functions table row is anchored, and the call graph links to it.
+        assert!(html.contains("id=\"fn-2\""), "function row anchored");
+        assert!(
+            html.contains("href=\"#fn-2\""),
+            "call graph / points link to the function row"
+        );
+        // Program points are grouped per function under an anchored heading.
+        assert!(
+            html.contains("id=\"pts-1\""),
+            "per-function points group anchored"
+        );
+    }
+
+    #[test]
+    fn function_names_html_escaped() {
+        // A name with HTML metacharacters must be escaped wherever it's shown.
+        // (wat allows arbitrary quoted ids.)
+        let r = analyze_wat("(module (func $\"<x>\" (export \"e\") nop))");
+        let html = render_html(&r, "esc");
+        assert!(!html.contains("<x>"), "raw name not injected");
+        assert!(html.contains("&lt;x&gt;"), "name escaped");
     }
 
     #[test]


### PR DESCRIPTION
## What

You asked to "see more on the function names / where they sit" in the viz. Right now scry-viz shows bare indices (`func 42`). This resolves every function to a **name** and reworks the dashboard around **structure**.

### Core (`scry-sai-core`) — a library capability
Additive `AnalysisResult.function_meta: Vec<FunctionMeta>` — one entry per function index (imports + defined, sorted). Each carries:
- `name: Option<String>` resolved in priority order: **custom `name` section → export name → import `module.field` → `None`**,
- `imported: bool`,
- `exports: Vec<String>`.

Parsed from the wasm `name` custom section (best-effort — malformed entries skipped) plus the import/export sections already read. **Library-only** — WIT mirror unchanged, the wasm wrapper ignores the field. Helps any consumer: synth's footprint report can read `$compute` instead of `func 42`.

### Viz (`scry-sai-viz`) — the rework
- **Functions table:** name column + **kind badges** (`import` / `export "run"` / defined) + per-function **program-point count**; rows anchored (`id="fn-N"`).
- **Call graph:** caller and resolved targets are **named links** — `1 compute → 2 helper` — that jump to the function's row.
- **Program points:** **grouped per function** under an anchored heading (`func 1 · compute`) instead of one flat table — answers "where they sit". The Functions table's point-count and the call graph link straight into the right group.
- All names HTML-escaped.

On scry's own 5.9 MB module this turns the dashboard from bare indices into `__wasi_fd_write` / `calloc` / `dlfree` … with 32 export + 4 import badges.

## Soundness / posture
Still a **faithful rendering** — names are a verbatim projection of the `name`/export/import sections, never inferred. Additive 1.x field (SemVer-compatible).

## Traceability + tests
- rivet: **FEAT-027** (`satisfies` REQ-013, `depends-on` FEAT-024). `rivet validate` PASS.
- Core: `feat027_function_meta_names` (name-section/export/import priority, imported flag, gapless index order) + `feat027_no_names_is_none` (fallback); fixture-19.
- Viz: `renders_function_names_kinds_and_grouped_points` + `function_names_html_escaped`. 23 tests pass across both crates.
- Lockstep bump 1.15.0 → **1.16.0**. The Pages dashboard auto-redeploys on the tag (FEAT-026).

## Falsification statement
If a rendered function name is not a verbatim projection of the module's `name`/export/import sections (i.e. inferred or wrong), or if `function_meta` omits/misorders an index, this release's claim is false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)