### PR TITLE
v2.1.0 (FEAT-034): independently-verified fusion premises + meld cross-check (scry#5/#51 slice-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-06-26
+
+Headline: **scry independently verifies the fusion premises and surfaces them
+(FEAT-034, scry#5/#51 slice-2).** The premise-consumption follow-on, done the
+sound way — *verify, don't trust*.
+
+### Added — FEAT-034 (traces FEAT-032)
+
+- `AnalysisResult.verified_premises: FusionPremises` — scry's OWN determination,
+  derived by inspecting the module (independent of any meld-provided premise):
+  `bounded_memory` = no `memory.grow` anywhere (linear memory is fixed),
+  `closed_world` = no functional imports (no external caller scry cannot see).
+  A consumer (synth's footprint proof) can rely on these because scry proved
+  them — meld stays out of scry's TCB. Mirrored in the WIT
+  (`analysis-result.verified-premises`); surfaced in the scry-viz summary.
+- **Cross-check:** when a meld `component-provenance` v3 section asserts
+  `bounded_memory = true` on a module that contains `memory.grow`, scry emits an
+  `UnsoundnessFallback` diagnostic (a producer↔consumer disagreement detector)
+  and keeps its own conservative determination.
+- `closed_world` is only conservatively verifiable at the core level (scry
+  can't distinguish a cross-component import from a WASI host import), so scry
+  never refutes meld's `closed_world`; it reports its own provable value and
+  leaves meld's claim surfaced in `provenance.premises`.
+
+### Posture
+
+- Additive field (SemVer-minor). Sound by construction: every `verified_premise`
+  is something scry verified itself; the meld premise is only ever a cross-check,
+  never a trusted assumption.
+
 ### Traceability — FEAT-033 (scry#59): ASPICE V-model verification spine
 
 - Added the Automotive-SPICE v4.0 schema (`aspice`) and a parallel V-model in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -1654,6 +1654,107 @@ artifacts:
       - type: traces-to
         target: G-005
 
+  - id: FEAT-034
+    type: feature
+    title: "v2.x — Independently-verified fusion premises + meld cross-check (FEAT-032 slice-2 consumption)"
+    status: proposed
+    description: >
+      Consume the fusion premises (scry#63 / FEAT-032) the SOUND way:
+      VERIFY, don't TRUST. scry parses every op, so it independently determines
+      its own `bounded_memory` (no `memory.grow` anywhere → linear memory is
+      fixed) and a conservative `closed_world` (no functional imports at all →
+      no external caller it cannot see), and surfaces them on
+      `AnalysisResult.verified_premises` — facts a consumer (synth's footprint
+      proof, scry#5/#51) can rely on because scry proved them, not because meld
+      asserted them (meld stays out of scry's TCB).
+
+      Cross-check: when a meld `component-provenance` v3 section carries
+      `premises.bounded_memory = true` but scry OBSERVES `memory.grow`, scry
+      emits an UnsoundnessFallback diagnostic (a producer↔consumer disagreement
+      detector) and stays conservative. `closed_world` is only conservatively
+      verifiable at the core level (scry can't distinguish a cross-component
+      import from a WASI host import), so scry never refutes meld's
+      closed_world; it surfaces meld's claim (slice-1) and reports its own
+      provable `closed_world` separately.
+
+      Tightening (sound, premise-gated on scry's OWN verification): when scry
+      has verified `bounded_memory`, the default region's size is an EXACT bound
+      (not just the declared minimum), so an access provably past it is a
+      definite out-of-bounds rather than a conservative "cannot prove".
+    tags: [capability, interop, provenance, soundness, v2.x]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given any module, When scry analyzes it, Then AnalysisResult.verified_premises reports scry's own determination: bounded_memory = (no memory.grow), closed_world = (no functional imports) — derived by scry, independent of any meld premise."
+        - "Given a v3 provenance section asserting bounded_memory=true on a module that contains memory.grow, When scry analyzes it, Then scry emits a diagnostic flagging the meld↔scry disagreement and does not adopt the false premise."
+    links:
+      - type: traces-to
+        target: FEAT-032
+      - type: traces-to
+        target: G-005
+
+  - id: FEAT-035
+    type: feature
+    title: "v2.x — Align wasmparser/wasm-tools to 0.252 (dedup downstream trees, scry#62)"
+    status: proposed
+    description: >
+      Bump `wasmparser` 0.247 → 0.252 across the workspace so the dependency
+      tree dedups with downstream consumers (meld/synth) that have moved to
+      0.252. Maintenance/hygiene; risk is parser API drift, caught by the
+      existing build + soundness tests.
+    tags: [maintenance, dependencies, v2.x]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given the workspace on wasmparser 0.252, When the native + Bazel builds and the soundness/MC-DC gates run, Then all pass with no behavioral change to the analysis output."
+    links:
+      - type: traces-to
+        target: REQ-001
+
+  - id: FEAT-036
+    type: feature
+    title: "v2.x — Interprocedural range propagation (synth wishlist, scry#54)"
+    status: proposed
+    description: >
+      Narrow a callee's parameter invariants from the value ranges at its
+      call sites (a sound, monotone interprocedural pass over the existing
+      call graph + function summaries). Lets synth specialize on constant /
+      bounded arguments. Soundness-sensitive: must join over ALL call sites
+      (and ⊤ for any unresolved/indirect caller) so a param invariant is never
+      narrower than some reachable call permits.
+    tags: [capability, analysis, interop, v2.x]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given a function called only with arguments in a bounded range, When scry analyzes the module, Then that function's emitted parameter invariants reflect the join of all call-site argument ranges (⊤ when any caller is unresolved) — sound over every reachable call."
+    links:
+      - type: traces-to
+        target: REQ-004
+      - type: traces-to
+        target: G-005
+
+  - id: FEAT-037
+    type: feature
+    title: "v2.x — Known-bits / congruence abstract domain (synth wishlist, scry#54)"
+    status: proposed
+    description: >
+      Add a known-bits (and/or congruence `a·k + b`) abstract domain capturing
+      alignment and low-bit patterns the interval domain misses — enabling
+      alignment-driven check elision and bit-level specialization for codegen
+      consumers. Largest investment: a new domain crate + transfer functions +
+      mechanized Rocq soundness, integrated into the Interp alongside interval +
+      octagon.
+    tags: [capability, domain, analysis, v2.x]
+    fields:
+      phase: phase-2
+      acceptance-criteria:
+        - "Given a value with a statically-known alignment/low-bit pattern, When scry analyzes the module, Then the known-bits domain reports it soundly (γ over-approximates the concrete value), with an admit-free Rocq soundness proof for the domain's lattice + transfer functions."
+    links:
+      - type: traces-to
+        target: REQ-001
+      - type: traces-to
+        target: G-005
+
   # ──────────────────────────────────────────────────────────────────────
   # Safety goal for the v2.0 qualification milestone.
   # ──────────────────────────────────────────────────────────────────────

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "2.0.0" }
+scry-sai-interval = { path = "../scry-interval", version = "2.1.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,14 +43,14 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "2.0.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "2.0.0" }
+scry-sai-taint = { path = "../scry-taint", version = "2.1.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "2.1.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "2.0.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "2.1.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -330,6 +330,16 @@ pub struct AnalysisResult {
     /// consumer (synth's footprint report, scry-viz) show `$compute_stack` in
     /// place of `func 42`. Library-only addition (not in the WIT mirror).
     pub function_meta: Vec<FunctionMeta>,
+    /// FEAT-034: fusion premises scry determined for ITSELF by inspecting the
+    /// module (verify-not-trust) — `bounded_memory` = no `memory.grow` anywhere
+    /// (linear memory is fixed), `closed_world` = no functional imports (no
+    /// external caller scry cannot see). These are scry's OWN sound facts,
+    /// independent of any meld-provided premise in `provenance.premises`; a
+    /// consumer can rely on them because scry proved them. When a meld v3
+    /// premise contradicts scry's verification (e.g. claims bounded_memory on a
+    /// module containing `memory.grow`), scry emits a diagnostic and keeps its
+    /// own (conservative) determination here.
+    pub verified_premises: FusionPremises,
 }
 
 /// FEAT-027: human-readable metadata for one function index.
@@ -418,7 +428,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "2.0.0";
+const SCRY_VERSION: &str = "2.1.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).
@@ -1529,6 +1539,39 @@ pub fn analyze(
         &name_section,
     );
 
+    // FEAT-034: scry's OWN fusion premises (verify-not-trust). A syntactic
+    // scan — `memory.grow` anywhere ⇒ memory is not provably fixed; any
+    // functional import ⇒ scry cannot prove a closed world at the core level.
+    // These are sound because scry derived them, independent of meld's claim.
+    let saw_memory_grow = defined_funcs.iter().any(|f| {
+        f.ops
+            .iter()
+            .any(|op| matches!(op, Operator::MemoryGrow { .. }))
+    });
+    let verified_premises = FusionPremises {
+        bounded_memory: !saw_memory_grow,
+        closed_world: import_func_count == 0,
+    };
+    // Cross-check meld's asserted premise against scry's observation: a v3
+    // section claiming `bounded_memory` on a module that contains `memory.grow`
+    // is a producer↔consumer disagreement — flag it; scry keeps its own
+    // conservative determination (meld stays out of scry's TCB).
+    if config.emit_diagnostics
+        && let Some(section) = &provenance_section
+        && section.premises.bounded_memory
+        && saw_memory_grow
+    {
+        diagnostics.push(Diagnostic {
+            severity: DiagnosticSeverity::UnsoundnessFallback,
+            func_index: 0,
+            pc: 0,
+            message: "FEAT-034: meld component-provenance asserts bounded_memory but the fused \
+                 module contains memory.grow — premise rejected; scry uses its own \
+                 (unbounded) determination"
+                .to_string(),
+        });
+    }
+
     Ok(AnalysisResult {
         invariants,
         diagnostics,
@@ -1539,6 +1582,7 @@ pub fn analyze(
         stack_usage,
         reachable_from_exports,
         function_meta,
+        verified_premises,
     })
 }
 
@@ -4481,6 +4525,7 @@ mod tests {
             },
             reachable_from_exports: alloc::vec![],
             function_meta: alloc::vec![],
+            verified_premises: FusionPremises::default(),
         };
         assert_eq!(res.invariants.points.len(), 1);
         assert!(matches!(rp, AbstractValue::RegionPointer(_)));
@@ -4943,6 +4988,110 @@ mod tests {
         assert_eq!(res.function_meta.len(), 1);
         assert_eq!(res.function_meta[0].name, None, "no name source → None");
         assert!(!res.function_meta[0].imported);
+    }
+
+    fn analyze_default(src: &str) -> AnalysisResult {
+        analyze(
+            wat::parse_str(src).expect("assemble"),
+            AnalysisConfig::default(),
+        )
+        .expect("analyze")
+    }
+
+    /// FEAT-034: scry determines its OWN fusion premises (verify-not-trust):
+    /// bounded_memory = no `memory.grow`; closed_world = no functional imports.
+    #[test]
+    fn feat034_verified_premises() {
+        // memory.grow present → not bounded.
+        let g = analyze_default(
+            "(module (memory 1) (func (export \"g\") (result i32) i32.const 1 memory.grow))",
+        );
+        assert!(
+            !g.verified_premises.bounded_memory,
+            "memory.grow ⇒ not bounded"
+        );
+
+        // memory, no grow, no imports → bounded + closed.
+        let b = analyze_default("(module (memory 1) (func (export \"f\") nop))");
+        assert!(b.verified_premises.bounded_memory, "no grow ⇒ bounded");
+        assert!(
+            b.verified_premises.closed_world,
+            "no imports ⇒ closed world"
+        );
+
+        // a functional import → scry cannot prove closed world.
+        let i = analyze_default("(module (import \"env\" \"h\" (func)) (func (export \"f\") nop))");
+        assert!(
+            !i.verified_premises.closed_world,
+            "functional import ⇒ not provably closed"
+        );
+        assert!(
+            i.verified_premises.bounded_memory,
+            "no memory/grow ⇒ vacuously bounded"
+        );
+    }
+
+    /// FEAT-034: a meld v3 premise asserting bounded_memory on a module that
+    /// contains memory.grow is rejected with a disagreement diagnostic, and
+    /// scry keeps its own (unbounded) determination.
+    #[test]
+    fn feat034_rejects_false_bounded_memory_premise() {
+        // Module with memory.grow.
+        let mut module = wat::parse_str(
+            "(module (memory 1) (func (export \"g\") (result i32) i32.const 1 memory.grow))",
+        )
+        .expect("assemble");
+        // Append a component-provenance v3 section asserting bounded_memory=true.
+        let section = scry_provenance::ProvenanceSection {
+            premises: scry_provenance::FusionPremises {
+                bounded_memory: true,
+                closed_world: false,
+            },
+            fused_module_sha256: [0u8; 32],
+            origins: alloc::vec![],
+        };
+        let payload = scry_provenance::encode(&section);
+        let name = scry_provenance::SECTION_NAME.as_bytes();
+        let mut body = alloc::vec![];
+        write_uleb128(&mut body, name.len() as u64);
+        body.extend_from_slice(name);
+        body.extend_from_slice(&payload);
+        module.push(0x00); // custom section id
+        write_uleb128(&mut module, body.len() as u64);
+        module.extend_from_slice(&body);
+
+        let res = analyze(
+            module,
+            AnalysisConfig {
+                widening_threshold: Some(3),
+                emit_diagnostics: true,
+                taint_policy: None,
+            },
+        )
+        .expect("analyze");
+        // scry kept its own determination (not bounded), despite the premise.
+        assert!(!res.verified_premises.bounded_memory);
+        // and flagged the disagreement.
+        assert!(
+            res.diagnostics
+                .iter()
+                .any(|d| d.message.contains("premise rejected")),
+            "expected a bounded_memory disagreement diagnostic"
+        );
+    }
+
+    fn write_uleb128(out: &mut Vec<u8>, mut value: u64) {
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            out.push(byte);
+            if value == 0 {
+                break;
+            }
+        }
     }
 
     /// FEAT-021 slice-2b: the self-measuring fixture (two mutable i32 globals:

--- a/crates/scry-analyzer/src/lib.rs
+++ b/crates/scry-analyzer/src/lib.rs
@@ -116,6 +116,10 @@ fn result_to_wit(r: ac::AnalysisResult) -> wit::AnalysisResult {
             .map(taint_finding_to_wit)
             .collect(),
         stack_usage: stack_usage_to_wit(r.stack_usage),
+        verified_premises: wit::FusionPremises {
+            bounded_memory: r.verified_premises.bounded_memory,
+            closed_world: r.verified_premises.closed_world,
+        },
     }
 }
 

--- a/crates/scry-analyzer/wit/scry.wit
+++ b/crates/scry-analyzer/wit/scry.wit
@@ -420,6 +420,11 @@ interface analyzer {
         /// Worst-case shadow-stack bound (FEAT-021): per-function frames and
         /// the module's `max-stack-bytes`.
         stack-usage: stack-usage,
+        /// Fusion premises scry verified for ITSELF by inspecting the module
+        /// (FEAT-034, verify-not-trust): `bounded-memory` = no `memory.grow`,
+        /// `closed-world` = no functional imports. scry's own sound facts,
+        /// independent of any meld-provided `provenance.premises`.
+        verified-premises: fusion-premises,
     }
 
     /// Reasons an analyze call can fail without producing a partial

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "2.0.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "2.1.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -248,6 +248,17 @@ fn render_header(s: &mut String, r: &AnalysisResult) {
     kv(s, "call-graph edges", &r.call_graph.len().to_string());
     kv(s, "diagnostics", &r.diagnostics.len().to_string());
     kv(s, "program points", &points.to_string());
+    // FEAT-034: scry's own verified fusion premises (independent of meld).
+    let vp = &r.verified_premises;
+    kv(
+        s,
+        "verified premises",
+        &format!(
+            "bounded-memory: {} · closed-world: {}",
+            if vp.bounded_memory { "yes" } else { "no" },
+            if vp.closed_world { "yes" } else { "no" },
+        ),
+    );
     s.push_str("</dl></section>");
 }
 


### PR DESCRIPTION
The premise-consumption follow-on to FEAT-032 (#5/#51 slice-2), done the sound way — **verify, don't trust.**

## What
scry parses every op, so it determines its OWN fusion premises and surfaces them on `AnalysisResult.verified_premises` (+ WIT `analysis-result.verified-premises`, + the scry-viz summary):
- **`bounded_memory`** = no `memory.grow` anywhere → linear memory is fixed.
- **`closed_world`** = no functional imports → no external caller scry cannot see.

These are sound because **scry proved them itself** — meld is never trusted into scry's TCB.

**Cross-check (the disagreement detector):** when a meld `component-provenance` v3 section asserts `bounded_memory = true` on a module that contains `memory.grow`, scry emits an `UnsoundnessFallback` diagnostic and keeps its own conservative determination.

`closed_world` is only conservatively verifiable at the core level (scry can't distinguish a cross-component import from a WASI host import), so scry **never refutes** meld's `closed_world` — it reports its own provable value and leaves meld's claim surfaced in `provenance.premises`.

## Why this is the sound version
Earlier I flagged premise-*consumption* as marginal/anti-sound if scry trusted meld. The fix is the verify-not-trust framing: scry's verified facts are independent and sound; meld's premise is only ever a cross-check. synth's footprint proof gets a fact scry stands behind.

## Traceability + tests
- rivet: **FEAT-034** (traces FEAT-032). Also files **FEAT-035/036/037** as `proposed` (wasm-tools 0.252; interproc ranges; known-bits domain) — the rest of the plan. `rivet validate` PASS.
- Native: `feat034_verified_premises` (grow→not-bounded; no-grow→bounded; import→not-closed) + `feat034_rejects_false_bounded_memory_premise` (builds a module with `memory.grow` + a v3 section claiming bounded → asserts the disagreement diagnostic + scry keeps unbounded). 17 core + 17 viz tests pass; clippy clean.
- Additive `AnalysisResult` + WIT field → **SemVer-minor 2.0.0 → 2.1.0**. (The frozen v1 JSON contract is unchanged — consistent with how stack-usage/reachable/function-meta are handled.)

## Falsification statement
If `verified_premises.bounded_memory` is `true` for a module that actually contains a reachable `memory.grow`, or `closed_world` is `true` for a module with a functional import, the determination is unsound and this claim is false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)