### PR TITLE
v2.2.0 (FEAT-036, synth#54): interprocedural parameter ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,11 @@ its call sites — a sound interprocedural fact for downstream specialization.
 - `FunctionSummary.param_ranges: Vec<AbstractValue>` — per parameter, the join
   of `arg_ranges` over every **direct** call site reaching the function. Sound
   by construction: it is `Unknown` (⊤) for every parameter of a function that is
-  **exported, the start function, or reachable via `call_indirect`** (external /
-  over-approximate entry points whose arguments scry cannot bound), and ⊤ if any
-  indirect edge is unsound — so a `param_ranges` entry is never narrower than
-  some reachable call permits. Otherwise it is the over-approximate incoming
-  value across all calls (e.g. a function called with `5` and `10` gets
-  `[5, 10]`).
+  **exported or the start function** (external entry points whose arguments scry
+  cannot bound), and — conservatively — for **every** function in a module that
+  contains **any `call_indirect`** (see soundness note). Otherwise it is the
+  over-approximate incoming value across all calls (e.g. a function called with
+  `5` and `10` gets `[5, 10]`), never narrower than some reachable call permits.
 - Both fields are library-only (read off the `scry-sai-core` `AnalysisResult`);
   the WIT mirror and the frozen v1 JSON contract are unchanged.
 
@@ -36,6 +35,16 @@ its call sites — a sound interprocedural fact for downstream specialization.
   an over-approximation; the ⊤ fallback for any unaccounted (external /
   indirect) caller means scry never claims a parameter range that excludes a
   reachable argument.
+- **Soundness note (clean-room finding, fixed before merge).** scry's static
+  table model under-reports `call_indirect` targets — passive/declared element
+  segments, runtime `table.init`/`table.set`, and non-constant dispatch indices
+  all leave the resolved target set incomplete, so scry cannot prove a function
+  is *not* an indirect callee. The conservative rule is therefore the whole-
+  module bail: if the module contains **any** indirect call, every function's
+  `param_ranges` is ⊤. Narrowing happens only in indirect-call-free modules,
+  where the recorded direct call sites are provably the complete caller set. A
+  future slice can recover precision with whole-table-mutation analysis. Covered
+  by `feat036_indirect_call_forces_top`.
 
 ## [2.1.1] — 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ its call sites — a sound interprocedural fact for downstream specialization.
   by construction: it is `Unknown` (⊤) for every parameter of a function that is
   **exported or the start function** (external entry points whose arguments scry
   cannot bound), and — conservatively — for **every** function in a module that
-  contains **any `call_indirect`** (see soundness note). Otherwise it is the
-  over-approximate incoming value across all calls (e.g. a function called with
-  `5` and `10` gets `[5, 10]`), never narrower than some reachable call permits.
+  bears a **funcref container** (declares/imports any table, or uses any
+  `ref.func`; see soundness note). Otherwise it is the over-approximate incoming
+  value across all calls (e.g. a function called with `5` and `10` gets
+  `[5, 10]`), never narrower than some reachable call permits.
 - Both fields are library-only (read off the `scry-sai-core` `AnalysisResult`);
   the WIT mirror and the frozen v1 JSON contract are unchanged.
 
@@ -35,16 +36,25 @@ its call sites — a sound interprocedural fact for downstream specialization.
   an over-approximation; the ⊤ fallback for any unaccounted (external /
   indirect) caller means scry never claims a parameter range that excludes a
   reachable argument.
-- **Soundness note (clean-room finding, fixed before merge).** scry's static
-  table model under-reports `call_indirect` targets — passive/declared element
-  segments, runtime `table.init`/`table.set`, and non-constant dispatch indices
-  all leave the resolved target set incomplete, so scry cannot prove a function
-  is *not* an indirect callee. The conservative rule is therefore the whole-
-  module bail: if the module contains **any** indirect call, every function's
-  `param_ranges` is ⊤. Narrowing happens only in indirect-call-free modules,
-  where the recorded direct call sites are provably the complete caller set. A
-  future slice can recover precision with whole-table-mutation analysis. Covered
-  by `feat036_indirect_call_forces_top`.
+- **Soundness note (three clean-room findings, all fixed before merge).** Two
+  successive adversarial clean-room passes refuted weaker gates. (1) An
+  edge-based gate that only ⊤'d functions appearing in a resolved indirect-edge
+  target set missed functions reachable through a table whose contents scry
+  under-reports (passive/declared element segments, runtime `table.init`/`set`,
+  non-constant indices). (2) An *exported funcref table* lets the **host**
+  `call_indirect` a defined function even when the module has no `call_indirect`
+  of its own. (3) `return_call_indirect` / `call_ref` are unsupported ops that
+  scrub to ⊤ and record **no** call-graph edge, so any edge-based test misses
+  them. The root cause is uniform: a non-null funcref to a defined function can
+  only originate from a `ref.func` instruction or a table. The final
+  **root-cause-sound** rule therefore narrows `param_ranges` *only* when the
+  module has **neither a table (declared or imported) nor any `ref.func`** — in
+  which case no funcref to any defined function can exist anywhere, so no
+  indirect or host dispatch is possible and the recorded direct calls are
+  provably the complete caller set. A future slice can recover precision in
+  funcref-bearing modules with whole-table escape analysis. Covered by
+  `feat036_indirect_call_forces_top`, `feat036_exported_table_forces_top`, and
+  `feat036_ref_func_forces_top`.
 
 ## [2.1.1] — 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ its call sites — a sound interprocedural fact for downstream specialization.
   **exported or the start function** (external entry points whose arguments scry
   cannot bound), and — conservatively — for **every** function in a module that
   bears a **funcref container** (declares/imports any table, or uses any
-  `ref.func`; see soundness note). Otherwise it is the over-approximate incoming
-  value across all calls (e.g. a function called with `5` and `10` gets
-  `[5, 10]`), never narrower than some reachable call permits.
+  `ref.func` in a body, a global init expr, or an element-segment item; see
+  soundness note). Otherwise it is the over-approximate incoming value across
+  all calls (e.g. a function called with `5` and `10` gets `[5, 10]`), never
+  narrower than some reachable call permits.
 - Both fields are library-only (read off the `scry-sai-core` `AnalysisResult`);
   the WIT mirror and the frozen v1 JSON contract are unchanged.
 
@@ -36,25 +37,30 @@ its call sites — a sound interprocedural fact for downstream specialization.
   an over-approximation; the ⊤ fallback for any unaccounted (external /
   indirect) caller means scry never claims a parameter range that excludes a
   reachable argument.
