### PR TITLE
v1.18.0: demangled names + long-name handling (FEAT-029) + taint/provenance (FEAT-030) + gated self-check (FEAT-031)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,15 @@ jobs:
       # robustness oracle — a panic / error analyzing a real, large,
       # compiler-emitted module turns the build red, where the tiny fixtures
       # cannot reach.
+      # FEAT-031 (FEAT-025 slice-2): a LIVE robustness GATE — analyze scry's own
+      # module and assert the result is structurally well-formed (no inverted
+      # interval, 64-hex sha, gapless function metadata, sorted reachable set).
+      # A violation is a scry bug and turns the build red (exit 5). This runs
+      # before the render so a malformed result fails loudly, not silently.
+      - name: Dogfood gate — scry-viz check on scry's own module (FEAT-031)
+        run: |
+          cargo run --release -p scry-sai-viz -- check \
+            crates/scry-mcdc/target/wasm32-wasip1/release/scry_mcdc.wasm
       - name: Dogfood — scry-viz on scry's own module (FEAT-025)
         run: |
           cargo run --release -p scry-sai-viz -- \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,6 +399,9 @@ jobs:
       - name: Render scry-viz self-analysis (scry on scry)
         run: |
           set -euo pipefail
+          # FEAT-031 gate first: a malformed self-analysis fails the deploy.
+          cargo run --release -p scry-sai-viz -- check \
+            crates/scry-mcdc/target/wasm32-wasip1/release/scry_mcdc.wasm
           cargo run --release -p scry-sai-viz -- \
             crates/scry-mcdc/target/wasm32-wasip1/release/scry_mcdc.wasm \
             -o "$GITHUB_WORKSPACE/dist/self-analysis.html" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.18.0] — 2026-06-23
