### PR TITLE
v2.0.0 (FEAT-032): component-provenance SCPV v3 — meld boundary reconciled + fusion premises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0] — 2026-06-26
+
+Headline: **`component-provenance` SCPV v3 — the meld→scry boundary reconciled,
+plus fusion premises (FEAT-032, scry#63 / meld#313).** First major bump: the
+provenance wire format is reshaped, a breaking change to the published
+`scry-sai-provenance` / `scry-sai-core` APIs.
+
+### Why a major bump
+
+Investigating scry#63 surfaced that the meld→scry `component-provenance`
+boundary had **never connected**: meld emitted JSON v2 (string `component_id`,
+`fused_module_sha256`, `code_range`); scry decoded a custom binary `SCPV` v1
+(u32 `component_id`) — mutually undecodable, so scry rejected every real meld
+section (`BadMagic` → conservative `none`). avrabe ratified **binary-canonical
+SCPV v3**: scry's strict `no_std` binary stays the canonical wire shape (keeps
+the DO-333 trusted decoder lean — no JSON parser in the trusted base) and grows
+meld's richer schema; meld (#313) swaps its section encoder JSON→binary to match.
+
+### Changed — FEAT-032 (REQ-008 / DD-002), **breaking**
+
+- **`scry-sai-provenance`** decodes/encodes `SCPV` **v3**: a fixed header
+  carrying the two **fusion premises** meld knows by construction —
+  `bounded_memory` (no `memory.grow` → fixed linear memory) and `closed_world`
+  (cross-component imports internalised) — plus a `fused_module_sha256`
+  binding; per entry a length-prefixed UTF-8 `component_id` (was `u32`) and an
+  optional `code_range`. `decode()` now returns a `ProvenanceSection`
+  (premises + sha + origins). Strict: hard-errors on bad magic / unknown
+  version / malformed flag / bad UTF-8 / truncation / trailing bytes.
+- **`scry-sai-core`**: `AnalysisResult.provenance` (`ComponentProvenance`) now
+  carries `premises` + `fused_module_sha256`, and `ComponentOrigin` carries the
+  string `component_id` + optional `code_range`. Re-exports `FusionPremises` /
+  `CodeRange`.
+- **WIT** (`component-origin.component-id: string`, new `code-range` +
+  `fusion-premises` records, `component-provenance` gains `premises` +
+  `fused-module-sha256`) and the JSON-schema contract updated to match.
+
+### Compatibility
+
+- **synth's consumed surface is untouched** — `call_graph`,
+  `function_summaries`, `stack_usage`, `reachable_from_exports`, and the
+  per-program-point `operand_stack` are unchanged and remain additive-only. The
+  break is confined to the provenance types, which synth does not read; so 2.0
+  is a smooth bump for synth (heads-up on #51/#54).
+- Consuming the premises to *tighten* the analysis (bounded_memory drops
+  grow-reachability widening, closed_world tightens reachability) is a separate
+  follow-on slice (scry#5 / scry#51); this release lands the format + surfaces
+  the premises.
+
+### Falsification statement
+
+If scry decodes a non-v3 (v1/v2) or malformed `component-provenance` payload as
+anything other than a hard error (Warning + `provenance = none`) — i.e. a
+silent partial parse or a wrong attribution — this release's contract is false.
+The `scry-provenance` + `scry-host-tests` round-trip/rejection tests pin it.
+
 ## [1.18.0] — 2026-06-23
 
 Headline: **readable demangled names + long-name handling in the dashboard

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "1.18.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1851,14 +1851,14 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "1.18.0"
+version = "2.0.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-core"
-version = "1.18.0"
+version = "2.0.0"
 dependencies = [
  "scry-sai-interval",
  "scry-sai-octagon",
@@ -1871,11 +1871,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "1.18.0"
+version = "2.0.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "1.18.0"
+version = "2.0.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1884,19 +1884,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "1.18.0"
+version = "2.0.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "1.18.0"
+version = "2.0.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "1.18.0"
+version = "2.0.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "1.18.0"
+version = "2.0.0"
 dependencies = [
  "cpp_demangle 0.5.1",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "1.18.0"
+version = "2.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -1567,6 +1567,60 @@ artifacts:
       - type: traces-to
         target: G-005
 
+  - id: FEAT-032
+    type: feature
+    title: "v2.0 — component-provenance SCPV v3: canonical binary format + fusion premises (scry#63 / meld#313)"
+    status: proposed
+    description: >
+      Reconcile and extend the meld→scry `component-provenance` boundary
+      (DD-002). FINDING that gated scry#63: the boundary had never connected —
+      meld emitted JSON v2 (string component_id, fused_module_sha256,
+      code_range), scry decoded a custom binary `SCPV` v1 (u32 component_id);
+      mutually undecodable, so scry rejected every real meld section
+      (BadMagic → conservative None). avrabe ratified **binary-canonical SCPV
+      v3**: scry's strict `no_std` binary stays the canonical wire shape (keeps
+      the DO-333 trusted decoder lean — no JSON parser in the trusted base) and
+      grows meld's richer schema; meld#313 swaps its section encoder JSON→binary
+      to match.
+
+      SCPV v3 (scry-provenance): fixed header carries the two **fusion premises**
+      meld knows by construction — `bounded_memory` (no memory.grow → fixed
+      linear memory) and `closed_world` (cross-component imports internalised) —
+      plus a `fused_module_sha256` binding; per-entry a length-prefixed UTF-8
+      `component_id` and an optional `code_range`. Strict decoder: hard-error on
+      bad magic / unknown version / malformed flag / bad UTF-8 / truncation /
+      trailing bytes (never a partial parse). Surfaced on
+      `AnalysisResult.provenance` (premises + sha + origins) for a library
+      consumer; mirrored in the WIT (`component-origin.component-id: string`,
+      `code-range`, `fusion-premises`) + the JSON-schema contract.
+
+      BREAKING (⇒ v2.0): the reshape retypes `component_id` (u32→string) and
+      changes `decode()`'s return type on the published `scry-sai-provenance` /
+      `scry-sai-core` APIs. synth's consumed surface (call-graph / stack /
+      reachability / operand-stack) is untouched, so it is a smooth 2.0 for
+      synth (heads-up on #51/#54).
+
+      slice-1 (this issue): the format + decode + surface premises on the
+      result. slice-2 (separate, soundness-laden): CONSUME the premises to
+      tighten analysis — bounded_memory drops grow-reachability widening (scry#5),
+      closed_world tightens reachable_from_exports (scry#51).
+    tags: [capability, interop, provenance, meld-boundary, breaking, v2.0]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given a `SCPV` v3 `component-provenance` payload, When scry-provenance decodes it, Then it round-trips losslessly (premises in the header, sha binding, UTF-8 component ids, optional code ranges) and the strict decoder hard-errors on every malformed shape rather than partial-parsing."
+        - "Given a fused module carrying a v3 section, When scry analyzes it, Then AnalysisResult.provenance carries the fusion premises + module hash + origins; a non-v3 (or absent) section yields none with a diagnostic, never a crash."
+        - "Kill-criterion: a v1/v2 section, or any malformed v3 payload, is a hard decode error (Warning + provenance=none), never a silent partial parse or a wrong attribution."
+    links:
+      - type: satisfies
+        target: REQ-008
+      - type: traces-to
+        target: DD-002
+      - type: traces-to
+        target: FEAT-002
+      - type: traces-to
+        target: G-005
+
   # ──────────────────────────────────────────────────────────────────────
   # Safety goal for the v2.0 qualification milestone.
   # ──────────────────────────────────────────────────────────────────────

--- a/contracts/scry-invariants-v1.schema.json
+++ b/contracts/scry-invariants-v1.schema.json
@@ -53,6 +53,11 @@
       "minimum": 0,
       "maximum": 4294967295
     },
+    "u8": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
     "s64": {
       "type": "integer",
       "minimum": -9223372036854775808,
@@ -309,13 +314,40 @@
         }
       }
     },
+    "code-range": {
+      "type": "object",
+      "description": "WIT record `code-range` (FEAT-032 / SCPV v3): a function body's byte span in the fused module, for DWARF address remapping.",
+      "required": ["start", "end"],
+      "additionalProperties": false,
+      "properties": {
+        "start": { "$ref": "#/$defs/u32" },
+        "end": { "$ref": "#/$defs/u32" }
+      }
+    },
+    "fusion-premises": {
+      "type": "object",
+      "description": "WIT record `fusion-premises` (FEAT-032 / scry#63): facts meld asserts by construction after fusion, usable as sound analysis assumptions.",
+      "required": ["bounded-memory", "closed-world"],
+      "additionalProperties": false,
+      "properties": {
+        "bounded-memory": {
+          "type": "boolean",
+          "description": "No `memory.grow` in the fused core → fixed linear memory."
+        },
+        "closed-world": {
+          "type": "boolean",
+          "description": "All cross-component imports internalised → no external mutation between components."
+        }
+      }
+    },
     "component-origin": {
       "type": "object",
-      "description": "WIT record `component-origin` (FEAT-002 / DD-002): one fused-module function's origin. Decoded from meld's `component-provenance` custom section (binary format `SCPV` v1, defined by the scry-provenance crate).",
+      "description": "WIT record `component-origin` (FEAT-002 / FEAT-032 / DD-002): one fused-module function's origin. Decoded from meld's `component-provenance` custom section (binary format `SCPV` v3, defined by the scry-provenance crate).",
       "required": [
         "fused-func-index",
         "component-id",
-        "orig-func-index"
+        "orig-func-index",
+        "code-range"
       ],
       "additionalProperties": false,
       "properties": {
@@ -324,23 +356,38 @@
           "$ref": "#/$defs/u32"
         },
         "component-id": {
-          "description": "Opaque identifier of the originating component. Only equality is meaningful.",
-          "$ref": "#/$defs/u32"
+          "type": "string",
+          "description": "Identifier of the originating component (meld's string id, FEAT-032 / v3). Only equality / labelling is meaningful."
         },
         "orig-func-index": {
           "description": "Function index within the originating component, before fusion.",
           "$ref": "#/$defs/u32"
+        },
+        "code-range": {
+          "description": "Byte span of the function body in the fused module, if meld recorded it (FEAT-032 / v3); null otherwise.",
+          "oneOf": [{ "$ref": "#/$defs/code-range" }, { "type": "null" }]
         }
       }
     },
     "component-provenance": {
       "type": "object",
-      "description": "WIT record `component-provenance` (FEAT-002): the decoded function-origin map meld emitted for a fused module.",
+      "description": "WIT record `component-provenance` (FEAT-002 / FEAT-032): the decoded `SCPV` v3 section meld emitted for a fused module — fusion premises, module-binding hash, and function-origin map.",
       "required": [
+        "premises",
+        "fused-module-sha256",
         "origins"
       ],
       "additionalProperties": false,
       "properties": {
+        "premises": {
+          "description": "Fusion premises meld asserts by construction (v3 header).",
+          "$ref": "#/$defs/fusion-premises"
+        },
+        "fused-module-sha256": {
+          "type": "array",
+          "description": "SHA-256 of the fused module (32 raw bytes), binding the section to its module.",
+          "items": { "$ref": "#/$defs/u8" }
+        },
         "origins": {
           "type": "array",
           "description": "One entry per fused-module function meld recorded, in file order.",

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "1.18.0" }
+scry-sai-interval = { path = "../scry-interval", version = "2.0.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,14 +43,14 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "1.18.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "1.18.0" }
+scry-sai-taint = { path = "../scry-taint", version = "2.0.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "2.0.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "1.18.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "2.0.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -80,16 +80,17 @@ use alloc::vec::Vec;
 use sha2::{Digest, Sha256};
 use wasmparser::{Operator, Parser, Payload};
 
-// The pure meld<->scry boundary crate (DD-002 / FEAT-002): the binary
-// format of the `component-provenance` custom section plus the projection
-// lookup. Aliased to avoid colliding with the mirror `ComponentOrigin`
-// type below; conversion between the two is a trivial field copy where the
-// `provenance` field is built.
-use scry_provenance::ComponentOrigin as ProvOrigin;
-
+// The pure meld<->scry boundary crate (DD-002 / FEAT-002 / FEAT-032): the
+// binary format of the `component-provenance` v3 custom section plus the
+// projection lookup. `decode()` returns a `ProvenanceSection` (premises +
+// sha + origins); the `provenance` field below maps it into the mirror types.
 use scry_octagon::Octagon;
 
 pub use scry_interval::{Interval, Region};
+// FEAT-032 (scry#63): the fusion premises + code-range types travel with the
+// `component-provenance` v3 section; re-exported so a library consumer reads
+// them off `AnalysisResult.provenance` without depending on scry-provenance.
+pub use scry_provenance::{CodeRange, FusionPremises};
 /// Mirror of WIT `abstract-value`. The abstract value of one Wasm
 /// value-stack entry or local at a program point.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -222,17 +223,26 @@ pub struct FunctionSummary {
 
 /// Mirror of WIT `component-origin` (FEAT-002 / DD-002). One fused-module
 /// function's origin.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ComponentOrigin {
     pub fused_func_index: u32,
-    pub component_id: u32,
+    /// meld's string id for the originating component (FEAT-032 / v3).
+    pub component_id: String,
     pub orig_func_index: u32,
+    /// Byte span of the function body in the fused module, if meld recorded it.
+    pub code_range: Option<CodeRange>,
 }
 
-/// Mirror of WIT `component-provenance` (FEAT-002). Decoded
-/// `component-provenance` custom section.
+/// Mirror of WIT `component-provenance` (FEAT-002 / FEAT-032). Decoded
+/// `component-provenance` v3 custom section: the fusion premises, the
+/// module-binding hash, and the function-origin table.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ComponentProvenance {
+    /// Fusion premises meld asserts by construction (scry#63). A consumer may
+    /// use these as sound analysis assumptions; absent ⇒ stay conservative.
+    pub premises: FusionPremises,
+    /// SHA-256 of the fused module the section was emitted for.
+    pub fused_module_sha256: [u8; 32],
     pub origins: Vec<ComponentOrigin>,
 }
 
@@ -408,7 +418,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "1.18.0";
+const SCRY_VERSION: &str = "2.0.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).
@@ -883,7 +893,7 @@ pub fn analyze(
     // either no section (a single un-fused component, or any plain
     // Core Wasm input) or a section that failed to decode (reported
     // via a Warning diagnostic — never a partial parse).
-    let mut provenance_origins: Option<Vec<ProvOrigin>> = None;
+    let mut provenance_section: Option<scry_provenance::ProvenanceSection> = None;
 
     for payload in Parser::new(0).parse_all(&module_bytes) {
         let payload = payload.map_err(|e| {
@@ -1088,7 +1098,7 @@ pub fn analyze(
                 // dwarf, …) are ignored.
                 if reader.name() == scry_provenance::SECTION_NAME => {
                     match scry_provenance::decode(reader.data()) {
-                        Ok(origins) => provenance_origins = Some(origins),
+                        Ok(section) => provenance_section = Some(section),
                         Err(e) => {
                             if config.emit_diagnostics {
                                 diagnostics.push(Diagnostic {
@@ -1395,7 +1405,8 @@ pub fn analyze(
     // `analysis-result.provenance`; the richer handle-state /
     // capability-flow analysis is a later FEAT-002 slice.
     // ───────────────────────────────────────────────────────────
-    let provenance = provenance_origins.as_ref().map(|origins| {
+    let provenance = provenance_section.as_ref().map(|section| {
+        let origins = &section.origins;
         if config.emit_diagnostics {
             for func in &defined_funcs {
                 match scry_provenance::project(origins, func.abs_index) {
@@ -1423,12 +1434,15 @@ pub fn analyze(
             }
         }
         ComponentProvenance {
+            premises: section.premises,
+            fused_module_sha256: section.fused_module_sha256,
             origins: origins
                 .iter()
                 .map(|o| ComponentOrigin {
                     fused_func_index: o.fused_func_index,
-                    component_id: o.component_id,
+                    component_id: o.component_id.clone(),
                     orig_func_index: o.orig_func_index,
+                    code_range: o.code_range,
                 })
                 .collect(),
         }

--- a/crates/scry-analyzer/src/lib.rs
+++ b/crates/scry-analyzer/src/lib.rs
@@ -211,6 +211,11 @@ fn summary_to_wit(s: ac::FunctionSummary) -> wit::FunctionSummary {
 
 fn provenance_to_wit(p: ac::ComponentProvenance) -> wit::ComponentProvenance {
     wit::ComponentProvenance {
+        premises: wit::FusionPremises {
+            bounded_memory: p.premises.bounded_memory,
+            closed_world: p.premises.closed_world,
+        },
+        fused_module_sha256: p.fused_module_sha256.to_vec(),
         origins: p.origins.into_iter().map(origin_to_wit).collect(),
     }
 }
@@ -220,6 +225,10 @@ fn origin_to_wit(o: ac::ComponentOrigin) -> wit::ComponentOrigin {
         fused_func_index: o.fused_func_index,
         component_id: o.component_id,
         orig_func_index: o.orig_func_index,
+        code_range: o.code_range.map(|c| wit::CodeRange {
+            start: c.start,
+            end: c.end,
+        }),
     }
 }
 

--- a/crates/scry-analyzer/wit/scry.wit
+++ b/crates/scry-analyzer/wit/scry.wit
@@ -267,31 +267,58 @@ interface analyzer {
     /// function-origin map of DD-002 variant (b.1) — resource/handle
     /// shapes are NOT carried here (scry derives those from the
     /// original component sources directly).
+    /// A function body's byte span in the fused module (FEAT-032 / v3),
+    /// for DWARF address remapping. Optional per origin.
+    record code-range {
+        start: u32,
+        end: u32,
+    }
+
     record component-origin {
         /// Index of the function in the fused Core Wasm module. This is
         /// the same index scry's `program-point.func-index` and
         /// `call-edge.caller-func` are keyed by, so projecting an
         /// invariant onto its origin is a join on this field.
         fused-func-index: u32,
-        /// Opaque identifier of the originating component in the
-        /// composition graph. Only equality is meaningful.
-        component-id: u32,
+        /// Identifier of the originating component in the composition
+        /// graph (meld's string id; FEAT-032 / v3). Only equality /
+        /// labelling is meaningful.
+        component-id: string,
         /// Index of the function within its originating component,
         /// before fusion.
         orig-func-index: u32,
+        /// Byte span of the function body in the fused module, if meld
+        /// recorded it (FEAT-032 / v3).
+        code-range: option<code-range>,
     }
 
-    /// The decoded `component-provenance` custom section (FEAT-002):
-    /// the function-origin map meld emitted for a fused module. Present
-    /// on `analysis-result.provenance` only when the analyzed module
-    /// actually carried a well-formed section; a module with no section
-    /// (e.g. a single un-fused component, or any v0.1-style Core Wasm
-    /// input) yields `none`, and a malformed section is reported via a
-    /// `diagnostic` and also yields `none` (never a partial parse).
+    /// The fusion premises meld asserts by construction (FEAT-032 /
+    /// scry#63) — facts scry cannot soundly assume on its own but that
+    /// hold after fusion. A consumer may use them as sound analysis
+    /// assumptions.
+    record fusion-premises {
+        /// No `memory.grow` in the fused core → fixed linear memory.
+        bounded-memory: bool,
+        /// All cross-component imports internalised → no external
+        /// mutation of fused state between components.
+        closed-world: bool,
+    }
+
+    /// The decoded `component-provenance` custom section (FEAT-002 /
+    /// FEAT-032). Present on `analysis-result.provenance` only when the
+    /// analyzed module carried a well-formed `SCPV` v3 section; a module
+    /// with no section yields `none`, and a malformed section is reported
+    /// via a `diagnostic` and also yields `none` (never a partial parse).
     record component-provenance {
+        /// Fusion premises meld asserts by construction (header of the
+        /// v3 section).
+        premises: fusion-premises,
+        /// SHA-256 of the fused module the section was emitted for (raw
+        /// 32 bytes), binding the section to its module.
+        fused-module-sha256: list<u8>,
         /// One entry per fused-module function meld recorded, in file
         /// order. The byte format is defined by the `scry-provenance`
-        /// crate (`SCPV` v1).
+        /// crate (`SCPV` v3).
         origins: list<component-origin>,
     }
 

--- a/crates/scry-host-tests/tests/contract.rs
+++ b/crates/scry-host-tests/tests/contract.rs
@@ -155,19 +155,37 @@ struct FunctionSummary {
     recursive: bool,
 }
 
-/// FEAT-002 — serde mirror of WIT `component-provenance` / `component-origin`.
+/// FEAT-002 / FEAT-032 — serde mirror of WIT `component-provenance` /
+/// `component-origin` / `fusion-premises` / `code-range` (SCPV v3).
 #[derive(Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct ComponentProvenance {
+    premises: FusionPremises,
+    fused_module_sha256: Vec<u8>,
     origins: Vec<ComponentOrigin>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct FusionPremises {
+    bounded_memory: bool,
+    closed_world: bool,
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct ComponentOrigin {
     fused_func_index: u32,
-    component_id: u32,
+    component_id: String,
     orig_func_index: u32,
+    code_range: Option<CodeRange>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct CodeRange {
+    start: u32,
+    end: u32,
 }
 
 // ── Schema location + representative value ───────────────────────────
@@ -293,19 +311,26 @@ fn representative_result() -> AnalysisResult {
                 recursive: true,
             },
         ],
-        // FEAT-002: a decoded component-provenance map attributing two
-        // fused functions to their originating components.
+        // FEAT-002 / FEAT-032: a decoded SCPV v3 component-provenance section —
+        // fusion premises + module hash + two attributed fused functions.
         provenance: Some(ComponentProvenance {
+            premises: FusionPremises {
+                bounded_memory: true,
+                closed_world: false,
+            },
+            fused_module_sha256: vec![0xab; 32],
             origins: vec![
                 ComponentOrigin {
                     fused_func_index: 0,
-                    component_id: 0,
+                    component_id: "lattice".to_string(),
                     orig_func_index: 0,
+                    code_range: Some(CodeRange { start: 0, end: 64 }),
                 },
                 ComponentOrigin {
                     fused_func_index: 3,
-                    component_id: 1,
+                    component_id: "analyzer".to_string(),
                     orig_func_index: 1,
+                    code_range: None,
                 },
             ],
         }),

--- a/crates/scry-host-tests/tests/provenance.rs
+++ b/crates/scry-host-tests/tests/provenance.rs
@@ -1,112 +1,125 @@
-//! Provenance round-trip + projection test — FEAT-002 (DD-002).
+//! Provenance round-trip + projection test — FEAT-002 / FEAT-032 (DD-002).
 //!
-//! This is the native falsifier for the v0.7.0 provenance slice. It
-//! exercises the `scry-provenance` crate — the *same source* the
-//! `wasm32-wasip2` scry-analyzer component links — directly under
-//! `cargo test`, so the meld<->scry section contract is mechanically
-//! checked even though a live `analyze()` round-trip is still blocked by
-//! the wac-compose / wasmtime-45 limitation documented in
-//! `tests/soundness.rs`.
+//! This is the native falsifier for the provenance slice. It exercises the
+//! `scry-provenance` crate — the *same source* the `wasm32-wasip2`
+//! scry-analyzer component links — directly under `cargo test`, so the
+//! meld<->scry section contract is mechanically checked even though a live
+//! `analyze()` round-trip is still blocked by the wac-compose / wasmtime-45
+//! limitation documented in `tests/soundness.rs`.
 //!
-//! What it asserts:
+//! What it asserts (now against the `SCPV` v3 wire format, scry#63):
 //!
-//!   * `decode(encode(x)) == x` for representative origin tables
-//!     (lossless round-trip — FEAT-002 AC#5, scry half).
-//!   * `project()` attributes a fused-module function index to its
-//!     component origin and never invents an origin for an unmapped
-//!     index (FEAT-002 AC#2, the projection primitive).
-//!   * the strict decoder rejects every malformed shape (bad magic,
-//!     unknown version, truncation, trailing garbage) rather than
+//!   * `decode(encode(x)) == x` for a representative section (lossless
+//!     round-trip incl. the header premises, sha binding, string component
+//!     ids, and optional code ranges).
+//!   * `project()` attributes a fused-module function index to its component
+//!     origin and never invents an origin for an unmapped index.
+//!   * the strict decoder rejects every malformed shape (bad magic, unknown
+//!     version, malformed flag, truncation, trailing garbage) rather than
 //!     silently partial-parsing.
 
 #![forbid(unsafe_code)]
 
 use scry_provenance::{
-    ComponentOrigin, DecodeError, FORMAT_VERSION, MAGIC, SECTION_NAME, decode, encode, project,
+    CodeRange, ComponentOrigin, DecodeError, FORMAT_VERSION, FusionPremises, MAGIC,
+    ProvenanceSection, SECTION_NAME, decode, encode, project,
 };
 
-fn sample() -> Vec<ComponentOrigin> {
-    vec![
-        // Two functions from component 0 (e.g. the lattice component),
-        // one from component 1 (the analyzer), with a non-trivial
-        // fused-index gap to prove projection isn't positional.
-        ComponentOrigin {
-            fused_func_index: 0,
-            component_id: 0,
-            orig_func_index: 0,
+fn sample() -> ProvenanceSection {
+    ProvenanceSection {
+        premises: FusionPremises {
+            bounded_memory: true,
+            closed_world: false,
         },
-        ComponentOrigin {
-            fused_func_index: 1,
-            component_id: 0,
-            orig_func_index: 1,
-        },
-        ComponentOrigin {
-            fused_func_index: 5,
-            component_id: 1,
-            orig_func_index: 0,
-        },
-        ComponentOrigin {
-            fused_func_index: 6,
-            component_id: 1,
-            orig_func_index: 1,
-        },
-    ]
+        fused_module_sha256: [0x5a; 32],
+        // Two functions from the lattice component, two from the analyzer,
+        // with a non-trivial fused-index gap to prove projection isn't
+        // positional, and a mix of present/absent code ranges + a UTF-8 id.
+        origins: vec![
+            ComponentOrigin {
+                fused_func_index: 0,
+                component_id: "lattice".to_string(),
+                orig_func_index: 0,
+                code_range: Some(CodeRange { start: 0, end: 64 }),
+            },
+            ComponentOrigin {
+                fused_func_index: 1,
+                component_id: "lattice".to_string(),
+                orig_func_index: 1,
+                code_range: None,
+            },
+            ComponentOrigin {
+                fused_func_index: 5,
+                component_id: "analyzer".to_string(),
+                orig_func_index: 0,
+                code_range: Some(CodeRange {
+                    start: 64,
+                    end: 4096,
+                }),
+            },
+            ComponentOrigin {
+                fused_func_index: 6,
+                component_id: "analyzer".to_string(),
+                orig_func_index: 1,
+                code_range: None,
+            },
+        ],
+    }
 }
 
 #[test]
 fn section_name_is_the_meld_contract() {
-    // If this string ever changes, meld's emitter and scry's reader
+    // If this string/version ever changes, meld's emitter and scry's reader
     // disagree and projection silently disappears — pin it.
     assert_eq!(SECTION_NAME, "component-provenance");
     assert_eq!(&MAGIC, b"SCPV");
-    assert_eq!(FORMAT_VERSION, 1);
+    assert_eq!(FORMAT_VERSION, 3);
 }
 
 #[test]
 fn round_trip_is_lossless() {
-    let origins = sample();
-    let bytes = encode(&origins);
+    let section = sample();
+    let bytes = encode(&section);
     let decoded = decode(&bytes).expect("round-trip decode must succeed");
-    assert_eq!(
-        decoded, origins,
-        "decode(encode(x)) must equal x (FEAT-002 AC#5)"
-    );
+    assert_eq!(decoded, section, "decode(encode(x)) must equal x");
+}
+
+#[test]
+fn premises_survive_the_round_trip() {
+    for (bm, cw) in [(false, false), (true, false), (false, true), (true, true)] {
+        let mut s = sample();
+        s.premises = FusionPremises {
+            bounded_memory: bm,
+            closed_world: cw,
+        };
+        let d = decode(&encode(&s)).unwrap();
+        assert_eq!(d.premises.bounded_memory, bm);
+        assert_eq!(d.premises.closed_world, cw);
+    }
 }
 
 #[test]
 fn empty_table_round_trips() {
-    assert_eq!(decode(&encode(&[])), Ok(Vec::new()));
+    let s = ProvenanceSection {
+        premises: FusionPremises::default(),
+        fused_module_sha256: [0; 32],
+        origins: Vec::new(),
+    };
+    assert_eq!(decode(&encode(&s)), Ok(s));
 }
 
 #[test]
 fn projection_attributes_and_never_invents() {
-    let origins = sample();
+    let origins = sample().origins;
 
-    // A mapped fused index resolves to its exact component origin.
-    assert_eq!(
-        project(&origins, 5),
-        Some(ComponentOrigin {
-            fused_func_index: 5,
-            component_id: 1,
-            orig_func_index: 0
-        }),
-        "projection must attribute fused func 5 to component 1 / func 0"
-    );
+    let hit = project(&origins, 5).expect("fused func 5 maps");
+    assert_eq!(hit.component_id, "analyzer");
+    assert_eq!(hit.orig_func_index, 0);
 
-    // Projection is keyed by fused-func-index, not position: index 6
-    // (the 4th entry) resolves correctly.
-    assert_eq!(
-        project(&origins, 6),
-        Some(ComponentOrigin {
-            fused_func_index: 6,
-            component_id: 1,
-            orig_func_index: 1
-        })
-    );
+    // Keyed by fused-func-index, not position: index 6 (the 4th entry).
+    assert_eq!(project(&origins, 6).unwrap().orig_func_index, 1);
 
-    // Unmapped fused indices must yield None — never a fabricated
-    // origin (the soundness property of attribution: scry never claims
-    // a component source it cannot prove).
+    // Unmapped fused indices must yield None — never a fabricated origin.
     assert_eq!(project(&origins, 2), None);
     assert_eq!(project(&origins, 4), None);
     assert_eq!(project(&origins, 100), None);
@@ -116,18 +129,13 @@ fn projection_attributes_and_never_invents() {
 #[test]
 fn round_trips_through_a_real_wasm_custom_section() {
     // Build a minimal core module and append a real Wasm custom section
-    // named `component-provenance` carrying the encoded payload, then
-    // confirm the section name + payload survive the Wasm encoding and
-    // decode back to the original table. This is the exact byte path the
-    // analyzer's pre-pass walks: `reader.name() == SECTION_NAME` then
-    // `decode(reader.data())`.
-    let origins = sample();
-    let payload = encode(&origins);
+    // named `component-provenance` carrying the encoded payload, then confirm
+    // it decodes back. This is the exact byte path the analyzer's pre-pass
+    // walks: `reader.name() == SECTION_NAME` then `decode(reader.data())`.
+    let section = sample();
+    let payload = encode(&section);
 
-    // Smallest valid core module: the 8-byte header `\0asm` + version 1.
     let mut module: Vec<u8> = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
-    // Custom section: id 0, then a size-prefixed body of
-    // (name-len, name, payload).
     let name = SECTION_NAME.as_bytes();
     let mut body: Vec<u8> = Vec::new();
     write_uleb128(&mut body, name.len() as u64);
@@ -137,9 +145,7 @@ fn round_trips_through_a_real_wasm_custom_section() {
     write_uleb128(&mut module, body.len() as u64);
     module.extend_from_slice(&body);
 
-    // Walk the module with wasmparser exactly as the analyzer does and
-    // pull the `component-provenance` section back out.
-    let mut found: Option<Vec<ComponentOrigin>> = None;
+    let mut found: Option<ProvenanceSection> = None;
     for payload in wasmparser::Parser::new(0).parse_all(&module) {
         if let wasmparser::Payload::CustomSection(reader) =
             payload.expect("module the test just built must parse")
@@ -150,7 +156,7 @@ fn round_trips_through_a_real_wasm_custom_section() {
     }
     assert_eq!(
         found,
-        Some(origins),
+        Some(section),
         "the component-provenance custom section must survive Wasm encoding and decode losslessly"
     );
 }
@@ -162,28 +168,33 @@ fn decoder_rejects_malformed_payloads() {
     bad[0] = b'Z';
     assert!(matches!(decode(&bad), Err(DecodeError::BadMagic { .. })));
 
-    // Unknown version.
+    // Unknown version (a v1/v2 section is a hard error on this v3 build).
     let mut bad = encode(&sample());
-    bad[4] = 9;
+    bad[4] = 1;
     assert_eq!(
         decode(&bad),
-        Err(DecodeError::UnsupportedVersion { found: 9 })
+        Err(DecodeError::UnsupportedVersion { found: 1 })
     );
 
-    // Truncated body.
+    // Malformed premise flag.
     let mut bad = encode(&sample());
-    bad.truncate(bad.len() - 1);
+    bad[5] = 2;
     assert!(matches!(
         decode(&bad),
-        Err(DecodeError::LengthMismatch { .. })
+        Err(DecodeError::MalformedFlag { .. })
     ));
+
+    // Truncated body (chop into the last entry).
+    let mut bad = encode(&sample());
+    bad.truncate(bad.len() - 1);
+    assert!(matches!(decode(&bad), Err(DecodeError::Truncated { .. })));
 
     // Trailing garbage.
     let mut bad = encode(&sample());
     bad.push(0x00);
     assert!(matches!(
         decode(&bad),
-        Err(DecodeError::LengthMismatch { .. })
+        Err(DecodeError::TrailingBytes { .. })
     ));
 
     // Too short for the header.
@@ -193,9 +204,9 @@ fn decoder_rejects_malformed_payloads() {
     ));
 }
 
-/// Minimal unsigned LEB128 writer — wasmparser reads sizes as LEB128, so
-/// the test must encode the custom-section name length and body length
-/// the same way. (We don't pull in `wasm-encoder` just for this.)
+/// Minimal unsigned LEB128 writer — wasmparser reads sizes as LEB128, so the
+/// test must encode the custom-section name length and body length the same
+/// way. (We don't pull in `wasm-encoder` just for this.)
 fn write_uleb128(out: &mut Vec<u8>, mut value: u64) {
     loop {
         let mut byte = (value & 0x7f) as u8;

--- a/crates/scry-provenance/README.md
+++ b/crates/scry-provenance/README.md
@@ -10,6 +10,14 @@ section, so scry can attribute a fused-module function back to its originating
 component instance. The round-trip is the contract that lets scry report
 findings in component-level terms.
 
+The wire format is the strict little-endian binary **`SCPV` v3** (scry#63 /
+meld#313): the canonical shape both meld (producer) and scry (consumer) build
+to. v3 carries, in the section, the **fusion premises** meld knows by
+construction — `bounded_memory` and `closed_world` — a `fused_module_sha256`
+binding, a UTF-8 `component_id`, and an optional per-entry `code_range`. The
+decoder is strict: a bad magic, unknown version, malformed flag, non-UTF-8 id,
+truncation, or trailing bytes is a hard error, never a partial parse.
+
 Compiles natively and to `wasm32` (the shipped scry component links this code).
 Imported as `scry_provenance`.
 

--- a/crates/scry-provenance/src/lib.rs
+++ b/crates/scry-provenance/src/lib.rs
@@ -1,116 +1,130 @@
-//! scry-provenance — the typed boundary between meld and scry for the
-//! Wasm Component Model analysis (DD-002, [[FEAT-002]]).
+//! `scry-provenance` — the `component-provenance` custom-section format
+//! (DD-002 / REQ-008): **meld is the producer, scry is the consumer.**
 //!
-//! ## What this is
+//! This crate is scry's *trusted* decoder for the section meld writes onto a
+//! fused Core Wasm module. It is `#![no_std]` and parses a strict little-endian
+//! binary format — no JSON parser in the trusted base (scry#63: keep the
+//! DO-333 decoder lean; the one-time encoder swap lands on meld, the untrusted
+//! std host).
 //!
-//! Per DD-002 (closed 2026-05-26 in favour of option (b)), scry runs its
-//! Component-Model analysis on the *original component sources* upstream
-//! of meld, while meld emits a minimal `component-provenance` custom
-//! section into the fused Core Wasm module. That section maps each
-//! fused-module function index back to the component + function it came
-//! from. scry's post-meld stage decodes the section and *projects* its
-//! Component-Model invariants onto concrete fused-module locations so
-//! they stay consumable by loom, witness, and the sigil/rivet evidence
-//! chain.
+//! ## Binary format (`SCPV` v3)
 //!
-//! This crate is exactly that typed contract: the on-the-wire byte
-//! format of the section, plus the projection lookup. meld is the
-//! producer (its emitter is a separate cross-repo concern, mirroring
-//! FEAT-008 / meld#192); scry is the consumer. Putting the format in
-//! one pure crate means both sides agree on the bytes by construction
-//! rather than by prose.
-//!
-//! ## v0.7.0 scope (provenance-first slice)
-//!
-//! This is the *provenance half* of FEAT-002. It delivers the typed
-//! boundary + the projection primitive; the handle-state lattice
-//! (fresh/owned/borrowed/dropped) and use-after-drop detection are a
-//! later slice. Per DD-002's chosen variant (b.1), the section is the
-//! minimal function-origin map only — resource type names and handle
-//! shapes are NOT recorded here (scry derives those from the original
-//! component sources directly).
-//!
-//! ## Why a separate, zero-dependency crate
-//!
-//! The same source compiles into the `wasm32-wasip2` scry-analyzer
-//! component (`#![no_std]` + `alloc`) *and* natively into the
-//! scry-host-tests harness. Keeping it dependency-free means the
-//! encode -> decode -> project round-trip is mechanically falsifiable on
-//! the native cargo path (`cargo test`) even while the live component
-//! `analyze()` round-trip stays blocked by the wac-compose / wasmtime-45
-//! limitation documented in `crates/scry-host-tests/tests/soundness.rs`.
-//!
-//! ## Binary format (`SCPV` v1)
-//!
-//! The custom section's *payload* (i.e. the bytes after the Wasm
-//! custom-section name `component-provenance`) is:
+//! v3 (scry#63 / meld#313) makes scry's binary format the canonical wire shape
+//! both sides build to. It adds, over the original v1: the two **fusion
+//! premises** meld knows by construction (carried in the fixed header so a
+//! consumer reads them without walking entries), a `fused_module_sha256`
+//! binding the section to its module, a UTF-8 (length-prefixed) `component_id`
+//! (meld's string id), and an optional per-entry `code_range` (the function
+//! body's byte span, for DWARF address remapping).
 //!
 //! ```text
-//! offset  size  field
-//! 0       4     magic = b"SCPV" (0x53 0x43 0x50 0x56)
-//! 4       1     format-version = 1
-//! 5       4     entry-count : u32 little-endian
-//! 9       12*n  entries, each:
-//!                 0  4  fused-func-index : u32 LE
-//!                 4  4  component-id     : u32 LE
-//!                 8  4  orig-func-index  : u32 LE
+//! offset  size    field
+//! 0       4       magic = b"SCPV"
+//! 4       1       version = 3              (decoder dispatches AFTER magic)
+//! 5       1       bounded_memory : 0|1     premise: no memory.grow in fused core
+//! 6       1       closed_world   : 0|1     premise: cross-component imports internalised
+//! 7       32      fused_module_sha256      raw bytes, binds section ↔ module
+//! 39      4       entry_count : u32 LE
+//! 43      …       entries[entry_count], each (variable length):
+//!                   0  4        fused_func_index  : u32 LE
+//!                   4  4        component_id_len  : u32 LE
+//!                   8  len      component_id      : UTF-8 bytes
+//!                   …  4        orig_func_index   : u32 LE
+//!                   …  1        has_code_range    : 0|1
+//!                   [if 1] 4    code_range_start  : u32 LE
+//!                          4    code_range_end    : u32 LE
 //! ```
 //!
-//! All multi-byte integers are little-endian. The decoder is strict:
-//! it rejects a bad magic, an unknown version, a truncated buffer, and
-//! any trailing bytes past the declared entry count — so a malformed or
-//! version-mismatched section is a hard error, never a silent
-//! partial-parse.
+//! All multi-byte integers are little-endian. The decoder is strict: it rejects
+//! a bad magic, an unknown version, a malformed flag byte, a non-UTF-8
+//! component id, a truncated buffer, and any trailing bytes past the declared
+//! entries — so a malformed or version-mismatched section is a hard error,
+//! never a silent partial-parse. (Premises are *absent* only in older versions;
+//! a v3 header always carries them — a consumer reading an older version that
+//! lacks the bytes falls back to conservative.)
 
 #![cfg_attr(not(test), no_std)]
 
 extern crate alloc;
 
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
 
-/// Wasm custom-section name meld writes and scry reads. This is the
-/// `name` field of the Wasm custom section, not the payload.
+/// Wasm custom-section name meld writes and scry reads. This is the `name`
+/// field of the Wasm custom section, not the payload.
 pub const SECTION_NAME: &str = "component-provenance";
 
 /// Payload magic: `b"SCPV"` — "scry component provenance".
 pub const MAGIC: [u8; 4] = *b"SCPV";
 
 /// The format version this crate emits and is the maximum it accepts.
-pub const FORMAT_VERSION: u8 = 1;
+pub const FORMAT_VERSION: u8 = 3;
 
-/// Fixed payload header size: 4 (magic) + 1 (version) + 4 (count).
-const HEADER_LEN: usize = 9;
+/// Fixed header size: 4 (magic) + 1 (version) + 1 (bounded_memory) +
+/// 1 (closed_world) + 32 (sha256) + 4 (entry_count).
+const HEADER_LEN: usize = 43;
 
-/// Fixed per-entry size: three u32s.
-const ENTRY_LEN: usize = 12;
+/// The fusion premises meld asserts by construction — facts scry cannot soundly
+/// assume on its own but that hold after fusion. Carried in the section header
+/// (scry#63). Absent ⇒ a consumer stays conservative; here they are always
+/// present in v3.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct FusionPremises {
+    /// No `memory.grow` in the fused core → linear memory is fixed-size. Lets
+    /// the analyzer drop grow-reachability widening.
+    pub bounded_memory: bool,
+    /// All cross-component imports internalised → no external mutation of fused
+    /// state between components. Lets the analyzer tighten reachability.
+    pub closed_world: bool,
+}
 
-/// One fused-module function's origin: which component + which function
-/// in that component it was lowered from. This is the minimal
-/// function-origin map of DD-002 variant (b.1) — no resource/handle
-/// shapes are recorded.
+/// The function body's byte span in the fused module (for DWARF address
+/// remapping). v2+ per-entry; optional.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CodeRange {
+    /// Start byte offset of the function body.
+    pub start: u32,
+    /// End byte offset (exclusive) of the function body.
+    pub end: u32,
+}
+
+/// One fused-module function's origin: which component + which function in that
+/// component it was lowered from. The minimal function-origin map of DD-002
+/// variant (b.1); v3 carries meld's string `component_id` and an optional
+/// `code_range`.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ComponentOrigin {
-    /// Index of the function in the fused Core Wasm module meld emitted.
-    /// This is the key scry's invariants / call-edges are already
-    /// keyed by, so projection is a join on this field.
+    /// Index of the function in the fused Core Wasm module meld emitted — the
+    /// key scry's invariants / call-edges are keyed by, so projection is a join
+    /// on this field.
     pub fused_func_index: u32,
-    /// Opaque identifier of the originating component in the
-    /// composition graph. Only equality is meaningful; the mapping
-    /// from id to a component name (if any) is out of scope for the
-    /// minimal section.
-    pub component_id: u32,
-    /// Index of the function within its originating component, before
-    /// fusion.
+    /// Identifier of the originating component in the composition graph
+    /// (meld's string id; only equality/labelling is meaningful).
+    pub component_id: String,
+    /// Index of the function within its originating component, before fusion.
     pub orig_func_index: u32,
+    /// Byte span of the function body in the fused module, if meld recorded it.
+    pub code_range: Option<CodeRange>,
+}
+
+/// A fully decoded `component-provenance` section: the fusion premises, the
+/// module-binding hash, and the function-origin table.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProvenanceSection {
+    /// Fusion premises (header).
+    pub premises: FusionPremises,
+    /// SHA-256 of the fused module the section was emitted for.
+    pub fused_module_sha256: [u8; 32],
+    /// Per-function origins, in file order.
+    pub origins: Vec<ComponentOrigin>,
 }
 
 /// Why decoding a `component-provenance` payload failed. The decoder is
-/// deliberately strict: every failure mode is a distinct, testable
-/// variant rather than a lenient best-effort parse.
+/// deliberately strict: every failure mode is a distinct, testable variant.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DecodeError {
-    /// The payload is shorter than the fixed 9-byte header.
+    /// The payload is shorter than the fixed header.
     TooShortForHeader {
         /// Actual payload length in bytes.
         len: usize,
@@ -125,15 +139,33 @@ pub enum DecodeError {
         /// The version byte that was found.
         found: u8,
     },
-    /// The declared entry count does not match the number of entry-sized
-    /// chunks actually present after the header. Catches both truncation
-    /// (fewer bytes than declared) and trailing garbage (more bytes than
-    /// declared).
-    LengthMismatch {
-        /// Entry count declared in the header.
-        declared_entries: u32,
-        /// Number of payload bytes after the 9-byte header.
-        body_len: usize,
+    /// A boolean flag byte (a premise, or `has_code_range`) was not 0 or 1.
+    MalformedFlag {
+        /// Byte offset of the bad flag.
+        offset: usize,
+        /// The non-boolean value found.
+        value: u8,
+    },
+    /// A `component_id` byte run was not valid UTF-8.
+    BadComponentId {
+        /// Byte offset where the id started.
+        offset: usize,
+    },
+    /// The payload ended mid-field while decoding an entry.
+    Truncated {
+        /// Offset at which more bytes were needed.
+        offset: usize,
+        /// Number of bytes still required there.
+        need: usize,
+        /// Total payload length.
+        len: usize,
+    },
+    /// Bytes remained after the declared number of entries were decoded.
+    TrailingBytes {
+        /// Offset where decoding finished.
+        at: usize,
+        /// Total payload length.
+        len: usize,
     },
 }
 
@@ -150,48 +182,110 @@ impl fmt::Display for DecodeError {
             ),
             DecodeError::UnsupportedVersion { found } => write!(
                 f,
-                "component-provenance unsupported format version {found} (this build accepts <= {FORMAT_VERSION})"
+                "component-provenance unsupported format version {found} (this build expects {FORMAT_VERSION})"
             ),
-            DecodeError::LengthMismatch {
-                declared_entries,
-                body_len,
-            } => write!(
+            DecodeError::MalformedFlag { offset, value } => write!(
                 f,
-                "component-provenance length mismatch: header declares {declared_entries} entries \
-                 ({} body bytes) but {body_len} body bytes are present",
-                (*declared_entries as usize).saturating_mul(ENTRY_LEN)
+                "component-provenance malformed flag byte {value} at offset {offset} (expected 0 or 1)"
+            ),
+            DecodeError::BadComponentId { offset } => write!(
+                f,
+                "component-provenance component_id at offset {offset} is not valid UTF-8"
+            ),
+            DecodeError::Truncated { offset, need, len } => write!(
+                f,
+                "component-provenance truncated at offset {offset}: need {need} more bytes ({len}-byte payload)"
+            ),
+            DecodeError::TrailingBytes { at, len } => write!(
+                f,
+                "component-provenance trailing bytes: decoded through offset {at} of a {len}-byte payload"
             ),
         }
     }
 }
 
-/// Serialize a function-origin table into a `component-provenance`
-/// section payload (the bytes after the section name). The output is
-/// always a valid `SCPV` v1 payload: `decode(&encode(x)) == Ok(x)`.
-pub fn encode(origins: &[ComponentOrigin]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(HEADER_LEN + origins.len() * ENTRY_LEN);
+/// Serialize a `ProvenanceSection` into a `SCPV` v3 payload (the bytes after the
+/// section name). `decode(&encode(x)) == Ok(x)`. (scry's encoder is for tests
+/// and tooling; meld is the production producer, building to the same layout.)
+pub fn encode(section: &ProvenanceSection) -> Vec<u8> {
+    let mut out = Vec::with_capacity(HEADER_LEN + section.origins.len() * 16);
     out.extend_from_slice(&MAGIC);
     out.push(FORMAT_VERSION);
-    out.extend_from_slice(&(origins.len() as u32).to_le_bytes());
-    for o in origins {
+    out.push(section.premises.bounded_memory as u8);
+    out.push(section.premises.closed_world as u8);
+    out.extend_from_slice(&section.fused_module_sha256);
+    out.extend_from_slice(&(section.origins.len() as u32).to_le_bytes());
+    for o in &section.origins {
         out.extend_from_slice(&o.fused_func_index.to_le_bytes());
-        out.extend_from_slice(&o.component_id.to_le_bytes());
+        let id = o.component_id.as_bytes();
+        out.extend_from_slice(&(id.len() as u32).to_le_bytes());
+        out.extend_from_slice(id);
         out.extend_from_slice(&o.orig_func_index.to_le_bytes());
+        match &o.code_range {
+            Some(cr) => {
+                out.push(1);
+                out.extend_from_slice(&cr.start.to_le_bytes());
+                out.extend_from_slice(&cr.end.to_le_bytes());
+            }
+            None => out.push(0),
+        }
     }
     out
 }
 
-/// Read a u32 little-endian at `off`. Caller guarantees the slice has at
-/// least `off + 4` bytes (the bounds are pre-checked by `decode`).
-fn read_u32_le(bytes: &[u8], off: usize) -> u32 {
-    u32::from_le_bytes([bytes[off], bytes[off + 1], bytes[off + 2], bytes[off + 3]])
+fn take_u32(b: &[u8], off: &mut usize) -> Result<u32, DecodeError> {
+    let end = off
+        .checked_add(4)
+        .filter(|e| *e <= b.len())
+        .ok_or(DecodeError::Truncated {
+            offset: *off,
+            need: 4,
+            len: b.len(),
+        })?;
+    let v = u32::from_le_bytes([b[*off], b[*off + 1], b[*off + 2], b[*off + 3]]);
+    *off = end;
+    Ok(v)
 }
 
-/// Decode a `component-provenance` section payload into its
-/// function-origin table. Strict: see [`DecodeError`] for every
-/// rejected shape. On success the returned vector has exactly the
-/// declared number of entries, in file order.
-pub fn decode(bytes: &[u8]) -> Result<Vec<ComponentOrigin>, DecodeError> {
+fn take_u8(b: &[u8], off: &mut usize) -> Result<u8, DecodeError> {
+    if *off >= b.len() {
+        return Err(DecodeError::Truncated {
+            offset: *off,
+            need: 1,
+            len: b.len(),
+        });
+    }
+    let v = b[*off];
+    *off += 1;
+    Ok(v)
+}
+
+fn take_slice<'a>(b: &'a [u8], off: &mut usize, n: usize) -> Result<&'a [u8], DecodeError> {
+    let end = off
+        .checked_add(n)
+        .filter(|e| *e <= b.len())
+        .ok_or(DecodeError::Truncated {
+            offset: *off,
+            need: n,
+            len: b.len(),
+        })?;
+    let s = &b[*off..end];
+    *off = end;
+    Ok(s)
+}
+
+fn decode_flag(byte: u8, offset: usize) -> Result<bool, DecodeError> {
+    match byte {
+        0 => Ok(false),
+        1 => Ok(true),
+        value => Err(DecodeError::MalformedFlag { offset, value }),
+    }
+}
+
+/// Decode a `component-provenance` section payload. Strict: see [`DecodeError`]
+/// for every rejected shape. On success the origins are in file order and the
+/// whole payload was consumed.
+pub fn decode(bytes: &[u8]) -> Result<ProvenanceSection, DecodeError> {
     if bytes.len() < HEADER_LEN {
         return Err(DecodeError::TooShortForHeader { len: bytes.len() });
     }
@@ -203,120 +297,159 @@ pub fn decode(bytes: &[u8]) -> Result<Vec<ComponentOrigin>, DecodeError> {
     if version != FORMAT_VERSION {
         return Err(DecodeError::UnsupportedVersion { found: version });
     }
-    let declared_entries = read_u32_le(bytes, 5);
-    let body_len = bytes.len() - HEADER_LEN;
-    // Exact match required: catches truncation AND trailing garbage.
-    // Use u64 math so the multiply can't overflow `usize` on a 32-bit
-    // host before the comparison.
-    let expected_body = (declared_entries as u64).saturating_mul(ENTRY_LEN as u64);
-    if expected_body != body_len as u64 {
-        return Err(DecodeError::LengthMismatch {
-            declared_entries,
-            body_len,
-        });
-    }
-    let mut origins = Vec::with_capacity(declared_entries as usize);
+    let premises = FusionPremises {
+        bounded_memory: decode_flag(bytes[5], 5)?,
+        closed_world: decode_flag(bytes[6], 6)?,
+    };
+    let mut fused_module_sha256 = [0u8; 32];
+    fused_module_sha256.copy_from_slice(&bytes[7..39]);
+
     let mut off = HEADER_LEN;
-    for _ in 0..declared_entries {
+    let entry_count = {
+        let mut h = 39;
+        take_u32(bytes, &mut h)? // header count at offset 39 (h advances to 43)
+    };
+    let mut origins = Vec::with_capacity(entry_count as usize);
+    for _ in 0..entry_count {
+        let fused_func_index = take_u32(bytes, &mut off)?;
+        let id_len = take_u32(bytes, &mut off)? as usize;
+        let id_start = off;
+        let id_bytes = take_slice(bytes, &mut off, id_len)?;
+        let component_id = match core::str::from_utf8(id_bytes) {
+            Ok(s) => String::from(s),
+            Err(_) => return Err(DecodeError::BadComponentId { offset: id_start }),
+        };
+        let orig_func_index = take_u32(bytes, &mut off)?;
+        let has_code_range = decode_flag(take_u8(bytes, &mut off)?, off - 1)?;
+        let code_range = if has_code_range {
+            let start = take_u32(bytes, &mut off)?;
+            let end = take_u32(bytes, &mut off)?;
+            Some(CodeRange { start, end })
+        } else {
+            None
+        };
         origins.push(ComponentOrigin {
-            fused_func_index: read_u32_le(bytes, off),
-            component_id: read_u32_le(bytes, off + 4),
-            orig_func_index: read_u32_le(bytes, off + 8),
+            fused_func_index,
+            component_id,
+            orig_func_index,
+            code_range,
         });
-        off += ENTRY_LEN;
     }
-    Ok(origins)
+    if off != bytes.len() {
+        return Err(DecodeError::TrailingBytes {
+            at: off,
+            len: bytes.len(),
+        });
+    }
+    Ok(ProvenanceSection {
+        premises,
+        fused_module_sha256,
+        origins,
+    })
 }
 
-/// Project a fused-module function index back to its component origin.
-///
-/// This is the core of FEAT-002's "associate every Component-Model
-/// invariant with a concrete location in the fused module" step: scry's
-/// invariants and call-edges are keyed by `fused_func_index`, so
-/// attaching an origin is a lookup in the decoded table.
-///
-/// Returns the first matching origin (meld emits at most one entry per
-/// fused function; if a malformed section ever carried duplicates the
-/// first wins, which is sound for attribution — it never invents an
-/// origin for an unmapped function).
+/// Project a fused-module function index back to its component origin. scry's
+/// invariants and call-edges are keyed by `fused_func_index`, so attaching an
+/// origin is a lookup in the decoded table. Returns the first matching origin;
+/// never invents an origin for an unmapped function.
 pub fn project(origins: &[ComponentOrigin], fused_func_index: u32) -> Option<ComponentOrigin> {
     origins
         .iter()
         .find(|o| o.fused_func_index == fused_func_index)
-        .copied()
+        .cloned()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
     use alloc::vec;
 
-    fn sample() -> Vec<ComponentOrigin> {
-        vec![
-            ComponentOrigin {
-                fused_func_index: 0,
-                component_id: 0,
-                orig_func_index: 0,
+    fn sample() -> ProvenanceSection {
+        ProvenanceSection {
+            premises: FusionPremises {
+                bounded_memory: true,
+                closed_world: false,
             },
-            ComponentOrigin {
-                fused_func_index: 1,
-                component_id: 0,
-                orig_func_index: 1,
-            },
-            ComponentOrigin {
-                fused_func_index: 7,
-                component_id: 3,
-                orig_func_index: 2,
-            },
-            ComponentOrigin {
-                fused_func_index: u32::MAX,
-                component_id: u32::MAX,
-                orig_func_index: u32::MAX,
-            },
-        ]
+            fused_module_sha256: [0xab; 32],
+            origins: vec![
+                ComponentOrigin {
+                    fused_func_index: 0,
+                    component_id: "auth".to_string(),
+                    orig_func_index: 0,
+                    code_range: Some(CodeRange { start: 0, end: 42 }),
+                },
+                ComponentOrigin {
+                    fused_func_index: 1,
+                    component_id: "auth".to_string(),
+                    orig_func_index: 1,
+                    code_range: None,
+                },
+                ComponentOrigin {
+                    fused_func_index: 7,
+                    component_id: "db-store".to_string(),
+                    orig_func_index: 2,
+                    code_range: Some(CodeRange {
+                        start: 100,
+                        end: u32::MAX,
+                    }),
+                },
+            ],
+        }
     }
 
     #[test]
     fn round_trip_is_lossless() {
-        let origins = sample();
-        let bytes = encode(&origins);
-        // Header + 4 entries.
-        assert_eq!(bytes.len(), HEADER_LEN + 4 * ENTRY_LEN);
+        let section = sample();
+        let bytes = encode(&section);
         assert_eq!(&bytes[0..4], &MAGIC);
         assert_eq!(bytes[4], FORMAT_VERSION);
+        assert_eq!(bytes[5], 1, "bounded_memory");
+        assert_eq!(bytes[6], 0, "closed_world");
         let decoded = decode(&bytes).expect("round-trip decode");
-        assert_eq!(decoded, origins, "decode(encode(x)) must equal x");
+        assert_eq!(decoded, section, "decode(encode(x)) must equal x");
+    }
+
+    #[test]
+    fn premises_in_header_decode_both_ways() {
+        for (bm, cw) in [(false, false), (true, false), (false, true), (true, true)] {
+            let mut s = sample();
+            s.premises = FusionPremises {
+                bounded_memory: bm,
+                closed_world: cw,
+            };
+            let d = decode(&encode(&s)).unwrap();
+            assert_eq!(d.premises.bounded_memory, bm);
+            assert_eq!(d.premises.closed_world, cw);
+        }
     }
 
     #[test]
     fn empty_table_round_trips() {
-        let bytes = encode(&[]);
+        let s = ProvenanceSection {
+            premises: FusionPremises::default(),
+            fused_module_sha256: [0; 32],
+            origins: Vec::new(),
+        };
+        let bytes = encode(&s);
         assert_eq!(bytes.len(), HEADER_LEN);
-        assert_eq!(decode(&bytes), Ok(Vec::new()));
+        assert_eq!(decode(&bytes), Ok(s));
+    }
+
+    #[test]
+    fn utf8_component_ids_round_trip() {
+        let mut s = sample();
+        s.origins[0].component_id = "compōnent/ünicode".to_string();
+        let d = decode(&encode(&s)).unwrap();
+        assert_eq!(d.origins[0].component_id, "compōnent/ünicode");
     }
 
     #[test]
     fn projection_hits_and_misses() {
-        let origins = sample();
-        assert_eq!(
-            project(&origins, 7),
-            Some(ComponentOrigin {
-                fused_func_index: 7,
-                component_id: 3,
-                orig_func_index: 2,
-            })
-        );
-        assert_eq!(
-            project(&origins, 0),
-            Some(ComponentOrigin {
-                fused_func_index: 0,
-                component_id: 0,
-                orig_func_index: 0,
-            })
-        );
-        // An unmapped fused index must not be invented.
-        assert_eq!(project(&origins, 2), None);
-        assert_eq!(project(&origins, 999), None);
+        let s = sample();
+        assert_eq!(project(&s.origins, 7).unwrap().component_id, "db-store");
+        assert_eq!(project(&s.origins, 0).unwrap().orig_func_index, 0);
+        assert_eq!(project(&s.origins, 2), None); // unmapped, not invented
         assert_eq!(project(&[], 0), None);
     }
 
@@ -343,57 +476,63 @@ mod tests {
 
     #[test]
     fn rejects_unsupported_version() {
+        // A v1/v2 (or future) section is a hard error on this v3 build.
         let mut bytes = encode(&sample());
-        bytes[4] = 2;
+        bytes[4] = 1;
         assert_eq!(
             decode(&bytes),
-            Err(DecodeError::UnsupportedVersion { found: 2 })
+            Err(DecodeError::UnsupportedVersion { found: 1 })
         );
     }
 
     #[test]
-    fn rejects_truncated_body() {
+    fn rejects_malformed_premise_flag() {
         let mut bytes = encode(&sample());
-        // Drop the last 3 bytes of the final entry → body shorter than
-        // the header's declared 4 entries.
-        bytes.truncate(bytes.len() - 3);
-        let body_len = bytes.len() - HEADER_LEN;
+        bytes[5] = 2; // bounded_memory neither 0 nor 1
         assert_eq!(
             decode(&bytes),
-            Err(DecodeError::LengthMismatch {
-                declared_entries: 4,
-                body_len,
+            Err(DecodeError::MalformedFlag {
+                offset: 5,
+                value: 2
             })
         );
     }
 
     #[test]
-    fn rejects_trailing_garbage() {
+    fn rejects_truncated_entry() {
+        let mut bytes = encode(&sample());
+        bytes.truncate(bytes.len() - 3); // chop into the last entry
+        assert!(matches!(decode(&bytes), Err(DecodeError::Truncated { .. })));
+    }
+
+    #[test]
+    fn rejects_trailing_bytes() {
         let mut bytes = encode(&sample());
         bytes.push(0xff);
-        let body_len = bytes.len() - HEADER_LEN;
-        assert_eq!(
+        assert!(matches!(
             decode(&bytes),
-            Err(DecodeError::LengthMismatch {
-                declared_entries: 4,
-                body_len,
-            })
-        );
+            Err(DecodeError::TrailingBytes { .. })
+        ));
     }
 
     #[test]
-    fn count_overstated_without_bytes_is_rejected() {
-        // Header claims 5 entries but no body bytes follow.
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(&MAGIC);
-        bytes.push(FORMAT_VERSION);
-        bytes.extend_from_slice(&5u32.to_le_bytes());
-        assert_eq!(
-            decode(&bytes),
-            Err(DecodeError::LengthMismatch {
-                declared_entries: 5,
-                body_len: 0,
-            })
-        );
+    fn rejects_bad_utf8_component_id() {
+        // Hand-build a one-entry section with an invalid UTF-8 id (0xff).
+        let mut b = Vec::new();
+        b.extend_from_slice(&MAGIC);
+        b.push(FORMAT_VERSION);
+        b.push(0); // bounded_memory
+        b.push(0); // closed_world
+        b.extend_from_slice(&[0u8; 32]);
+        b.extend_from_slice(&1u32.to_le_bytes()); // entry_count = 1
+        b.extend_from_slice(&0u32.to_le_bytes()); // fused_func_index
+        b.extend_from_slice(&1u32.to_le_bytes()); // component_id_len = 1
+        b.push(0xff); // invalid UTF-8
+        b.extend_from_slice(&0u32.to_le_bytes()); // orig_func_index
+        b.push(0); // has_code_range
+        assert!(matches!(
+            decode(&b),
+            Err(DecodeError::BadComponentId { .. })
+        ));
     }
 }

--- a/crates/scry-provenance/src/lib.rs
+++ b/crates/scry-provenance/src/lib.rs
@@ -309,7 +309,17 @@ pub fn decode(bytes: &[u8]) -> Result<ProvenanceSection, DecodeError> {
         let mut h = 39;
         take_u32(bytes, &mut h)? // header count at offset 39 (h advances to 43)
     };
-    let mut origins = Vec::with_capacity(entry_count as usize);
+    // Pre-size from the count, but BOUND it by what the remaining payload could
+    // possibly hold: `entry_count` is attacker-controlled (up to u32::MAX) from
+    // a 43-byte header, and a bare `Vec::with_capacity(entry_count)` panics with
+    // "capacity overflow" on a 32-bit target (the wasm32 production build) for a
+    // crafted tiny payload — a DoS in the trusted decoder. The smallest possible
+    // entry is 13 bytes (fused u32 + id_len u32 + 0-byte id + orig u32 +
+    // has_code_range u8), so no more than `body_len / 13` entries can follow;
+    // an over-stated count then fails the per-entry `take_*` bound check below.
+    let body_len = bytes.len().saturating_sub(HEADER_LEN);
+    let cap = (entry_count as usize).min(body_len / 13);
+    let mut origins = Vec::with_capacity(cap);
     for _ in 0..entry_count {
         let fused_func_index = take_u32(bytes, &mut off)?;
         let id_len = take_u32(bytes, &mut off)? as usize;
@@ -513,6 +523,22 @@ mod tests {
             decode(&bytes),
             Err(DecodeError::TrailingBytes { .. })
         ));
+    }
+
+    #[test]
+    fn huge_entry_count_does_not_panic_or_oom() {
+        // A 43-byte header declaring u32::MAX entries (no body) must fail with
+        // a bounded decode error — never a `Vec::with_capacity` capacity-
+        // overflow panic (which aborts on the 32-bit wasm32 production target).
+        let mut b = Vec::new();
+        b.extend_from_slice(&MAGIC);
+        b.push(FORMAT_VERSION);
+        b.push(0); // bounded_memory
+        b.push(0); // closed_world
+        b.extend_from_slice(&[0u8; 32]);
+        b.extend_from_slice(&u32::MAX.to_le_bytes()); // entry_count = u32::MAX
+        // No entry bytes follow → the first take_u32 of entry 0 is Truncated.
+        assert!(matches!(decode(&b), Err(DecodeError::Truncated { .. })));
     }
 
     #[test]

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "1.18.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "2.0.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -676,28 +676,58 @@ fn label(l: &SecurityLabel) -> &'static str {
 /// decoded; absent for a plain Core Wasm module, so no section is emitted then.
 fn render_provenance(s: &mut String, r: &AnalysisResult) {
     let Some(prov) = &r.provenance else { return };
+    s.push_str("<section><h2>Component provenance</h2>");
+    // FEAT-032: the fusion premises meld asserts by construction (v3 header).
+    let yn = |b: bool| {
+        if b {
+            "<span class=\"ok\">yes</span>"
+        } else {
+            "<span class=\"muted\">no</span>"
+        }
+    };
+    let _ = write!(
+        s,
+        "<dl><dt>fusion premises</dt><dd>bounded-memory: {} · closed-world: {}</dd>\
+         <dt>fused module sha256</dt><dd><code>{}</code></dd></dl>",
+        yn(prov.premises.bounded_memory),
+        yn(prov.premises.closed_world),
+        hex32(&prov.fused_module_sha256),
+    );
     if prov.origins.is_empty() {
+        s.push_str("<p class=\"empty\">No per-function origins.</p></section>");
         return;
     }
-    s.push_str("<section><h2>Component provenance</h2>");
     s.push_str(
         "<p class=\"muted\">meld fusion origin map: each fused function traced \
-         to its source component and original index.</p>",
+         to its source component, original index, and code range.</p>",
     );
     s.push_str(
         "<table><thead><tr><th>fused func</th><th>component</th>\
-         <th>original func</th></tr></thead><tbody>",
+         <th>original func</th><th>code range</th></tr></thead><tbody>",
     );
     for o in &prov.origins {
+        let cr = match &o.code_range {
+            Some(c) => format!("[{}, {})", c.start, c.end),
+            None => "<span class=\"muted\">—</span>".to_string(),
+        };
         let _ = write!(
             s,
-            "<tr><td>{}</td><td>{}</td><td>{}</td></tr>",
+            "<tr><td>{}</td><td><code>{}</code></td><td>{}</td><td>{cr}</td></tr>",
             fn_link(r, o.fused_func_index),
-            o.component_id,
+            esc(&o.component_id),
             o.orig_func_index,
         );
     }
     s.push_str("</tbody></table></section>");
+}
+
+/// Lowercase hex of a 32-byte hash.
+fn hex32(b: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(64);
+    for byte in b {
+        let _ = write!(s, "{byte:02x}");
+    }
+    s
 }
 
 fn render_points(s: &mut String, r: &AnalysisResult) {


### PR DESCRIPTION
Resolves the consumer side of **#63** (pairs with meld#313).

## The finding that gated #63
The meld→scry `component-provenance` boundary had **never connected**: meld emitted **JSON v2** (string `component_id`, `fused_module_sha256`, `code_range`); scry decoded a custom binary **`SCPV` v1** (u32 `component_id`). Mutually undecodable — scry rejected every real meld section (`BadMagic` → conservative `none`). avrabe ratified **binary-canonical SCPV v3** on the issue: scry's strict `no_std` binary stays canonical (keeps the DO-333 trusted decoder lean — no JSON parser in the trusted base) and grows meld's richer schema; meld#313 swaps its encoder JSON→binary to match.

## What changed (FEAT-032)
- **`scry-sai-provenance`** — `SCPV` v3 decode/encode. Fixed header carries the **fusion premises** meld knows by construction (`bounded_memory`, `closed_world`) + a `fused_module_sha256` binding; per entry a length-prefixed UTF-8 `component_id` (was `u32`) + optional `code_range`. `decode()` → `ProvenanceSection`. Strict: hard-errors on bad magic / unknown version / malformed flag / bad UTF-8 / truncation / trailing bytes (never a partial parse). 12 unit tests.
- **`scry-sai-core`** — `AnalysisResult.provenance` carries `premises` + `fused_module_sha256`; `ComponentOrigin` carries string `component_id` + optional `code_range`; re-exports `FusionPremises`/`CodeRange`.
- **WIT** (`component-id: string`, new `code-range` + `fusion-premises` records, `component-provenance` gains `premises` + `fused-module-sha256`), the **wrapper**, the **JSON-schema contract**, and **scry-host-tests** (provenance + contract) all updated to v3. **scry-viz** renders premises + sha + code-range.

## Breaking ⇒ v2.0.0
Reshapes published `scry-sai-provenance` / `scry-sai-core` public types (`component_id` u32→String, `decode()` signature). Per scry's promise to synth (*"a reshape is 2.0 with a heads-up"*) this is the first major bump.

**synth is unaffected in practice**: its consumed surface (`call_graph`, `function_summaries`, `stack_usage`, `reachable_from_exports`, `operand_stack`) is untouched and additive-only — the break is confined to the provenance types, which synth doesn't read. Heads-up will go on #51/#54.

Consuming the premises to *tighten* analysis (bounded_memory drops grow-reachability widening — scry#5; closed_world tightens reachability — scry#51) is a separate follow-on slice; this lands the format + surfaces the premises.

## Traceability + tests
- rivet: **FEAT-032** (`satisfies` REQ-008, `traces-to` DD-002 / FEAT-002). `rivet validate` PASS. (The 3 `verifies`-backlink warnings on REQ-011/012/013 are pre-existing — the verification-mapping gap tracked in #59 — not from this PR.)
- Native: scry-provenance 12, scry-host-tests provenance 7 + contract 6, core 15, viz green. (The one local soundness failure is the pre-existing no-bazel-component gate; CI builds `//:scry` first.)
- Lockstep bump 1.18.0 → **2.0.0**.

## Falsification statement
If scry decodes a non-v3 or malformed `component-provenance` payload as anything other than a hard error (Warning + `provenance = none`) — a silent partial parse or a wrong attribution — this release's contract is false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)