-- **Soundness note (three clean-room findings, all fixed before merge).** Two
-  successive adversarial clean-room passes refuted weaker gates. (1) An
-  edge-based gate that only ⊤'d functions appearing in a resolved indirect-edge
-  target set missed functions reachable through a table whose contents scry
-  under-reports (passive/declared element segments, runtime `table.init`/`set`,
-  non-constant indices). (2) An *exported funcref table* lets the **host**
-  `call_indirect` a defined function even when the module has no `call_indirect`
-  of its own. (3) `return_call_indirect` / `call_ref` are unsupported ops that
-  scrub to ⊤ and record **no** call-graph edge, so any edge-based test misses
-  them. The root cause is uniform: a non-null funcref to a defined function can
-  only originate from a `ref.func` instruction or a table. The final
-  **root-cause-sound** rule therefore narrows `param_ranges` *only* when the
-  module has **neither a table (declared or imported) nor any `ref.func`** — in
-  which case no funcref to any defined function can exist anywhere, so no
+- **Soundness note (four clean-room findings across three adversarial passes,
+  all fixed before merge).** Successive clean-room passes refuted weaker gates.
+  (1) An edge-based gate that only ⊤'d functions appearing in a resolved
+  indirect-edge target set missed functions reachable through a table whose
+  contents scry under-reports (passive/declared element segments, runtime
+  `table.init`/`set`, non-constant indices). (2) An *exported funcref table*
+  lets the **host** `call_indirect` a defined function even when the module has
+  no `call_indirect` of its own. (3) `return_call_indirect` / `call_ref` are
+  unsupported ops that scrub to ⊤ and record **no** call-graph edge, so any
+  edge-based test misses them. (4) A `ref.func` in a **global init expression**
+  (or an element-segment item) takes a defined function's address with **no
+  table and no `ref.func` in any function body** — a body-only scan misses it,
+  and the resulting funcref escapes through, e.g., an exported global. The root
+  cause is uniform: a non-null funcref to a defined function can only originate
+  from a `ref.func` (in code *or* a const position) or a table. The final
+  **root-cause-sound** rule narrows `param_ranges` *only* when the module has
+  **no table (declared or imported), no `ref.func` anywhere (function bodies,
+  global init exprs, or element-segment items), and no indirect-dispatch op** —
+  in which case no funcref to any defined function can exist anywhere, so no
   indirect or host dispatch is possible and the recorded direct calls are
   provably the complete caller set. A future slice can recover precision in
-  funcref-bearing modules with whole-table escape analysis. Covered by
-  `feat036_indirect_call_forces_top`, `feat036_exported_table_forces_top`, and
-  `feat036_ref_func_forces_top`.
+  funcref-bearing modules with whole-table / escape analysis. Covered by
+  `feat036_indirect_call_forces_top`, `feat036_exported_table_forces_top`,
+  `feat036_ref_func_forces_top`, and `feat036_global_init_ref_func_forces_top`.
 
 ## [2.1.1] — 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.2.0] — 2026-06-26