+
+Headline: **readable demangled names + long-name handling in the dashboard
+(FEAT-029)**, plus two follow-ups — **taint/provenance rendering (FEAT-030)**
+and a **gated self-analysis robustness check (FEAT-031)**.
+
+### Added — FEAT-029 (REQ-013): demangling + long names
+
+- scry-viz now **demangles** the wasm `name`-section symbols for display:
+  Rust legacy (`_ZN…E`) and v0 (`_R…`) via `rustc-demangle` (hash stripped),
+  Itanium C++ (`_Z…`) via `cpp_demangle`. A `rust`/`c++` **language tag** is
+  shown only when a demangler accepted the symbol; a plain/C name is left
+  unchanged and gets no language guess. (scry's own module: `_ZN4core3ptr…
+  drop_in_place$LT$…$GT$17h…E` now reads `core::ptr::drop_in_place<…>`.)
+- Demangling is deterministic *decoding*, not inference — the **raw symbol is
+  always preserved on hover**, so nothing is hidden.
+- **Long names** are shortened in place (CSS ellipsis) with the full demangled
+  name + raw symbol on the `title` hover; short names are unaffected. The core
+  `function_meta.name` stays the raw symbol (presentation-only change).
+
+### Added — FEAT-030 (REQ-013): taint + provenance
+
+- scry-viz renders the two `AnalysisResult` sections it previously dropped,
+  **only when present**: taint (noninterference) findings (func:pc · flow kind ·
+  High→Low labels · message) and the component-provenance fusion origin map.
+  Both faithful, HTML-escaped projections.
+
+### Added — FEAT-031: gated self-analysis robustness check
+
+- A `scry-viz check <module>` subcommand runs structural well-formedness checks
+  on the `AnalysisResult` (no inverted `[lo,hi]` interval; 64-hex sha; gapless
+  `function_meta`; sorted `reachable_from_exports`) and exits non-zero on a
+  violation. Wired into CI (the MC/DC job, on scry's own module) and the
+  release publish-pages step — promoting the FEAT-025 dogfood from an artifact
+  to a **live gate**. Structural validation (a scry-bug tripwire), not a
+  soundness oracle.
+
+### Posture
+
+- All three stay faithful renderings / presentation-only: demangling and the
+  taint/provenance sections add no analysis and infer nothing; the check is
+  structural. No JavaScript, no external assets (scry-viz invariant intact).
+
 ## [1.17.0] — 2026-06-22
 
 Headline: **a call-graph diagram in the dashboard (FEAT-028)** — the FEAT-024

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp_demangle"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,7 +1834,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1842,14 +1851,14 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-core"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "scry-sai-interval",
  "scry-sai-octagon",
@@ -1862,11 +1871,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "1.17.0"
+version = "1.18.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1875,20 +1884,22 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "1.17.0"
+version = "1.18.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "1.17.0"
+version = "1.18.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "1.17.0"
+version = "1.18.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
+ "cpp_demangle 0.5.1",
+ "rustc-demangle",
  "scry-sai-core",
  "wat",
 ]
@@ -2622,7 +2633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7da3dcce82a7e784121c19c8c9c5f69a743088264ff5212033e4a1f1b9dfaaf"
 dependencies = [
  "anyhow",
- "cpp_demangle",
+ "cpp_demangle 0.4.5",
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "1.17.0"
+version = "1.18.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -1469,6 +1469,104 @@ artifacts:
       - type: traces-to
         target: G-005
 
+  - id: FEAT-029
+    type: feature
+    title: "v1.x — Demangle function names + long-name handling in scry-viz"
+    status: proposed
+    description: >
+      Make the wasm `name`-section symbols readable in the visualization.
+      Compiler-emitted names are mangled (scry's own module: 1242 legacy `_ZN…`
+      + 803 v0 `_R…`); scry-viz now DECODES them for display — Rust legacy and
+      v0 via rustc-demangle (hash stripped), Itanium C++ (`_Z…`) via
+      cpp_demangle — and shows a small language tag (`rust`/`c++`) ONLY when a
+      demangler accepted the symbol (a plain/C name is left as-is and gets no
+      language guess). Demangling is deterministic decoding, not inference; the
+      exact raw symbol is always preserved on hover, so nothing is hidden.
+
+      Long names (demangled C++/Rust get long) are handled in place: a CSS
+      ellipsis (`.nm`) shortens the name in tables/headings with the full
+      demangled name + raw symbol available via the `title` hover; short names
+      are unaffected. In the SVG diagram the box shows a truncated name with the
+      full form in the SVG `<title>`. Presentation-only — `scry-sai-core`'s
+      `function_meta.name` stays the raw symbol (a consumer demangles if it
+      wants), keeping the no_std core dependency-free.
+    tags: [capability, visualization, readability, demangle, v1.x]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given a function whose name-section symbol is Rust (legacy `_ZN…E` or v0 `_R…`) or Itanium C++ (`_Z…`), When scry-viz renders it, Then the demangled (hash-stripped) name is shown with a language tag and the raw symbol preserved on hover; a plain/un-mangled name is shown unchanged with no language tag."
+        - "Given a long (demangled) name, When scry-viz renders it in a table or heading, Then it is shortened in place (CSS ellipsis) with the complete name available on hover — and every demangled name is HTML-escaped."
+    links:
+      - type: satisfies
+        target: REQ-013
+      - type: depends-on
+        target: FEAT-027
+      - type: traces-to
+        target: G-005
+
+  - id: FEAT-030
+    type: feature
+    title: "v1.x — Render taint findings + component provenance in scry-viz"
+    status: proposed
+    description: >
+      Surface the two `AnalysisResult` sections scry-viz previously dropped
+      (a clean-room/field-report finding, pulseengine.eu#95): the taint
+      (noninterference) findings (FEAT-009) and the component-provenance origin
+      map (FEAT-002). Each is a faithful, HTML-escaped projection. A taint
+      finding shows func:pc, flow kind (explicit/implicit), source→sink security
+      labels (High/Low), and message; provenance shows the meld fusion origin
+      map (fused func → component id → original func). Both are rendered ONLY
+      when present (the CLI runs with no taint policy and most modules carry no
+      provenance section), so the common page stays uncluttered while the data
+      is surfaced whenever it exists.
+    tags: [capability, visualization, taint, provenance, v1.x]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given an AnalysisResult with taint findings, When scry-viz renders it, Then a Taint-findings section lists each finding (func:pc, explicit/implicit, High→Low labels, message), HTML-escaped; given none, no section is emitted."
+        - "Given an AnalysisResult with component provenance, When scry-viz renders it, Then a Provenance section lists the fusion origin map; given no provenance, no section is emitted."
+    links:
+      - type: satisfies
+        target: REQ-013
+      - type: depends-on
+        target: FEAT-024
+      - type: traces-to
+        target: FEAT-009
+      - type: traces-to
+        target: FEAT-002
+      - type: traces-to
+        target: G-005
+
+  - id: FEAT-031
+    type: feature
+    title: "v1.x — Gated self-analysis robustness check (FEAT-025 slice-2)"
+    status: proposed
+    description: >
+      Promote the self-analysis dogfood (FEAT-025) from an artifact to a LIVE
+      GATE. A `scry-viz check <module>` subcommand runs structural
+      well-formedness checks on the `AnalysisResult` — invariants the analyzer
+      must always satisfy regardless of input: no inverted `[lo,hi]` interval
+      (in locals / operand stack / function-summary results / region offsets),
+      a 64-hex `module_sha256`, gapless index-ordered `function_meta`, and a
+      sorted `reachable_from_exports` — and exits non-zero on any violation.
+      Wired into CI (the MC/DC job, which already builds scry's own
+      `scry_mcdc.wasm`) and the release publish-pages step, so a structural
+      regression on a real, large, compiler-emitted module turns the build red.
+      This is STRUCTURAL validation (a scry-bug tripwire), explicitly NOT a
+      soundness oracle — soundness remains the host tests' and proofs' job.
+    tags: [capability, dogfood, ci, robustness, v1.x]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given scry's own compiled module, When CI runs `scry-viz check` on it, Then the analysis-result passes the structural well-formedness checks (build green); an injected violation (e.g. an inverted interval) is detected and exits non-zero."
+    links:
+      - type: depends-on
+        target: FEAT-024
+      - type: depends-on
+        target: FEAT-025
+      - type: traces-to
+        target: G-005
+
   # ──────────────────────────────────────────────────────────────────────
   # Safety goal for the v2.0 qualification milestone.
   # ──────────────────────────────────────────────────────────────────────

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "1.17.0" }
+scry-sai-interval = { path = "../scry-interval", version = "1.18.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,14 +43,14 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "1.17.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "1.17.0" }
+scry-sai-taint = { path = "../scry-taint", version = "1.18.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "1.18.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "1.17.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "1.18.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -408,7 +408,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "1.17.0";
+const SCRY_VERSION: &str = "1.18.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,12 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "1.17.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "1.18.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }
+# FEAT-029: demangle the names in the wasm `name` section for display. Rust
+# legacy (`_ZN…E`) + v0 (`_R…`) via rustc-demangle; Itanium C++ (`_Z…`) via
+# cpp_demangle. Decoding only — the raw symbol is always kept (shown on hover).
+rustc-demangle = "0.1"
+cpp_demangle = "0.5"

--- a/crates/scry-viz/README.md
+++ b/crates/scry-viz/README.md
@@ -17,9 +17,15 @@ assets) with:
 - **Summary** — module SHA-256, schema, worst-case shadow-stack bound,
   stack-pointer global, and headline counts.
 - **Functions** — per function: **name** (resolved from the wasm `name`
-  section / export / import) · **kind** badges (import · `export "run"` ·
-  defined) · reachable-from-exports? · recursive? · params · shadow-stack
-  frame · worst-case stack · program-point count. Rows are anchored.
+  section / export / import, and **demangled** for Rust `_ZN…`/`_R…` and C++
+  `_Z…` with a `rust`/`c++` language tag — raw symbol on hover) · **kind**
+  badges (import · `export "run"` · defined) · reachable-from-exports? ·
+  recursive? · params · shadow-stack frame · worst-case stack · program-point
+  count. Rows are anchored; long names are ellipsized with the full name on
+  hover.
+- **Taint findings / Provenance** — shown only when present: noninterference
+  findings (func:pc · explicit/implicit · High→Low · message) and the meld
+  component-provenance fusion origin map.
 - **Call graph** — caller · pc · `call`/`call_indirect` · resolved targets ·
   soundness tag. Caller and targets are **named links** (`1 compute →
   2 helper`) that jump to the function's row. Plus a **diagram**: an inline SVG
@@ -44,6 +50,10 @@ scry-viz module.wasm --title "my firmware"
 # Build a landing page linking the dashboard views present in a site dir
 # (the analogue of `witness-viz pages-index`):
 scry-viz index --site-dir dist --title "scry — verification dashboard"
+
+# Structural well-formedness gate (no inverted intervals, gapless metadata,
+# …) — exits non-zero on a violation. Used in CI on scry's own module.
+scry-viz check module.wasm
 ```
 
 scry uses this to publish a verification dashboard to GitHub Pages on every

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -450,11 +450,16 @@ struct DiagramEdge {
 fn mermaid_source(r: &AnalysisResult, nodes: &[u32], edges: &[DiagramEdge]) -> String {
     let mut m = String::from("graph LR\n");
     for &n in nodes {
-        // Mermaid labels go in quotes; use the demangled name and drop any
-        // quotes/newlines to keep the `["…"]` label well-formed (the whole
-        // block is additionally HTML-escaped before it enters the <pre>).
+        // Mermaid labels go in quotes; use the demangled name and sanitize the
+        // few chars that break the `["…"]` label — drop quotes/newlines and map
+        // square brackets (common in demangled types like `[u8; 4]`, which
+        // would prematurely close the label) to parens. The whole block is
+        // additionally HTML-escaped before it enters the <pre>.
         let label = match fn_meta(r, n).and_then(|x| x.name.as_deref()) {
-            Some(name) => format!("{n} {}", demangle(name).display.replace(['"', '\n'], "")),
+            Some(name) => {
+                let d = demangle(name).display.replace(['"', '\n'], "");
+                format!("{n} {}", d.replace('[', "(").replace(']', ")"))
+            }
             None => format!("{n}"),
         };
         let _ = writeln!(m, "  n{n}[\"{label}\"]", label = label);

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -31,7 +31,7 @@ use core::fmt::Write as _;
 
 use scry_analyze_core::{
     AbstractValue, AnalysisResult, Diagnostic, DiagnosticSeverity, FunctionMeta, FunctionStack,
-    Interval, Region, SoundnessTag, StackBound,
+    Interval, Region, SecurityLabel, SoundnessTag, StackBound, TaintFindingKind,
 };
 
 /// FEAT-027: metadata for one function index, if scry resolved any.
@@ -39,11 +39,80 @@ fn fn_meta(r: &AnalysisResult, idx: u32) -> Option<&FunctionMeta> {
     r.function_meta.iter().find(|m| m.func_index == idx)
 }
 
+/// FEAT-029: a name resolved for display — the demangled (human-readable) form,
+/// the exact raw symbol, and a best-guess source language. Demangling is
+/// deterministic *decoding*; the language is only a guess, so it's set ONLY
+/// when a demangler actually accepted the symbol, and `raw` is always kept so
+/// the hover can show the exact source string (nothing is hidden).
+struct Shown {
+    display: String,
+    raw: String,
+    lang: Option<&'static str>,
+}
+
+/// Demangle a wasm-`name`-section symbol: Rust legacy (`_ZN…E`) and v0 (`_R…`)
+/// via rustc-demangle (hash stripped with the `{:#}` formatter), Itanium C++
+/// (`_Z…`) via cpp_demangle. A plain/C name matches neither and is returned
+/// unchanged with no language.
+fn demangle(raw: &str) -> Shown {
+    if let Ok(d) = rustc_demangle::try_demangle(raw) {
+        return Shown {
+            display: format!("{d:#}"),
+            raw: raw.to_string(),
+            lang: Some("rust"),
+        };
+    }
+    if let Ok(sym) = cpp_demangle::Symbol::new(raw)
+        && let Ok(d) = sym.demangle()
+    {
+        return Shown {
+            display: d,
+            raw: raw.to_string(),
+            lang: Some("c++"),
+        };
+    }
+    Shown {
+        display: raw.to_string(),
+        raw: raw.to_string(),
+        lang: None,
+    }
+}
+
+/// FEAT-029: render a name for a table cell / heading — the demangled text in a
+/// CSS-ellipsized span whose `title` (hover) carries the full demangled name
+/// and, when it differs, the raw mangled symbol. Everything HTML-escaped, so a
+/// long name is shortened in place with the complete form one hover away.
+fn name_span(sh: &Shown) -> String {
+    let title = if sh.display != sh.raw {
+        format!("{}\n[symbol] {}", sh.display, sh.raw)
+    } else {
+        sh.display.clone()
+    };
+    format!(
+        "<span class=\"nm\" title=\"{}\">{}</span>",
+        esc(&title),
+        esc(&sh.display),
+    )
+}
+
+/// A small language tag (`rust` / `c++`) shown only when demangling identified
+/// the source language. Empty otherwise — we do not guess a language for an
+/// un-mangled (e.g. C / hand-written) name.
+fn lang_badge(sh: &Shown) -> String {
+    match sh.lang {
+        Some(l) => format!("<span class=\"badge lang\">{l}</span> "),
+        None => String::new(),
+    }
+}
+
 /// A function reference as a link to its row in the Functions table, showing
-/// the resolved name when there is one: `42 $compute` (or just `42`).
+/// the demangled name when there is one: `42 compute` (or just `42`).
 fn fn_link(r: &AnalysisResult, idx: u32) -> String {
     match fn_meta(r, idx).and_then(|m| m.name.as_deref()) {
-        Some(n) => format!("<a href=\"#fn-{idx}\">{idx} <code>{}</code></a>", esc(n)),
+        Some(n) => format!(
+            "<a href=\"#fn-{idx}\">{idx} {}</a>",
+            name_span(&demangle(n))
+        ),
         None => format!("<a href=\"#fn-{idx}\">{idx}</a>"),
     }
 }
@@ -87,6 +156,8 @@ pub fn render_html(result: &AnalysisResult, title: &str) -> String {
     render_functions(&mut s, result);
     render_call_graph(&mut s, result);
     render_diagnostics(&mut s, &result.diagnostics);
+    render_taint(&mut s, result);
+    render_provenance(&mut s, result);
     render_points(&mut s, result);
 
     s.push_str(
@@ -231,10 +302,14 @@ fn render_functions(s: &mut String, r: &AnalysisResult) {
         let maxs = stack
             .map(|f| stack_bound(&f.max_stack))
             .unwrap_or_else(|| "?".into());
-        let name = match meta.and_then(|m| m.name.as_deref()) {
-            Some(n) => format!("<code>{}</code>", esc(n)),
+        // FEAT-029: demangle for display; the raw symbol stays on hover, and a
+        // language tag rides in the kind column when a demangler identified it.
+        let shown = meta.and_then(|m| m.name.as_deref()).map(demangle);
+        let name = match &shown {
+            Some(sh) => name_span(sh),
             None => "<span class=\"muted\">—</span>".to_string(),
         };
+        let lang = shown.as_ref().map(lang_badge).unwrap_or_default();
         let n_points = r
             .invariants
             .points
@@ -248,8 +323,9 @@ fn render_functions(s: &mut String, r: &AnalysisResult) {
         };
         let _ = write!(
             s,
-            "<tr id=\"fn-{idx}\"><td>{idx}</td><td>{name}</td><td>{}</td><td>{}</td>\
+            "<tr id=\"fn-{idx}\"><td>{idx}</td><td>{name}</td><td>{}{}</td><td>{}</td>\
              <td>{}</td><td>{params}</td><td>{frame}</td><td>{maxs}</td><td>{points_cell}</td></tr>",
+            lang,
             kind_badges(meta),
             yesno(reachable),
             yesno(recursive),
@@ -374,10 +450,11 @@ struct DiagramEdge {
 fn mermaid_source(r: &AnalysisResult, nodes: &[u32], edges: &[DiagramEdge]) -> String {
     let mut m = String::from("graph LR\n");
     for &n in nodes {
-        // Mermaid labels go in quotes; drop any quotes in the name to keep the
-        // label well-formed (the whole block is additionally HTML-escaped).
+        // Mermaid labels go in quotes; use the demangled name and drop any
+        // quotes/newlines to keep the `["…"]` label well-formed (the whole
+        // block is additionally HTML-escaped before it enters the <pre>).
         let label = match fn_meta(r, n).and_then(|x| x.name.as_deref()) {
-            Some(name) => format!("{n} {}", name.replace('"', "")),
+            Some(name) => format!("{n} {}", demangle(name).display.replace(['"', '\n'], "")),
             None => format!("{n}"),
         };
         let _ = writeln!(m, "  n{n}[\"{label}\"]", label = label);
@@ -482,9 +559,19 @@ fn render_callgraph_svg(s: &mut String, r: &AnalysisResult, nodes: &[u32], edges
         if meta.map(|m| !m.exports.is_empty()).unwrap_or(false) {
             cls.push_str(" exp");
         }
-        let label = match meta.and_then(|m| m.name.as_deref()) {
-            Some(name) => format!("{n} {name}"),
-            None => format!("{n}"),
+        // FEAT-029: box shows the (truncated) demangled name; the SVG <title>
+        // hover carries the full demangled name plus the raw symbol.
+        let (label, title) = match meta.and_then(|m| m.name.as_deref()) {
+            Some(name) => {
+                let sh = demangle(name);
+                let title = if sh.display != sh.raw {
+                    format!("{n} {}\n[symbol] {}", sh.display, sh.raw)
+                } else {
+                    format!("{n} {}", sh.display)
+                };
+                (format!("{n} {}", sh.display), title)
+            }
+            None => (format!("{n}"), format!("{n}")),
         };
         let shown = truncate_label(&label, 20);
         let _ = write!(
@@ -492,7 +579,7 @@ fn render_callgraph_svg(s: &mut String, r: &AnalysisResult, nodes: &[u32], edges
             "<g class=\"{cls}\"><title>{}</title>\
              <rect x=\"{x}\" y=\"{y}\" width=\"{BOX_W}\" height=\"{BOX_H}\" rx=\"4\"/>\
              <text x=\"{tx}\" y=\"{ty}\">{}</text></g>",
-            esc(&label),
+            esc(&title),
             esc(&shown),
             tx = x + 8,
             ty = y + BOX_H / 2 + 4,
@@ -538,6 +625,76 @@ fn render_diagnostics(s: &mut String, diags: &[Diagnostic]) {
     s.push_str("</ul></section>");
 }
 
+/// FEAT-030: taint (noninterference) findings. Rendered only when there ARE
+/// findings — the scry-viz CLI runs with no taint policy, so the common case is
+/// empty and a section would be noise; when present, each finding is a faithful
+/// projection (escaped). A finding means a High (secret-dependent) value
+/// reached a Low (public) sink.
+fn render_taint(s: &mut String, r: &AnalysisResult) {
+    if r.taint_findings.is_empty() {
+        return;
+    }
+    s.push_str("<section><h2>Taint findings (noninterference)</h2>");
+    s.push_str(
+        "<table><thead><tr><th>func</th><th>pc</th><th>kind</th>\
+         <th>source → sink</th><th>message</th></tr></thead><tbody>",
+    );
+    for f in &r.taint_findings {
+        let kind = match f.kind {
+            TaintFindingKind::HighResultExplicit => "explicit flow",
+            TaintFindingKind::HighResultImplicit => "implicit flow",
+        };
+        let _ = write!(
+            s,
+            "<tr><td>{}</td><td>{}</td><td><span class=\"badge err\">{kind}</span></td>\
+             <td>{} → {}</td><td>{}</td></tr>",
+            fn_link(r, f.func_index),
+            f.pc,
+            label(&f.source_label),
+            label(&f.sink_label),
+            esc(&f.message),
+        );
+    }
+    s.push_str("</tbody></table></section>");
+}
+
+/// A security label (`High`/`Low`) as a small styled span.
+fn label(l: &SecurityLabel) -> &'static str {
+    match l {
+        SecurityLabel::High => "<span class=\"warn\">High</span>",
+        SecurityLabel::Low => "<span class=\"ok\">Low</span>",
+    }
+}
+
+/// FEAT-030: component provenance (FEAT-002) — the meld fusion origin map.
+/// Rendered only when a `component-provenance` custom section was present and
+/// decoded; absent for a plain Core Wasm module, so no section is emitted then.
+fn render_provenance(s: &mut String, r: &AnalysisResult) {
+    let Some(prov) = &r.provenance else { return };
+    if prov.origins.is_empty() {
+        return;
+    }
+    s.push_str("<section><h2>Component provenance</h2>");
+    s.push_str(
+        "<p class=\"muted\">meld fusion origin map: each fused function traced \
+         to its source component and original index.</p>",
+    );
+    s.push_str(
+        "<table><thead><tr><th>fused func</th><th>component</th>\
+         <th>original func</th></tr></thead><tbody>",
+    );
+    for o in &prov.origins {
+        let _ = write!(
+            s,
+            "<tr><td>{}</td><td>{}</td><td>{}</td></tr>",
+            fn_link(r, o.fused_func_index),
+            o.component_id,
+            o.orig_func_index,
+        );
+    }
+    s.push_str("</tbody></table></section>");
+}
+
 fn render_points(s: &mut String, r: &AnalysisResult) {
     let points = &r.invariants.points;
     s.push_str("<section><h2>Program points</h2>");
@@ -553,7 +710,7 @@ fn render_points(s: &mut String, r: &AnalysisResult) {
     func_indices.dedup();
     for idx in func_indices {
         let heading = match fn_meta(r, idx).and_then(|m| m.name.as_deref()) {
-            Some(n) => format!("func {idx} · <code>{}</code>", esc(n)),
+            Some(n) => format!("func {idx} · {}", name_span(&demangle(n))),
             None => format!("func {idx}"),
         };
         let _ = write!(
@@ -598,6 +755,78 @@ fn render_points(s: &mut String, r: &AnalysisResult) {
         s.push_str("</tbody></table>");
     }
     s.push_str("</section>");
+}
+
+// ── FEAT-031: well-formedness oracle ───────────────────────────────────────
+
+/// The interval inside an [`AbstractValue`], if it carries one.
+fn interval_of(v: &AbstractValue) -> Option<&Interval> {
+    match v {
+        AbstractValue::I32Interval(iv) | AbstractValue::I64Interval(iv) => Some(iv),
+        AbstractValue::RegionPointer(Region { offset, .. }) => Some(offset),
+        AbstractValue::Unknown => None,
+    }
+}
+
+/// FEAT-031: structural well-formedness checks on an `AnalysisResult` —
+/// invariants the analyzer must ALWAYS satisfy regardless of input. Returns the
+/// list of violations (empty ⇒ well-formed). `scry-viz check` runs this on
+/// scry's OWN compiled module in CI as a robustness gate: a violation is a scry
+/// bug, and fails the build. This is structural validation (e.g. no inverted
+/// `[lo,hi]` interval), NOT a soundness oracle — soundness is the host tests'
+/// and proofs' job.
+pub fn check_wellformed(r: &AnalysisResult) -> Vec<String> {
+    let mut v = Vec::new();
+    if r.invariants.schema.is_empty() {
+        v.push("invariants.schema is empty".to_string());
+    }
+    let sha = &r.invariants.module_sha256;
+    if sha.len() != 64 || !sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+        v.push(format!("module_sha256 is not 64 hex chars: {sha:?}"));
+    }
+    let check_iv = |whr: String, val: &AbstractValue, out: &mut Vec<String>| {
+        if let Some(iv) = interval_of(val)
+            && iv.lo > iv.hi
+        {
+            out.push(format!("{whr}: inverted interval [{}, {}]", iv.lo, iv.hi));
+        }
+    };
+    for p in &r.invariants.points {
+        for l in &p.locals {
+            check_iv(
+                format!("fn{} pc{} L{}", p.func_index, p.pc, l.local_index),
+                &l.value,
+                &mut v,
+            );
+        }
+        for (i, sv) in p.operand_stack.iter().enumerate() {
+            check_iv(
+                format!("fn{} pc{} stack{i}", p.func_index, p.pc),
+                sv,
+                &mut v,
+            );
+        }
+    }
+    for fs in &r.function_summaries {
+        for (i, sv) in fs.result_summary.iter().enumerate() {
+            check_iv(format!("fn{} result{i}", fs.func_index), sv, &mut v);
+        }
+    }
+    // FEAT-027 metadata must be index-ordered and gapless.
+    for (i, m) in r.function_meta.iter().enumerate() {
+        if m.func_index as usize != i {
+            v.push(format!(
+                "function_meta not gapless/sorted at position {i}: func_index {}",
+                m.func_index
+            ));
+            break;
+        }
+    }
+    // FEAT-022: reachable set is documented sorted ascending.
+    if !r.reachable_from_exports.is_sorted() {
+        v.push("reachable_from_exports is not sorted ascending".to_string());
+    }
+    v
 }
 
 // ── value formatting ─────────────────────────────────────────────────────
@@ -684,6 +913,12 @@ const STYLE: &str = "<style>\
     border:1px solid var(--line);white-space:nowrap}\
     .badge.import{background:#eef4ff;border-color:#cdd9f0}\
     .badge.export{background:#eafaf0;border-color:#c5e8d2}\
+    .badge.lang{background:#f3eefe;border-color:#ddd0f5}\
+    .badge.err{background:#fdecef;border-color:#f3c2cc;color:var(--err)}\
+    .nm{display:inline-block;max-width:42ch;overflow:hidden;text-overflow:ellipsis;\
+    white-space:nowrap;vertical-align:bottom;font-family:ui-monospace,Menlo,monospace;\
+    font-size:12px}\
+    td .nm{max-width:38ch}h3 .nm{max-width:60ch}\
     h3.fn-points{font-size:14px;margin:22px 0 4px;scroll-margin-top:8px}\
     tr[id^=\"fn-\"]{scroll-margin-top:8px}\
     .backref{font-size:11px;font-weight:400;text-decoration:none;color:var(--muted)}\
@@ -888,6 +1123,72 @@ mod tests {
     }
 
     #[test]
+    fn demangles_rust_legacy_v0_and_leaves_plain() {
+        // FEAT-029: name-section symbols (modelled via quoted wat ids) are
+        // demangled for display; a plain name is left as-is with no language.
+        let r = analyze_wat(
+            "(module \
+             (func $\"_ZN9scry_mcdc5drive17h16e8a19d4dbffa6cE\" (export \"a\") nop) \
+             (func $\"_RNvNtCsi9YzqDQQz2q_5alloc3fmt6format\" (export \"b\") nop) \
+             (func $calloc (export \"c\") nop))",
+        );
+        let html = render_html(&r, "demangle");
+        // Rust legacy `_ZN…E` → `scry_mcdc::drive` (hash stripped from the
+        // DISPLAY — the display text ends at the name, no `…17h<hash>` glued
+        // on; the raw symbol with the hash is kept only on hover, below).
+        assert!(html.contains("scry_mcdc::drive"), "rust legacy demangled");
+        assert!(
+            html.contains("scry_mcdc::drive</span>"),
+            "display ends at the demangled name (hash stripped)"
+        );
+        // Rust v0 `_R…` → `alloc::fmt::format`.
+        assert!(html.contains("alloc::fmt::format"), "rust v0 demangled");
+        // A language tag appears for the demangled ones.
+        assert!(html.contains("badge lang\">rust"), "rust language tag");
+        // Plain C-style name is unchanged (and not tagged with a language).
+        assert!(html.contains("calloc"), "plain name preserved");
+        // The raw symbol is preserved on hover (title carries `[symbol] …`).
+        assert!(
+            html.contains("[symbol] _ZN9scry_mcdc5drive"),
+            "raw symbol kept on hover"
+        );
+    }
+
+    #[test]
+    fn demangled_generic_name_is_escaped() {
+        // A Rust generic demangles to a name containing `<…>`; it must be
+        // HTML-escaped wherever shown.
+        let r = analyze_wat(
+            "(module (func \
+             $\"_ZN4core3ptr54drop_in_place$LT$scry_analyze_core..AnalysisResult$GT$17h40256ad9d7a94464E\" \
+             (export \"d\") nop))",
+        );
+        let html = render_html(&r, "generic");
+        assert!(
+            html.contains("drop_in_place&lt;"),
+            "demangled generic angle-brackets escaped"
+        );
+        assert!(!html.contains("drop_in_place<scry"), "no raw < emitted");
+    }
+
+    #[test]
+    fn long_name_uses_ellipsis_class_with_hover() {
+        // Long demangled names are shortened in place (CSS .nm ellipsis) with
+        // the full form in the title hover.
+        let r = analyze_wat(
+            "(module (func \
+             $\"_ZN4core3ptr54drop_in_place$LT$scry_analyze_core..AnalysisResult$GT$17h40256ad9d7a94464E\" \
+             (export \"d\") nop))",
+        );
+        let html = render_html(&r, "long");
+        assert!(
+            html.contains("<span class=\"nm\""),
+            "name uses the ellipsizable .nm span"
+        );
+        assert!(html.contains("title=\""), "full name available on hover");
+    }
+
+    #[test]
     fn function_names_html_escaped() {
         // A name with HTML metacharacters must be escaped wherever it's shown.
         // (wat allows arbitrary quoted ids.)
@@ -895,6 +1196,93 @@ mod tests {
         let html = render_html(&r, "esc");
         assert!(!html.contains("<x>"), "raw name not injected");
         assert!(html.contains("&lt;x&gt;"), "name escaped");
+    }
+
+    #[test]
+    fn renders_taint_findings_when_present() {
+        // FEAT-030: with a taint policy (High param 0 → Low result 0), a
+        // leaking function produces a finding the viz now surfaces.
+        let bytes = wat::parse_str(
+            "(module (func (export \"leak\") (param i32) (result i32) local.get 0))",
+        )
+        .unwrap();
+        let cfg = scry_analyze_core::AnalysisConfig {
+            widening_threshold: Some(3),
+            emit_diagnostics: true,
+            taint_policy: Some(scry_analyze_core::TaintPolicy {
+                high_params: alloc_vec(0),
+                low_results: alloc_vec(0),
+            }),
+        };
+        let r = scry_analyze_core::analyze(bytes, cfg).unwrap();
+        assert!(!r.taint_findings.is_empty(), "policy must yield a finding");
+        let html = render_html(&r, "taint");
+        assert!(html.contains("Taint findings"), "taint section present");
+        assert!(html.contains("explicit flow"), "finding kind shown");
+        assert!(html.contains(">High<"), "source label shown");
+        assert!(html.contains(">Low<"), "sink label shown");
+    }
+
+    fn alloc_vec(x: u32) -> Vec<u32> {
+        vec![x]
+    }
+
+    #[test]
+    fn no_taint_or_provenance_section_when_absent() {
+        // FEAT-030: the common case (no taint policy, plain Core Wasm) shows
+        // neither section — they are surfaced only when present, not as clutter.
+        let r = analyze_wat("(module (func (export \"run\") nop))");
+        let html = render_html(&r, "plain");
+        assert!(
+            !html.contains("Taint findings"),
+            "no taint section when empty"
+        );
+        assert!(
+            !html.contains("Component provenance"),
+            "no provenance section when absent"
+        );
+    }
+
+    #[test]
+    fn check_wellformed_passes_on_real_module() {
+        // FEAT-031: a normally-analyzed module is well-formed — the gate must
+        // not false-positive.
+        for fx in [
+            "fixture-11-var-bound.wat",
+            "fixture-18-operand-stack.wat",
+            "fixture-19-named-functions.wat",
+        ] {
+            let r = analyze_fixture(fx);
+            let v = check_wellformed(&r);
+            assert!(v.is_empty(), "{fx} should be well-formed, got {v:?}");
+        }
+    }
+
+    fn analyze_fixture(name: &str) -> AnalysisResult {
+        let path = format!(
+            "{}/../scry-analyzer/test-fixtures/{name}",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let bytes = wat::parse_file(&path).expect("assemble fixture");
+        analyze(bytes, AnalysisConfig::default()).expect("analyze")
+    }
+
+    #[test]
+    fn check_wellformed_flags_an_inverted_interval() {
+        // Inject an impossible interval [5,1] and confirm the gate catches it.
+        let mut r = analyze_wat("(module (func (export \"run\") (result i32) i32.const 7))");
+        let bad = scry_analyze_core::AbstractValue::I32Interval(scry_analyze_core::Interval {
+            lo: 5,
+            hi: 1,
+        });
+        // Attach it to a program point's operand stack.
+        assert!(!r.invariants.points.is_empty());
+        r.invariants.points[0].operand_stack.push(bad);
+        let v = check_wellformed(&r);
+        assert!(
+            v.iter().any(|m| m.contains("inverted interval [5, 1]")),
+            "gate must flag the inverted interval, got {v:?}"
+        );
     }
 
     #[test]

--- a/crates/scry-viz/src/main.rs
+++ b/crates/scry-viz/src/main.rs
@@ -15,6 +15,11 @@ use scry_analyze_core::{AnalysisConfig, analyze};
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
+    // `scry-viz check <module>` is a well-formedness gate (its own exit code,
+    // no file output), so it's dispatched before the file-writing forms.
+    if args.first().map(String::as_str) == Some("check") {
+        return run_check(&args[1..]);
+    }
     // Subcommand dispatch: `scry-viz index ...` builds a landing page; the
     // bare form `scry-viz <input> ...` renders one analysis.
     let result = match args.first().map(String::as_str) {
@@ -30,6 +35,59 @@ fn main() -> ExitCode {
             eprintln!("scry-viz: {}", e.msg);
             ExitCode::from(e.code)
         }
+    }
+}
+
+/// `scry-viz check <input.wasm|input.wat>` — FEAT-031 well-formedness gate.
+/// Analyzes the module and runs `scry_viz::check_wellformed`; prints the
+/// violations and exits non-zero (5) if any, else prints an OK line and exits
+/// 0. Used in CI as a robustness gate on scry's own compiled module.
+fn run_check(args: &[String]) -> ExitCode {
+    let path = match args.iter().find(|a| !a.starts_with('-')) {
+        Some(p) => PathBuf::from(p),
+        None => {
+            eprintln!("scry-viz: usage: scry-viz check <input.wasm|input.wat>");
+            return ExitCode::from(2);
+        }
+    };
+    let bytes = match read_module(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("scry-viz: {}", e.msg);
+            return ExitCode::from(e.code);
+        }
+    };
+    let result = match analyze(
+        bytes,
+        AnalysisConfig {
+            emit_diagnostics: true,
+            ..Default::default()
+        },
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("scry-viz check: analysis failed: {e:?}");
+            return ExitCode::from(3);
+        }
+    };
+    let violations = scry_viz::check_wellformed(&result);
+    if violations.is_empty() {
+        eprintln!(
+            "scry-viz check: OK — {} functions, {} program points, {} call edges well-formed",
+            result.function_meta.len(),
+            result.invariants.points.len(),
+            result.call_graph.len(),
+        );
+        ExitCode::SUCCESS
+    } else {
+        eprintln!(
+            "scry-viz check: {} well-formedness violation(s):",
+            violations.len()
+        );
+        for v in &violations {
+            eprintln!("  - {v}");
+        }
+        ExitCode::from(5)
     }
 }
 


### PR DESCRIPTION
Three viz/dogfood improvements — the demangle/long-name request plus the two flagged follow-ups, bundled into one release.

## FEAT-029 — demangle + long names (the request)
wasm `name`-section symbols are mangled (scry's own module: **1242 `_ZN…` + 803 `_R…`**, unreadable). scry-viz now **decodes** them for display:
- Rust legacy `_ZN…E` + v0 `_R…` via `rustc-demangle` (hash stripped); Itanium C++ `_Z…` via `cpp_demangle`.
- A `rust`/`c++` **language tag** shown *only* when a demangler accepts the symbol — a plain/C name is left as-is, no language guessed.
- Decoding, not inference: the **raw symbol is always on hover**, nothing hidden.
- **Long names** shortened in place (CSS ellipsis) with the full demangled name + raw symbol on the `title` hover; short names unaffected. Core `function_meta.name` stays the raw symbol (presentation-only; no_std core stays dependency-free).

On scry's own module, 451 names now read `core::ptr::drop_in_place<scry_analyze_core::AnalysisResult>`, `scry_mcdc::drive`, `alloc::fmt::format`, …

## FEAT-030 — taint + provenance (follow-up)
Render the two `AnalysisResult` sections scry-viz previously dropped (flagged in pulseengine.eu#95), **only when present**: noninterference findings (func:pc · explicit/implicit · High→Low · message) and the meld component-provenance fusion origin map.

## FEAT-031 — gated self-analysis check (follow-up, FEAT-025 slice-2)
`scry-viz check <module>` runs structural well-formedness checks (no inverted `[lo,hi]`; 64-hex sha; gapless `function_meta`; sorted `reachable_from_exports`) and exits non-zero on violation. Wired into the CI MC/DC job and release publish-pages on scry's own module — promoting the dogfood from artifact to **live gate**. Structural validation (a scry-bug tripwire), not a soundness oracle.

## Posture
All three are faithful / presentation-only: demangling and the taint/provenance sections infer nothing; the check is structural. **No JavaScript, no external assets** (scry-viz invariant intact).

## Traceability + tests
- rivet: FEAT-029/030/031. `rivet validate` PASS.
- 17 viz lib tests incl. demangle priority (rust legacy/v0/plain), generic `<>`-escaping, long-name ellipsis+hover, taint rendering with a real policy, and an **injected inverted-interval caught by the gate**.
- Lockstep bump 1.17.0 → **1.18.0**. Pages dashboard auto-redeploys on the tag.

## Falsification statement
If a displayed name is not the deterministic demangling (or raw form) of the symbol; if a language tag appears for a symbol no demangler accepted; if taint/provenance render a value not in the `AnalysisResult`; or if `check` passes a structurally-malformed result (or fails a well-formed one) — the corresponding claim is false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)