+
+Headline: **interprocedural parameter ranges (FEAT-036, synth#54).** Each
+function's parameters now carry the join of the argument values observed across
+its call sites — a sound interprocedural fact for downstream specialization.
+
+### Added — FEAT-036 (traces REQ-004)
+
+- `CallEdge.arg_ranges: Vec<AbstractValue>` — the abstract arguments at each
+  call site, in parameter order (populated for direct calls; empty for
+  `call_indirect` / signature-unknown imports).
+- `FunctionSummary.param_ranges: Vec<AbstractValue>` — per parameter, the join
+  of `arg_ranges` over every **direct** call site reaching the function. Sound
+  by construction: it is `Unknown` (⊤) for every parameter of a function that is
+  **exported, the start function, or reachable via `call_indirect`** (external /
+  over-approximate entry points whose arguments scry cannot bound), and ⊤ if any
+  indirect edge is unsound — so a `param_ranges` entry is never narrower than
+  some reachable call permits. Otherwise it is the over-approximate incoming
+  value across all calls (e.g. a function called with `5` and `10` gets
+  `[5, 10]`).
+- Both fields are library-only (read off the `scry-sai-core` `AnalysisResult`);
+  the WIT mirror and the frozen v1 JSON contract are unchanged.
+
+### Posture
+
+- Additive fields (SemVer-minor). Sound: the join over all accounted callers is
+  an over-approximation; the ⊤ fallback for any unaccounted (external /
+  indirect) caller means scry never claims a parameter range that excludes a
+  reachable argument.
+
 ## [2.1.1] — 2026-06-26
 
 ### Changed — FEAT-035 (scry#62)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1851,14 +1851,14 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-core"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "scry-sai-interval",
  "scry-sai-octagon",
@@ -1871,11 +1871,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "2.1.1"
+version = "2.2.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1884,19 +1884,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "2.1.1"
+version = "2.2.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "2.1.1"
+version = "2.2.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "2.1.1"
+version = "2.2.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "cpp_demangle 0.5.1",
  "rustc-demangle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1851,14 +1851,14 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-core"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "scry-sai-interval",
  "scry-sai-octagon",
@@ -1871,11 +1871,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "2.1.0"
+version = "2.1.1"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1884,19 +1884,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "2.1.0"
+version = "2.1.1"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "2.1.0"
+version = "2.1.1"
 
 [[package]]
 name = "scry-sai-taint"
-version = "2.1.0"
+version = "2.1.1"
 
 [[package]]
 name = "scry-sai-viz"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "cpp_demangle 0.5.1",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "2.1.1"
+version = "2.2.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -1714,7 +1714,7 @@ artifacts:
   - id: FEAT-036
     type: feature
     title: "v2.x — Interprocedural range propagation (synth wishlist, scry#54)"
-    status: proposed
+    status: accepted
     description: >
       Narrow a callee's parameter invariants from the value ranges at its
       call sites (a sound, monotone interprocedural pass over the existing

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -1727,6 +1727,7 @@ artifacts:
       phase: phase-2
       acceptance-criteria:
         - "Given a function called only with arguments in a bounded range, When scry analyzes the module, Then that function's emitted parameter invariants reflect the join of all call-site argument ranges (⊤ when any caller is unresolved) — sound over every reachable call."
+        - "Given a module that contains any call_indirect (whose target set scry's static table model may under-report), When scry analyzes it, Then EVERY function's parameter ranges are ⊤ — scry never narrows a parameter on direct-call evidence alone while an unmodelled indirect caller could exist. (Clean-room soundness finding; covered by feat036_indirect_call_forces_top.)"
     links:
       - type: traces-to
         target: REQ-004

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -1727,7 +1727,7 @@ artifacts:
       phase: phase-2
       acceptance-criteria:
         - "Given a function called only with arguments in a bounded range, When scry analyzes the module, Then that function's emitted parameter invariants reflect the join of all call-site argument ranges (⊤ when any caller is unresolved) — sound over every reachable call."
-        - "Given a module that bears a funcref container (declares/imports any table, or uses any ref.func — the only origins of a funcref to a defined function), When scry analyzes it, Then EVERY function's parameter ranges are ⊤ — scry never narrows a parameter on direct-call evidence alone while an unmodelled indirect or host caller could exist. (Three clean-room soundness findings: under-reported table targets, exported funcref table, and edge-less return_call_indirect/call_ref; covered by feat036_indirect_call_forces_top, feat036_exported_table_forces_top, feat036_ref_func_forces_top.)"
+        - "Given a module that bears a funcref container (declares/imports any table, or uses any ref.func in a function body, a global init expr, or an element-segment item — the only origins of a funcref to a defined function), When scry analyzes it, Then EVERY function's parameter ranges are ⊤ — scry never narrows a parameter on direct-call evidence alone while an unmodelled indirect or host caller could exist. (Four clean-room soundness findings across three adversarial passes: under-reported table targets, exported funcref table, edge-less return_call_indirect/call_ref, and ref.func in a global init expr; covered by feat036_indirect_call_forces_top, feat036_exported_table_forces_top, feat036_ref_func_forces_top, feat036_global_init_ref_func_forces_top.)"
     links:
       - type: traces-to
         target: REQ-004

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -1727,7 +1727,7 @@ artifacts:
       phase: phase-2
       acceptance-criteria:
         - "Given a function called only with arguments in a bounded range, When scry analyzes the module, Then that function's emitted parameter invariants reflect the join of all call-site argument ranges (⊤ when any caller is unresolved) — sound over every reachable call."
-        - "Given a module that contains any call_indirect (whose target set scry's static table model may under-report), When scry analyzes it, Then EVERY function's parameter ranges are ⊤ — scry never narrows a parameter on direct-call evidence alone while an unmodelled indirect caller could exist. (Clean-room soundness finding; covered by feat036_indirect_call_forces_top.)"
+        - "Given a module that bears a funcref container (declares/imports any table, or uses any ref.func — the only origins of a funcref to a defined function), When scry analyzes it, Then EVERY function's parameter ranges are ⊤ — scry never narrows a parameter on direct-call evidence alone while an unmodelled indirect or host caller could exist. (Three clean-room soundness findings: under-reported table targets, exported funcref table, and edge-less return_call_indirect/call_ref; covered by feat036_indirect_call_forces_top, feat036_exported_table_forces_top, feat036_ref_func_forces_top.)"
     links:
       - type: traces-to
         target: REQ-004

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "2.1.1" }
+scry-sai-interval = { path = "../scry-interval", version = "2.2.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,14 +43,14 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "2.1.1" }
-scry-sai-provenance = { path = "../scry-provenance", version = "2.1.1" }
+scry-sai-taint = { path = "../scry-taint", version = "2.2.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "2.2.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "2.1.1" }
+scry-sai-octagon = { path = "../scry-octagon", version = "2.2.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -208,6 +208,12 @@ pub struct CallEdge {
     pub indirect: bool,
     pub resolved_targets: Vec<u32>,
     pub soundness: SoundnessTag,
+    /// FEAT-036: the abstract argument values at this call site, in parameter
+    /// declaration order (param 0 first) — the operand-stack slots the call
+    /// consumes. Populated for direct calls (empty for `call_indirect` and for
+    /// calls to a signature-unknown import). A library-only field — the WIT
+    /// `call-edge` mirror does not carry it.
+    pub arg_ranges: Vec<AbstractValue>,
 }
 
 /// Mirror of WIT `function-summary` (FEAT-007). Per-function abstract
@@ -219,6 +225,15 @@ pub struct FunctionSummary {
     pub result_summary: Vec<AbstractValue>,
     pub context_sensitive: bool,
     pub recursive: bool,
+    /// FEAT-036: interprocedural parameter ranges — the join, per parameter, of
+    /// the argument values observed at every call site reaching this function.
+    /// SOUND only when scry has accounted for ALL callers, so it is `Unknown`
+    /// (⊤) for every parameter of a function that is exported, the start
+    /// function, or reachable by any `call_indirect` (external/over-approximate
+    /// entry whose arguments scry cannot bound). Otherwise each entry is the
+    /// join over all direct call sites — an over-approximation of the
+    /// parameter's incoming value across every reachable call. Library-only.
+    pub param_ranges: Vec<AbstractValue>,
 }
 
 /// Mirror of WIT `component-origin` (FEAT-002 / DD-002). One fused-module
@@ -428,7 +443,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "2.1.1";
+const SCRY_VERSION: &str = "2.2.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).
@@ -1391,15 +1406,61 @@ pub fn analyze(
     // ───────────────────────────────────────────────────────────
     // Assemble the per-function-summary output records (FEAT-007).
     // ───────────────────────────────────────────────────────────
+    // FEAT-036: interprocedural parameter ranges. A function's params are sound
+    // to narrow ONLY when scry has accounted for EVERY caller. The over-approx
+    // / external entry points whose arguments scry cannot bound are: exports,
+    // the start function, and any function reachable via `call_indirect` (its
+    // index appears in some indirect edge's resolved-target superset). If any
+    // indirect edge is unsound (an under-approximation), any function could be
+    // an unseen indirect target, so we bail to ⊤ for everything. Otherwise a
+    // function's params are the join of the arguments over all DIRECT call
+    // sites reaching it — a sound over-approximation of every reachable call.
+    let mut indirect_targets: Vec<u32> = Vec::new();
+    let mut any_unsound_edge = false;
+    for e in &call_graph {
+        if e.indirect {
+            indirect_targets.extend_from_slice(&e.resolved_targets);
+        }
+        if e.soundness == SoundnessTag::UnsoundFallback {
+            any_unsound_edge = true;
+        }
+    }
+
     let mut function_summaries: Vec<FunctionSummary> = Vec::with_capacity(defined_funcs.len());
     for (defined, func) in defined_funcs.iter().enumerate() {
         if let Some(entry) = summaries.get(defined).and_then(|s| s.as_ref()) {
+            let abs = func.abs_index;
+            let n = func.params.len();
+            let top_params = || (0..n).map(|_| AbstractValue::Unknown).collect::<Vec<_>>();
+            let param_ranges = if n == 0
+                || any_unsound_edge
+                || exported_funcs.contains(&abs)
+                || start_func == Some(abs)
+                || indirect_targets.contains(&abs)
+            {
+                top_params()
+            } else {
+                // Join arguments over every direct call site reaching `abs`.
+                let mut acc: Option<Vec<AbstractValue>> = None;
+                for e in &call_graph {
+                    if !e.indirect && e.resolved_targets.contains(&abs) && e.arg_ranges.len() == n {
+                        acc = Some(match acc {
+                            Some(a) => join_locals(&a, &e.arg_ranges),
+                            None => e.arg_ranges.iter().map(clone_value).collect(),
+                        });
+                    }
+                }
+                // No direct caller found (dead / unreached): nothing constrains
+                // the params, so ⊤ — never invent a tighter range.
+                acc.unwrap_or_else(top_params)
+            };
             function_summaries.push(FunctionSummary {
-                func_index: func.abs_index,
-                param_count: func.params.len() as u32,
+                func_index: abs,
+                param_count: n as u32,
                 result_summary: entry.result_summary.iter().map(clone_value).collect(),
                 context_sensitive: entry.context_sensitive,
                 recursive: entry.recursive,
+                param_ranges,
             });
         }
     }
@@ -3665,19 +3726,23 @@ fn handle_call(
     callee_func_index: u32,
     depth: u32,
 ) -> Result<(), AnalyzeError> {
-    call_graph.push(CallEdge {
-        caller_func: func_index,
-        pc,
-        indirect: false,
-        resolved_targets: alloc::vec![callee_func_index],
-        soundness: SoundnessTag::Sound,
-    });
-
+    // The call edge is recorded in each branch below, once the argument
+    // values are known (FEAT-036: `arg_ranges`). For a signature-unknown
+    // import the args can't be popped, so the edge carries empty `arg_ranges`.
+    //
     // Resolve the callee's signature. If unknown (import / unrecorded
     // type), keep v0.4's behaviour: leave the operand stack untouched
     // (sound for the straight-line core — see `apply_call_stack_effect`
     // doc), record the edge, emit the diagnostic, done.
     let Some((param_tys, _result_tys)) = module_ctx.signature_of_func(callee_func_index) else {
+        call_graph.push(CallEdge {
+            caller_func: func_index,
+            pc,
+            indirect: false,
+            resolved_targets: alloc::vec![callee_func_index],
+            soundness: SoundnessTag::Sound,
+            arg_ranges: Vec::new(),
+        });
         if emit_diagnostics {
             diagnostics.push(Diagnostic {
                 severity: DiagnosticSeverity::Info,
@@ -3699,6 +3764,16 @@ fn handle_call(
         args.push(ctx.operand_stack.pop().unwrap_or(AbstractValue::Unknown));
     }
     args.reverse(); // now in declaration order (param 0 first)
+
+    // FEAT-036: record the edge carrying the abstract arguments at this site.
+    call_graph.push(CallEdge {
+        caller_func: func_index,
+        pc,
+        indirect: false,
+        resolved_targets: alloc::vec![callee_func_index],
+        soundness: SoundnessTag::Sound,
+        arg_ranges: args.clone(),
+    });
 
     let summary = module_ctx.summary_by_abs(callee_func_index);
     let callee = module_ctx.defined_by_abs(callee_func_index);
@@ -3916,6 +3991,10 @@ fn emit_call_indirect_edge(
         // are sound; an over-approximation is still sound (it never
         // drops a concretely reachable target).
         soundness: SoundnessTag::Sound,
+        // FEAT-036: indirect-call arguments are not harvested (and any
+        // indirectly-reachable callee is forced to ⊤ params anyway), so leave
+        // empty.
+        arg_ranges: Vec::new(),
     });
 
     if emit_diagnostics {
@@ -5092,6 +5171,52 @@ mod tests {
                 break;
             }
         }
+    }
+
+    /// FEAT-036: a non-exported, only-directly-called function's parameter
+    /// ranges are the JOIN of the arguments at every call site.
+    #[test]
+    fn feat036_interproc_param_ranges() {
+        // $callee (func 0) is called with 5 and with 10; not exported / not
+        // indirect → params bounded by the join 5 ⊔ 10 = [5, 10].
+        let r = analyze_default(
+            "(module \
+             (func (param i32) (result i32) local.get 0) \
+             (func (export \"a\") (result i32) i32.const 5 call 0) \
+             (func (export \"b\") (result i32) i32.const 10 call 0))",
+        );
+        let callee = r
+            .function_summaries
+            .iter()
+            .find(|f| f.func_index == 0)
+            .expect("callee summary");
+        assert_eq!(callee.param_count, 1);
+        assert!(
+            matches!(
+                callee.param_ranges.first(),
+                Some(AbstractValue::I32Interval(iv)) if iv.lo == 5 && iv.hi == 10
+            ),
+            "param range must be the join of call-site args [5,10], got {:?}",
+            callee.param_ranges
+        );
+    }
+
+    /// FEAT-036 soundness: an EXPORTED function has unknown external arguments,
+    /// so its parameter ranges must be ⊤ — never narrowed.
+    #[test]
+    fn feat036_exported_params_are_top() {
+        let r =
+            analyze_default("(module (func (export \"f\") (param i32) (result i32) local.get 0))");
+        let f = r
+            .function_summaries
+            .iter()
+            .find(|f| f.func_index == 0)
+            .unwrap();
+        assert!(
+            matches!(f.param_ranges.first(), Some(AbstractValue::Unknown)),
+            "exported function params must be ⊤ (unknown external args), got {:?}",
+            f.param_ranges
+        );
     }
 
     /// FEAT-021 slice-2b: the self-measuring fixture (two mutable i32 globals:

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -229,10 +229,13 @@ pub struct FunctionSummary {
     /// the argument values observed at every call site reaching this function.
     /// SOUND only when scry has accounted for ALL callers, so it is `Unknown`
     /// (⊤) for every parameter of a function that is exported, the start
-    /// function, or reachable by any `call_indirect` (external/over-approximate
-    /// entry whose arguments scry cannot bound). Otherwise each entry is the
-    /// join over all direct call sites — an over-approximation of the
-    /// parameter's incoming value across every reachable call. Library-only.
+    /// function, or — conservatively — defined in a module that contains ANY
+    /// `call_indirect` (scry's static table model under-reports indirect
+    /// targets, so it cannot prove a function is not an indirect callee).
+    /// Otherwise each entry is the join over all direct call sites — an
+    /// over-approximation of the parameter's incoming value across every
+    /// reachable call (never narrower than some reachable call permits).
+    /// Library-only.
     pub param_ranges: Vec<AbstractValue>,
 }
 
@@ -1407,24 +1410,20 @@ pub fn analyze(
     // Assemble the per-function-summary output records (FEAT-007).
     // ───────────────────────────────────────────────────────────
     // FEAT-036: interprocedural parameter ranges. A function's params are sound
-    // to narrow ONLY when scry has accounted for EVERY caller. The over-approx
-    // / external entry points whose arguments scry cannot bound are: exports,
-    // the start function, and any function reachable via `call_indirect` (its
-    // index appears in some indirect edge's resolved-target superset). If any
-    // indirect edge is unsound (an under-approximation), any function could be
-    // an unseen indirect target, so we bail to ⊤ for everything. Otherwise a
-    // function's params are the join of the arguments over all DIRECT call
-    // sites reaching it — a sound over-approximation of every reachable call.
-    let mut indirect_targets: Vec<u32> = Vec::new();
-    let mut any_unsound_edge = false;
-    for e in &call_graph {
-        if e.indirect {
-            indirect_targets.extend_from_slice(&e.resolved_targets);
-        }
-        if e.soundness == SoundnessTag::UnsoundFallback {
-            any_unsound_edge = true;
-        }
-    }
+    // to narrow ONLY when scry has accounted for EVERY caller. The join over
+    // direct call sites is complete iff there is NO other way to reach the
+    // function with an argument scry did not capture. The external/unseen entry
+    // points are: exports and the start function (called with unknown args),
+    // and — critically — ANY `call_indirect` in the module. scry's static table
+    // model under-reports indirect targets (passive/declared element segments,
+    // runtime `table.init`/`set`, non-constant offsets all leave the resolved
+    // target set incomplete), so it cannot prove a function is NOT an indirect
+    // callee. Conservative-but-sound slice-1: if the module contains any
+    // indirect call at all, every function's params are ⊤. (A future slice can
+    // narrow this with whole-table-mutation analysis.) In an indirect-call-free
+    // module, the only callers are the direct call sites Phase 2 recorded, so
+    // the join over them is a sound over-approximation of every reachable call.
+    let any_indirect_call = call_graph.iter().any(|e| e.indirect);
 
     let mut function_summaries: Vec<FunctionSummary> = Vec::with_capacity(defined_funcs.len());
     for (defined, func) in defined_funcs.iter().enumerate() {
@@ -1433,10 +1432,9 @@ pub fn analyze(
             let n = func.params.len();
             let top_params = || (0..n).map(|_| AbstractValue::Unknown).collect::<Vec<_>>();
             let param_ranges = if n == 0
-                || any_unsound_edge
+                || any_indirect_call
                 || exported_funcs.contains(&abs)
                 || start_func == Some(abs)
-                || indirect_targets.contains(&abs)
             {
                 top_params()
             } else {
@@ -5216,6 +5214,52 @@ mod tests {
             matches!(f.param_ranges.first(), Some(AbstractValue::Unknown)),
             "exported function params must be ⊤ (unknown external args), got {:?}",
             f.param_ranges
+        );
+    }
+
+    /// FEAT-036 SOUNDNESS REGRESSION (clean-room finding): a function called
+    /// directly with a constant, in a module that ALSO contains a
+    /// `call_indirect`, must keep ⊤ params. scry's static table model
+    /// under-reports indirect targets (passive/declared element segments and
+    /// runtime table mutation leave the resolved target set incomplete), so the
+    /// directly-called function could ALSO be reached indirectly with an
+    /// unbounded argument. The conservative gate forces every param to ⊤ as
+    /// soon as the module has any indirect call. Without this, `param_ranges`
+    /// would narrow $callee to the single direct-call constant [7,7] — an
+    /// UNSOUND under-approximation.
+    #[test]
+    fn feat036_indirect_call_forces_top() {
+        // func 0 ($callee): called directly with 7 below.
+        // func 1 (exported "run"): contains a `call_indirect`, so the module is
+        // not indirect-call-free → no function may be narrowed.
+        let r = analyze_default(
+            "(module \
+             (type $t (func (param i32) (result i32))) \
+             (table 1 funcref) \
+             (func (param i32) (result i32) local.get 0) \
+             (func (export \"direct\") (result i32) i32.const 7 call 0) \
+             (func (export \"ind\") (param i32) (result i32) \
+               local.get 0 \
+               local.get 0 \
+               call_indirect (type $t)))",
+        );
+        // sanity: the module really did produce an indirect edge.
+        assert!(
+            r.call_graph.iter().any(|e| e.indirect),
+            "fixture must contain a call_indirect edge"
+        );
+        let callee = r
+            .function_summaries
+            .iter()
+            .find(|f| f.func_index == 0)
+            .expect("callee summary");
+        assert_eq!(callee.param_count, 1);
+        assert!(
+            matches!(callee.param_ranges.first(), Some(AbstractValue::Unknown)),
+            "a module with any call_indirect must leave ALL param ranges ⊤ \
+             (the directly-called func could be an unseen indirect target), \
+             got {:?}",
+            callee.param_ranges
         );
     }
 

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -1449,9 +1449,11 @@ pub fn analyze(
     // dispatch is possible and the recorded direct calls are provably the
     // complete caller set. Only then may we narrow. (A future slice can recover
     // precision in funcref-bearing modules with whole-table escape analysis.)
-    let any_ref_func = defined_funcs
-        .iter()
-        .any(|f| f.ops.iter().any(|op| matches!(op, Operator::RefFunc { .. })));
+    let any_ref_func = defined_funcs.iter().any(|f| {
+        f.ops
+            .iter()
+            .any(|op| matches!(op, Operator::RefFunc { .. }))
+    });
     let callers_fully_known = !module_has_table && !any_ref_func;
 
     let mut function_summaries: Vec<FunctionSummary> = Vec::with_capacity(defined_funcs.len());

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -1449,12 +1449,25 @@ pub fn analyze(
     // dispatch is possible and the recorded direct calls are provably the
     // complete caller set. Only then may we narrow. (A future slice can recover
     // precision in funcref-bearing modules with whole-table escape analysis.)
-    let any_ref_func = defined_funcs.iter().any(|f| {
-        f.ops
-            .iter()
-            .any(|op| matches!(op, Operator::RefFunc { .. }))
+    // Defense-in-depth: besides the funcref-origin signals above, also bail on
+    // the *presence* of any indirect-dispatch operator. In valid Wasm these
+    // imply a table (so `module_has_table` already fires), but matching the ops
+    // directly makes the gate robust to malformed input and to dispatch ops the
+    // value interpreter does not model (`return_call_indirect`, `call_ref` fall
+    // through to the scrub-to-⊤ arm and record no call-graph edge) — exactly the
+    // class of "an op slipped through" the clean-room kept surfacing.
+    let any_funcref_escape = defined_funcs.iter().any(|f| {
+        f.ops.iter().any(|op| {
+            matches!(
+                op,
+                Operator::RefFunc { .. }
+                    | Operator::CallIndirect { .. }
+                    | Operator::ReturnCallIndirect { .. }
+                    | Operator::CallRef { .. }
+            )
+        })
     });
-    let callers_fully_known = !module_has_table && !any_ref_func;
+    let callers_fully_known = !module_has_table && !any_funcref_escape;
 
     let mut function_summaries: Vec<FunctionSummary> = Vec::with_capacity(defined_funcs.len());
     for (defined, func) in defined_funcs.iter().enumerate() {

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -229,12 +229,14 @@ pub struct FunctionSummary {
     /// the argument values observed at every call site reaching this function.
     /// SOUND only when scry has accounted for ALL callers, so it is `Unknown`
     /// (⊤) for every parameter of a function that is exported, the start
-    /// function, or — conservatively — defined in a module that contains ANY
-    /// `call_indirect` (scry's static table model under-reports indirect
-    /// targets, so it cannot prove a function is not an indirect callee).
-    /// Otherwise each entry is the join over all direct call sites — an
-    /// over-approximation of the parameter's incoming value across every
-    /// reachable call (never narrower than some reachable call permits).
+    /// function, or — conservatively — defined in any module that bears a
+    /// funcref container: one that declares/imports ANY table OR uses any
+    /// `ref.func`. (A funcref to a defined function can only originate from a
+    /// table or a `ref.func`; with neither present, no indirect or host
+    /// dispatch is possible, so the recorded direct calls are the complete
+    /// caller set.) Otherwise each entry is the join over all direct call
+    /// sites — an over-approximation of the parameter's incoming value across
+    /// every reachable call (never narrower than some reachable call permits).
     /// Library-only.
     pub param_ranges: Vec<AbstractValue>,
 }
@@ -904,6 +906,12 @@ pub fn analyze(
     let mut table0_is_funcref: bool = false;
     let mut table0_max: Option<u64> = None;
     let mut table_section_seen: bool = false;
+    // FEAT-036 soundness: true if the module declares OR imports ANY table
+    // (of any element type). A table is the only funcref container besides a
+    // `ref.func` instruction, so its mere presence means a defined function's
+    // address may be reachable indirectly (or by the host, via an exported or
+    // imported table) — which the param-range gate cannot otherwise bound.
+    let mut module_has_table: bool = false;
     // Active element segments targeting table 0 with a constant
     // i32 offset: (offset, [func indices]). Collected here, then
     // baked into the `FuncTable` after we know the table length.
@@ -957,6 +965,11 @@ pub fn analyze(
                         // FEAT-027: imported funcs occupy the low indices in
                         // import order; record "module.field" as a fallback name.
                         import_func_meta.push(alloc::format!("{}.{}", imp.module, imp.name));
+                    }
+                    // FEAT-036 soundness: an imported table is host-controlled —
+                    // the host can dispatch through it with arbitrary arguments.
+                    if matches!(imp.ty, wasmparser::TypeRef::Table(_)) {
+                        module_has_table = true;
                     }
                 }
             }
@@ -1031,6 +1044,9 @@ pub fn analyze(
                 for entry in reader {
                     let table = entry
                         .map_err(|e| AnalyzeError::InvalidModule(format!("table section: {e}")))?;
+                    // FEAT-036 soundness: any declared table (any element type)
+                    // is a potential funcref container / indirect-dispatch root.
+                    module_has_table = true;
                     if first {
                         table_section_seen = true;
                         // `initial` / `maximum` are `u64` in the
@@ -1410,20 +1426,33 @@ pub fn analyze(
     // Assemble the per-function-summary output records (FEAT-007).
     // ───────────────────────────────────────────────────────────
     // FEAT-036: interprocedural parameter ranges. A function's params are sound
-    // to narrow ONLY when scry has accounted for EVERY caller. The join over
-    // direct call sites is complete iff there is NO other way to reach the
-    // function with an argument scry did not capture. The external/unseen entry
-    // points are: exports and the start function (called with unknown args),
-    // and — critically — ANY `call_indirect` in the module. scry's static table
-    // model under-reports indirect targets (passive/declared element segments,
-    // runtime `table.init`/`set`, non-constant offsets all leave the resolved
-    // target set incomplete), so it cannot prove a function is NOT an indirect
-    // callee. Conservative-but-sound slice-1: if the module contains any
-    // indirect call at all, every function's params are ⊤. (A future slice can
-    // narrow this with whole-table-mutation analysis.) In an indirect-call-free
-    // module, the only callers are the direct call sites Phase 2 recorded, so
-    // the join over them is a sound over-approximation of every reachable call.
-    let any_indirect_call = call_graph.iter().any(|e| e.indirect);
+    // to narrow ONLY when scry has accounted for EVERY caller. The join over the
+    // recorded DIRECT call sites is the complete caller set iff there is NO
+    // other way to reach the function with an argument scry did not capture.
+    //
+    // The external / unseen entry points are:
+    //   * exports and the start function — invoked by the host with unknown
+    //     args (gated per-function below); and
+    //   * ANY indirect dispatch. scry cannot soundly enumerate indirect
+    //     targets: its static table model under-reports them (passive/declared
+    //     element segments, runtime `table.init`/`set`, non-constant indices),
+    //     and several dispatch ops (`return_call_indirect`, `call_ref`) are
+    //     unsupported — they scrub to ⊤ and record NO call-graph edge, so an
+    //     edge-based test misses them entirely. A host holding an exported (or
+    //     imported) table can likewise `call_indirect` with arbitrary args.
+    //
+    // Root-cause-sound rule: a non-null funcref to a defined function can ONLY
+    // come from a `ref.func` instruction or a table (element segments). If the
+    // module has NEITHER a table (declared or imported) NOR any `ref.func`,
+    // then no funcref to any defined function can exist anywhere — in code, in
+    // a table, in a global, or returned to the host — so NO indirect or host
+    // dispatch is possible and the recorded direct calls are provably the
+    // complete caller set. Only then may we narrow. (A future slice can recover
+    // precision in funcref-bearing modules with whole-table escape analysis.)
+    let any_ref_func = defined_funcs
+        .iter()
+        .any(|f| f.ops.iter().any(|op| matches!(op, Operator::RefFunc { .. })));
+    let callers_fully_known = !module_has_table && !any_ref_func;
 
     let mut function_summaries: Vec<FunctionSummary> = Vec::with_capacity(defined_funcs.len());
     for (defined, func) in defined_funcs.iter().enumerate() {
@@ -1432,7 +1461,7 @@ pub fn analyze(
             let n = func.params.len();
             let top_params = || (0..n).map(|_| AbstractValue::Unknown).collect::<Vec<_>>();
             let param_ranges = if n == 0
-                || any_indirect_call
+                || !callers_fully_known
                 || exported_funcs.contains(&abs)
                 || start_func == Some(abs)
             {
@@ -5219,19 +5248,17 @@ mod tests {
 
     /// FEAT-036 SOUNDNESS REGRESSION (clean-room finding): a function called
     /// directly with a constant, in a module that ALSO contains a
-    /// `call_indirect`, must keep ⊤ params. scry's static table model
-    /// under-reports indirect targets (passive/declared element segments and
-    /// runtime table mutation leave the resolved target set incomplete), so the
-    /// directly-called function could ALSO be reached indirectly with an
-    /// unbounded argument. The conservative gate forces every param to ⊤ as
-    /// soon as the module has any indirect call. Without this, `param_ranges`
-    /// would narrow $callee to the single direct-call constant [7,7] — an
-    /// UNSOUND under-approximation.
+    /// `call_indirect` (and therefore a table), must keep ⊤ params. scry's
+    /// static table model under-reports indirect targets, so the directly-
+    /// called function could ALSO be reached indirectly with an unbounded
+    /// argument. The gate forces every param to ⊤ as soon as the module bears
+    /// a funcref container. Without this, `param_ranges` would narrow $callee
+    /// to the single direct-call constant [7,7] — an UNSOUND under-approx.
     #[test]
     fn feat036_indirect_call_forces_top() {
         // func 0 ($callee): called directly with 7 below.
-        // func 1 (exported "run"): contains a `call_indirect`, so the module is
-        // not indirect-call-free → no function may be narrowed.
+        // func 2 (exported "ind"): contains a `call_indirect` — and the module
+        // declares a table — so callers are not fully known → no narrowing.
         let r = analyze_default(
             "(module \
              (type $t (func (param i32) (result i32))) \
@@ -5256,9 +5283,63 @@ mod tests {
         assert_eq!(callee.param_count, 1);
         assert!(
             matches!(callee.param_ranges.first(), Some(AbstractValue::Unknown)),
-            "a module with any call_indirect must leave ALL param ranges ⊤ \
+            "a module bearing a funcref table must leave ALL param ranges ⊤ \
              (the directly-called func could be an unseen indirect target), \
              got {:?}",
+            callee.param_ranges
+        );
+    }
+
+    /// FEAT-036 SOUNDNESS REGRESSION (clean-room counterexample #1): an EXPORTED
+    /// funcref table lets the HOST `call_indirect` a defined function with
+    /// arbitrary arguments, even though the module itself has NO `call_indirect`
+    /// (so an edge-based gate sees nothing). The table's mere presence must
+    /// force ⊤. Without the fix, func 0 narrows to the single direct call [42].
+    #[test]
+    fn feat036_exported_table_forces_top() {
+        let r = analyze_default(
+            "(module \
+             (table (export \"t\") 1 funcref) \
+             (elem (i32.const 0) 0) \
+             (func (param i32) (result i32) local.get 0) \
+             (func (export \"run\") (result i32) i32.const 42 call 0))",
+        );
+        let callee = r
+            .function_summaries
+            .iter()
+            .find(|f| f.func_index == 0)
+            .expect("callee summary");
+        assert!(
+            matches!(callee.param_ranges.first(), Some(AbstractValue::Unknown)),
+            "a function in an exported funcref table is host-reachable with \
+             unknown args ⇒ params must be ⊤, got {:?}",
+            callee.param_ranges
+        );
+    }
+
+    /// FEAT-036 SOUNDNESS REGRESSION (clean-room counterexample #2 generalized):
+    /// a `ref.func` materializes a callable reference to a defined function that
+    /// can escape (to a table, a global, the host, or a `call_ref`) beyond the
+    /// direct call sites scry recorded. Its presence must force ⊤ even with no
+    /// table-section table. Here func 0 is called directly with 7 and also has
+    /// its address taken via `ref.func`.
+    #[test]
+    fn feat036_ref_func_forces_top() {
+        let r = analyze_default(
+            "(module \
+             (func (param i32) (result i32) local.get 0) \
+             (func (export \"take\") (result funcref) ref.func 0) \
+             (func (export \"direct\") (result i32) i32.const 7 call 0))",
+        );
+        let callee = r
+            .function_summaries
+            .iter()
+            .find(|f| f.func_index == 0)
+            .expect("callee summary");
+        assert!(
+            matches!(callee.param_ranges.first(), Some(AbstractValue::Unknown)),
+            "a function whose address is taken via ref.func can be called \
+             indirectly with unknown args ⇒ params must be ⊤, got {:?}",
             callee.param_ranges
         );
     }

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -912,6 +912,12 @@ pub fn analyze(
     // address may be reachable indirectly (or by the host, via an exported or
     // imported table) — which the param-range gate cannot otherwise bound.
     let mut module_has_table: bool = false;
+    // FEAT-036 soundness: true if a `ref.func` appears OUTSIDE a function body —
+    // in a global's init expression or an element segment's items. Such a
+    // funcref to a defined function can escape (e.g. via an exported global) to
+    // a `call_ref`/host call the param-range gate cannot bound, and the
+    // body-only operator scan would miss it. (Third clean-room finding.)
+    let mut func_ref_taken_in_const: bool = false;
     // Active element segments targeting table 0 with a constant
     // i32 offset: (offset, [func indices]). Collected here, then
     // baked into the `FuncTable` after we know the table length.
@@ -1031,6 +1037,12 @@ pub fn analyze(
                     if g.ty.mutable && matches!(g.ty.content_type, wasmparser::ValType::I32) {
                         mutable_i32_globals.push(gidx);
                     }
+                    // FEAT-036 soundness: a `ref.func` in the init expr takes a
+                    // defined function's address (the global can be exported /
+                    // read by the host) — outside any function body.
+                    if const_expr_takes_func_ref(&g.init_expr) {
+                        func_ref_taken_in_const = true;
+                    }
                     gidx = gidx.saturating_add(1);
                 }
             }
@@ -1073,6 +1085,14 @@ pub fn analyze(
                     let element = entry.map_err(|e| {
                         AnalyzeError::InvalidModule(format!("element section: {e}"))
                     })?;
+                    // FEAT-036 soundness: any element segment that names defined
+                    // functions takes their addresses. Active segments imply a
+                    // table (already caught), but passive/declared segments need
+                    // no table, so flag the escape uniformly here. (Third
+                    // clean-room finding.)
+                    if element_items_take_func_ref(&element.items)? {
+                        func_ref_taken_in_const = true;
+                    }
                     match &element.kind {
                         wasmparser::ElementKind::Active {
                             table_index,
@@ -1443,12 +1463,14 @@ pub fn analyze(
     //
     // Root-cause-sound rule: a non-null funcref to a defined function can ONLY
     // come from a `ref.func` instruction or a table (element segments). If the
-    // module has NEITHER a table (declared or imported) NOR any `ref.func`,
-    // then no funcref to any defined function can exist anywhere — in code, in
-    // a table, in a global, or returned to the host — so NO indirect or host
-    // dispatch is possible and the recorded direct calls are provably the
-    // complete caller set. Only then may we narrow. (A future slice can recover
-    // precision in funcref-bearing modules with whole-table escape analysis.)
+    // module has NEITHER a table (declared or imported) NOR any `ref.func`
+    // ANYWHERE — function bodies (`any_funcref_escape`) AND the const positions
+    // a body scan misses: global init exprs and element-segment items
+    // (`func_ref_taken_in_const`) — then no funcref to any defined function can
+    // exist anywhere (code, table, global, or returned/handed to the host), so
+    // NO indirect or host dispatch is possible and the recorded direct calls
+    // are provably the complete caller set. Only then may we narrow. (A future
+    // slice can recover precision with whole-table / escape analysis.)
     // Defense-in-depth: besides the funcref-origin signals above, also bail on
     // the *presence* of any indirect-dispatch operator. In valid Wasm these
     // imply a table (so `module_has_table` already fires), but matching the ops
@@ -1467,7 +1489,7 @@ pub fn analyze(
             )
         })
     });
-    let callers_fully_known = !module_has_table && !any_funcref_escape;
+    let callers_fully_known = !module_has_table && !any_funcref_escape && !func_ref_taken_in_const;
 
     let mut function_summaries: Vec<FunctionSummary> = Vec::with_capacity(defined_funcs.len());
     for (defined, func) in defined_funcs.iter().enumerate() {
@@ -3733,6 +3755,39 @@ fn const_i32_offset(offset_expr: &wasmparser::ConstExpr<'_>) -> Option<i64> {
     }
 }
 
+/// FEAT-036 soundness: does a constant expression (a global init or an
+/// element-segment offset/item) contain a `ref.func`? Such an expression takes
+/// a defined function's address OUTSIDE any function body — the body-only
+/// operator scan misses it, so the param-range gate must account for it here.
+fn const_expr_takes_func_ref(expr: &wasmparser::ConstExpr<'_>) -> bool {
+    expr.get_operators_reader()
+        .into_iter()
+        .any(|op| matches!(op, Ok(Operator::RefFunc { .. })))
+}
+
+/// FEAT-036 soundness: does an element segment name any defined function (and
+/// thereby take its address)? `Functions` items are bare func indices;
+/// `Expressions` items may carry `ref.func`. A malformed segment is treated as
+/// taking a reference (conservative — never under-reports an escape).
+fn element_items_take_func_ref(items: &wasmparser::ElementItems<'_>) -> Result<bool, AnalyzeError> {
+    match items {
+        wasmparser::ElementItems::Functions(funcs) => {
+            Ok(funcs.clone().into_iter().next().is_some())
+        }
+        wasmparser::ElementItems::Expressions(_, exprs) => {
+            for expr in exprs.clone() {
+                let expr = expr.map_err(|e| {
+                    AnalyzeError::InvalidModule(format!("element expression item: {e}"))
+                })?;
+                if const_expr_takes_func_ref(&expr) {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+    }
+}
+
 /// Handle a direct `Call { function_index }` (FEAT-006 graph +
 /// FEAT-007 effect). Records a trivially-sound single-target
 /// call-graph edge, then applies the callee's abstract summary to the
@@ -5355,6 +5410,33 @@ mod tests {
             matches!(callee.param_ranges.first(), Some(AbstractValue::Unknown)),
             "a function whose address is taken via ref.func can be called \
              indirectly with unknown args ⇒ params must be ⊤, got {:?}",
+            callee.param_ranges
+        );
+    }
+
+    /// FEAT-036 SOUNDNESS REGRESSION (clean-room counterexample #3): a `ref.func`
+    /// in a GLOBAL init expression takes a defined function's address with NO
+    /// table and NO `ref.func` in any function BODY — so a body-only scan misses
+    /// it. The exported global hands func 0's reference to the host, which can
+    /// `call_ref` it with arbitrary args. Must force ⊤; without the fix func 0
+    /// narrows to the single direct call [7,7].
+    #[test]
+    fn feat036_global_init_ref_func_forces_top() {
+        let r = analyze_default(
+            "(module \
+             (func (param i32) (result i32) local.get 0) \
+             (global (export \"g\") funcref (ref.func 0)) \
+             (func (export \"direct\") (result i32) i32.const 7 call 0))",
+        );
+        let callee = r
+            .function_summaries
+            .iter()
+            .find(|f| f.func_index == 0)
+            .expect("callee summary");
+        assert!(
+            matches!(callee.param_ranges.first(), Some(AbstractValue::Unknown)),
+            "a function whose address is taken in a global init expr escapes to \
+             the host ⇒ params must be ⊤, got {:?}",
             callee.param_ranges
         );
     }

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "2.1.1" }
+scry-sai-core = { path = "../scry-analyze-core", version = "2.2.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }


### PR DESCRIPTION
The next planned loop (synth wishlist, #54): sound interprocedural parameter ranges.

## What
- `CallEdge.arg_ranges: Vec<AbstractValue>` — the abstract arguments at each call site, in parameter order (populated for direct calls; empty for `call_indirect` / signature-unknown imports).
- `FunctionSummary.param_ranges: Vec<AbstractValue>` — per parameter, the **join** of `arg_ranges` over every direct call site reaching the function (e.g. a function called with `5` and `10` → `[5, 10]`).

## Soundness (the crux)
`param_ranges` is `Unknown` (⊤) for **every** parameter of a function that is **exported, the start function, or reachable via `call_indirect`** — the external / over-approximate entry points whose arguments scry cannot bound — and ⊤ if any indirect edge is unsound. Only when scry has accounted for *every* caller (a non-exported, non-start function reached solely by direct, fully-resolved calls) does it join their arguments. So a `param_ranges` entry is **never narrower than some reachable call permits** — it's an over-approximation of the incoming value, never an under-approximation.

The args are harvested from the actual values `handle_call` pops (not a fragile post-hoc stack lookup), so they're exactly what the call consumes.

## Surface
Both fields are **library-only** (read off the `scry-sai-core` `AnalysisResult`); the wasm wrapper ignores them (field-access mapping), so the WIT mirror and the frozen v1 JSON contract are unchanged — consistent with `operand_stack`/`function_meta`.

## Traceability + tests
- rivet: **FEAT-036** (traces REQ-004), accepted. `rivet validate` PASS.
- `feat036_interproc_param_ranges` (join 5⊔10 = [5,10]) + `feat036_exported_params_are_top` (exported → ⊤). 19 core tests pass; clippy clean.
- Additive fields → **SemVer-minor 2.1.1 → 2.2.0**.

## Falsification statement
If a `param_ranges` entry excludes an argument value that some reachable call actually passes — i.e. it's an under-approximation — the soundness claim is false. (Being clean-room-verified, focusing on the eligibility gating.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)