### PR TITLE
v2.4.0 (FEAT-038, scry#70): model memory.size/grow; bounded_memory ⇒ memory.size constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,15 @@ premise: a function that touches memory ops no longer collapses to ⊤.
   to ⊤** (every local degraded). Any function reading memory size or growing
   memory now keeps its interval / region / known-bits invariants.
 - `memory.size` returns the current size in **pages**; memory never shrinks, so
-  it is `[initial, max]` — and the **exact constant `initial`** when scry's own
-  check confirms no `memory.grow` anywhere (`verified_premises.bounded_memory`,
-  verify-not-trust). A fixed-memory module thus gets `memory.size` as a usable
-  constant for bounds-check elision.
+  it is `[initial, max]` — and the **exact constant `initial`** only when the
+  memory is provably fixed: **module-private** (not imported, exported, or
+  shared) AND no `memory.grow` in any defined function (scry's own check,
+  verify-not-trust). Then only this module's defined code could grow it, which
+  the grow-free check rules out — so a fixed-memory module gets `memory.size` as
+  a usable constant for bounds-check elision. An **imported** memory uses its
+  declared minimum as the sound lower bound (never `[0,0]`); an imported /
+  exported / shared memory is never collapsed to a constant (the host or another
+  thread may grow it). [clean-room soundness findings, fixed before merge]
 - `memory.grow(delta)` evaluates to the sound bounded interval `[-1, max]` (the
   previous size on success, `-1` on failure); it mutates linear memory, not
   locals, so it no longer degrades the function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ premise: a function that touches memory ops no longer collapses to ⊤.
   a usable constant for bounds-check elision. An **imported** memory uses its
   declared minimum as the sound lower bound (never `[0,0]`); an imported /
   exported / shared memory is never collapsed to a constant (the host or another
-  thread may grow it). [clean-room soundness findings, fixed before merge]
+  thread may grow it). A **64-bit memory** uses the 2⁴⁸-page ceiling (not the
+  memory32 65536) and returns an i64; `memory.size`/`memory.grow` are modelled
+  precisely only for the single-memory, memidx-0 case — a multi-memory module
+  or a non-zero memidx is ⊤. [four clean-room soundness findings, fixed before
+  merge]
 - `memory.grow(delta)` evaluates to the sound bounded interval `[-1, max]` (the
   previous size on success, `-1` on failure); it mutates linear memory, not
   locals, so it no longer degrades the function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.4.0] — 2026-06-27
+
+Headline: **`memory.size` / `memory.grow` modelled; verified `bounded_memory`
+makes `memory.size` a constant (FEAT-038, scry#70).** Spends the FEAT-034
+premise: a function that touches memory ops no longer collapses to ⊤.
+
+### Changed — FEAT-038 (traces REQ-001, G-005, FEAT-034)
+
+- `memory.size` and `memory.grow` are now modelled in the interpreter instead
+  of falling to the unsupported-op fallback, which **scrubbed the whole function
+  to ⊤** (every local degraded). Any function reading memory size or growing
+  memory now keeps its interval / region / known-bits invariants.
+- `memory.size` returns the current size in **pages**; memory never shrinks, so
+  it is `[initial, max]` — and the **exact constant `initial`** when scry's own
+  check confirms no `memory.grow` anywhere (`verified_premises.bounded_memory`,
+  verify-not-trust). A fixed-memory module thus gets `memory.size` as a usable
+  constant for bounds-check elision.
+- `memory.grow(delta)` evaluates to the sound bounded interval `[-1, max]` (the
+  previous size on success, `-1` on failure); it mutates linear memory, not
+  locals, so it no longer degrades the function.
+
+### Posture
+
+- Behavioral precision only — no API, WIT, or frozen-JSON-contract change.
+- **Falsification statement.** scry claims `memory.size` ∈ `[initial, max]` on
+  every run (and `= initial` under verified `bounded_memory`), and
+  `memory.grow` ∈ `[-1, max]`. FALSE if memory could exceed `max` pages, or if
+  `memory.size` returned a value outside that range, or if `bounded_memory` were
+  asserted while a reachable `memory.grow` exists (cross-checked + rejected per
+  FEAT-034). Falsifier: a fixture whose concrete `memory.size`/`grow` result
+  falls outside the reported interval.
+
 ## [2.3.0] — 2026-06-26
 
 Headline: **known-bits × interval-guarded congruence reduced product

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1851,18 +1851,18 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-bits"
-version = "2.3.0"
+version = "2.4.0"
 
 [[package]]
 name = "scry-sai-core"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-interval",
@@ -1876,11 +1876,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "2.3.0"
+version = "2.4.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1889,19 +1889,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "2.3.0"
+version = "2.4.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "2.3.0"
+version = "2.4.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "2.3.0"
+version = "2.4.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cpp_demangle 0.5.1",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "2.3.0"
+version = "2.4.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -1879,23 +1879,30 @@ artifacts:
   - id: FEAT-038
     type: feature
     title: "v2.x — Consume verified bounded_memory to tighten the region/memory fixpoint (scry#70)"
-    status: proposed
+    status: accepted
     description: >
-      Make FEAT-034's verified `bounded_memory` premise PAY OFF. Today scry
-      surfaces and cross-checks `verified_premises.bounded_memory` (no
-      `memory.grow` anywhere ⇒ fixed linear memory) but does not consume it: the
-      region/interval memory pass still treats `memory.grow` conservatively
-      (v0.3 region scope — a grow havocs memory-derived state). When
-      bounded_memory holds — proven by scry's OWN check (verify-not-trust;
-      never meld's premise alone) — that fallback is unnecessary, so region
-      offsets and memory-load invariants can stay tight instead of widening.
-      Additive precision; no API/contract change. SOUND only because scry
-      verifies the absence of `memory.grow` itself.
+      Make FEAT-034's verified `bounded_memory` premise PAY OFF. INVESTIGATION
+      REFRAME (v2.4.0): the concrete win is the `memory.size` / `memory.grow`
+      ops, which previously fell to the unsupported-op fallback that scrubs the
+      WHOLE function to ⊤ (every local degraded). FEAT-038 models them directly:
+        * `memory.size` returns the current size in PAGES; memory never shrinks,
+          so size ∈ [initial, max]. When scry's OWN check confirms NO
+          `memory.grow` anywhere (bounded_memory — verify-not-trust, never
+          meld's premise alone), it is the EXACT constant `initial`.
+        * `memory.grow(delta)` pushes the previous size or -1 → result ∈
+          [-1, max]; it mutates linear memory, NOT locals, so it no longer
+          degrades the function.
+      Net effect: any function touching `memory.size`/`memory.grow` keeps its
+      interval/region/bit invariants instead of collapsing to ⊤, and a fixed-
+      memory module gets `memory.size` as a usable constant (bounds-check
+      elision). Additive precision; no API/contract change; sound by scry's own
+      verification.
     tags: [capability, precision, analysis, premise-consumption, v2.x]
     fields:
       phase: phase-2
       acceptance-criteria:
-        - "Given a module with NO `memory.grow` (so scry's verified_premises.bounded_memory is true), When scry analyzes a memory-derived value that the conservative grow-havoc would have widened to ⊤, Then the region/interval invariant is retained (tighter) — and for a module that DOES contain `memory.grow`, the conservative havoc still applies (no under-approximation)."
+        - "Given a module with NO `memory.grow` (verified_premises.bounded_memory true) that reads `memory.size`, When scry analyzes it, Then `memory.size` evaluates to the exact constant initial page count and the surrounding locals are NOT degraded to ⊤ (which the pre-FEAT-038 fallback did)."
+        - "Given a module containing `memory.grow`, When scry analyzes it, Then the grow result is the sound bounded interval [-1, max] (never under-approximated) and the function's other locals survive (no whole-function ⊤ scrub) — while bounded_memory remains false."
     links:
       - type: traces-to
         target: REQ-001

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -1901,8 +1901,9 @@ artifacts:
     fields:
       phase: phase-2
       acceptance-criteria:
-        - "Given a module with NO `memory.grow` (verified_premises.bounded_memory true) that reads `memory.size`, When scry analyzes it, Then `memory.size` evaluates to the exact constant initial page count and the surrounding locals are NOT degraded to ⊤ (which the pre-FEAT-038 fallback did)."
+        - "Given a module with a MODULE-PRIVATE memory (not imported/exported/shared) and NO `memory.grow` in any defined function, When scry reads `memory.size`, Then it evaluates to the exact constant initial page count and the surrounding locals are NOT degraded to ⊤ (which the pre-FEAT-038 fallback did)."
         - "Given a module containing `memory.grow`, When scry analyzes it, Then the grow result is the sound bounded interval [-1, max] (never under-approximated) and the function's other locals survive (no whole-function ⊤ scrub) — while bounded_memory remains false."
+        - "Given a module whose memory is IMPORTED, EXPORTED, or SHARED (host/other thread may grow it), When scry reads `memory.size`, Then it is the sound interval [initial, max] — NEVER a constant, and an imported memory uses its declared minimum as the lower bound (never [0,0]). (Clean-room soundness findings.)"
     links:
       - type: traces-to
         target: REQ-001

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "2.3.0" }
+scry-sai-interval = { path = "../scry-interval", version = "2.4.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,20 +43,20 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "2.3.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "2.3.0" }
+scry-sai-taint = { path = "../scry-taint", version = "2.4.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "2.4.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "2.3.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "2.4.0" }
 
 # Known-bits × interval-guarded congruence reduced product (FEAT-037 / DD-017):
 # an additive bit/alignment/stride companion computed in a straight-line-sound
 # pass, surfaced library-only on `AnalysisResult.bit_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-bits = { path = "../scry-bits", version = "2.3.0" }
+scry-sai-bits = { path = "../scry-bits", version = "2.4.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -484,7 +484,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "2.3.0";
+const SCRY_VERSION: &str = "2.4.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).
@@ -665,6 +665,14 @@ struct ModuleCtx<'a> {
     func_table: &'a FuncTable,
     /// Per-region metadata for the v0.3 memory ops.
     default_region: &'a RegionMeta,
+    /// FEAT-038: scry verified that no `memory.grow` occurs anywhere, so the
+    /// linear memory is fixed at `memory_initial_pages` and `memory.size`
+    /// returns that exact constant. When false, `memory.size` is bounded by
+    /// `[memory_initial_pages, memory_max_pages]` (or unbounded above).
+    bounded_memory: bool,
+    /// FEAT-038: first memory's declared initial / maximum page counts.
+    memory_initial_pages: u64,
+    memory_max_pages: Option<u64>,
     /// Collected defined-function bodies (FEAT-007), indexed by
     /// defined-function index (absolute index minus
     /// `import_func_count`).
@@ -906,6 +914,12 @@ pub fn analyze(
     // until we see `memory.grow` (which currently still falls
     // back to UnsoundnessFallback per the v0.3 scope).
     let mut memory_min_bytes: u64 = 0;
+    // FEAT-038: the first memory's declared page limits, for `memory.size` /
+    // `memory.grow` modelling. `memory_initial_pages` is the page count
+    // `memory.size` returns when memory is fixed (bounded_memory); the maximum
+    // (when declared) caps the size interval otherwise.
+    let mut memory_initial_pages: u64 = 0;
+    let mut memory_max_pages: Option<u64> = None;
 
     // ── FEAT-021 shadow-stack state ──────────────────────────────
     // Indices of mutable i32 globals — the candidates for the C-style
@@ -1053,6 +1067,8 @@ pub fn analyze(
                         .map_err(|e| AnalyzeError::InvalidModule(format!("memory section: {e}")))?;
                     if first {
                         memory_min_bytes = mem.initial.saturating_mul(WASM_PAGE_SIZE);
+                        memory_initial_pages = mem.initial;
+                        memory_max_pages = mem.maximum;
                         first = false;
                     }
                 }
@@ -1387,6 +1403,19 @@ pub fn analyze(
     //       recursion-frontier result).
     // ───────────────────────────────────────────────────────────
     let static_callees = build_static_call_graph(&defined_funcs, &func_table, import_func_count);
+
+    // FEAT-038: scry's OWN bounded-memory determination — no `memory.grow` in
+    // any defined function ⇒ linear memory is fixed at its declared initial
+    // size (verify-not-trust; computed here, before the fixpoint, so the
+    // `memory.size` transfer can return the exact page count). Reused for
+    // `verified_premises` below.
+    let saw_memory_grow = defined_funcs.iter().any(|f| {
+        f.ops
+            .iter()
+            .any(|op| matches!(op, Operator::MemoryGrow { .. }))
+    });
+    let bounded_memory = !saw_memory_grow;
+
     let sccs = tarjan_sccs(&static_callees);
     let recursive_flags = recursive_flags_from_sccs(&sccs, &static_callees, defined_funcs.len());
 
@@ -1416,6 +1445,9 @@ pub fn analyze(
                 import_func_count,
                 func_table: &func_table,
                 default_region: &default_region_meta,
+                bounded_memory,
+                memory_initial_pages,
+                memory_max_pages,
                 defined_funcs: &defined_funcs,
                 summaries: &summaries,
             };
@@ -1458,6 +1490,9 @@ pub fn analyze(
         import_func_count,
         func_table: &func_table,
         default_region: &default_region_meta,
+        bounded_memory,
+        memory_initial_pages,
+        memory_max_pages,
         defined_funcs: &defined_funcs,
         summaries: &summaries,
     };
@@ -1704,13 +1739,11 @@ pub fn analyze(
     // scan — `memory.grow` anywhere ⇒ memory is not provably fixed; any
     // functional import ⇒ scry cannot prove a closed world at the core level.
     // These are sound because scry derived them, independent of meld's claim.
-    let saw_memory_grow = defined_funcs.iter().any(|f| {
-        f.ops
-            .iter()
-            .any(|op| matches!(op, Operator::MemoryGrow { .. }))
-    });
+    // `bounded_memory` (= `!saw_memory_grow`) is computed once before the
+    // fixpoint (FEAT-038, so `memory.size` can use it) and reused here.
+    let saw_memory_grow = !bounded_memory;
     let verified_premises = FusionPremises {
-        bounded_memory: !saw_memory_grow,
+        bounded_memory,
         closed_world: import_func_count == 0,
     };
     // Cross-check meld's asserted premise against scry's observation: a v3
@@ -3674,14 +3707,39 @@ fn interpret_op(
                 *table_index,
             );
         }
+        Operator::MemorySize { .. } => {
+            // FEAT-038: `memory.size` returns the current size in PAGES. Memory
+            // never shrinks, so size ∈ [initial, max]. When scry verified no
+            // `memory.grow` anywhere (bounded_memory), it is the exact constant
+            // `initial`. Modelled WITHOUT degrading the function (the prior
+            // `other` fallback scrubbed every local to ⊤).
+            let lo = module_ctx.memory_initial_pages as i64;
+            let hi = if module_ctx.bounded_memory {
+                lo
+            } else {
+                // memory32 caps at 65536 pages (4 GiB) when no maximum is given.
+                module_ctx.memory_max_pages.unwrap_or(65536) as i64
+            };
+            ctx.operand_stack
+                .push(AbstractValue::I32Interval(Interval { lo, hi }));
+        }
+        Operator::MemoryGrow { .. } => {
+            // FEAT-038: `memory.grow(delta)` pops the requested page delta and
+            // pushes the PREVIOUS size on success or -1 on failure — so the
+            // result is in `[-1, max]`. Sound, and (unlike the prior fallback)
+            // does not degrade locals: a grow mutates linear memory, not locals.
+            let _ = ctx.operand_stack.pop();
+            let hi = module_ctx.memory_max_pages.unwrap_or(65536) as i64;
+            ctx.operand_stack
+                .push(AbstractValue::I32Interval(Interval { lo: -1, hi }));
+        }
         other => {
             // Anything outside the supported set: emit a fallback
             // diagnostic, scrub state to top to preserve soundness
             // (REQ-001), and continue. Control flow (`If` / `Loop` /
-            // `Br*`) and `memory.grow` / `memory.size` still land
-            // here; FEAT-005 lifted the canonical memory ops,
-            // FEAT-006 lifted `call` / `call_indirect`, and FEAT-007
-            // will add interprocedural value propagation.
+            // `Br*`) still land here; FEAT-005 lifted the canonical
+            // memory ops, FEAT-006 lifted `call` / `call_indirect`,
+            // FEAT-038 lifted `memory.size` / `memory.grow`.
             if emit_diagnostics {
                 diagnostics.push(Diagnostic {
                     severity: DiagnosticSeverity::UnsoundnessFallback,
@@ -5522,6 +5580,55 @@ mod tests {
             .expect("bit fact for local 0");
         assert_eq!(f.width, 64);
         assert_eq!(f.known_ones, 0xFF_FFFF_FFFF, "low 40 bits known-1");
+    }
+
+    /// FEAT-038: under verified `bounded_memory` (no `memory.grow` anywhere),
+    /// `memory.size` is the exact constant initial page count — and modelling it
+    /// no longer degrades the function (the pre-FEAT-038 fallback scrubbed every
+    /// local to ⊤).
+    #[test]
+    fn feat038_memory_size_constant_when_bounded() {
+        // (memory 3), no grow ⇒ memory.size == 3 pages, stored into local 0.
+        let r = analyze_default(
+            "(module (memory 3) (func (result i32) (local i32) \
+               memory.size local.set 0 local.get 0))",
+        );
+        assert!(r.verified_premises.bounded_memory, "no grow ⇒ bounded");
+        let found = r.invariants.points.iter().any(|p| {
+            p.locals.iter().any(|l| {
+                l.local_index == 0
+                    && matches!(&l.value, AbstractValue::I32Interval(iv) if iv.lo == 3 && iv.hi == 3)
+            })
+        });
+        assert!(
+            found,
+            "memory.size under bounded_memory must make local 0 = [3,3] (not degraded); points={:?}",
+            r.invariants.points
+        );
+    }
+
+    /// FEAT-038: `memory.grow` is modelled (result ∈ [-1, max]) WITHOUT degrading
+    /// the function — its bounded result lands in a local instead of ⊤.
+    #[test]
+    fn feat038_memory_grow_does_not_degrade() {
+        // (memory 2 10): grow result ∈ [-1, 10], stored into local 0 (no drop —
+        // `drop` is itself unsupported and would degrade).
+        let r = analyze_default(
+            "(module (memory 2 10) (func (result i32) (local i32) \
+               i32.const 1 memory.grow local.set 0 local.get 0))",
+        );
+        assert!(!r.verified_premises.bounded_memory, "grow ⇒ not bounded");
+        let found = r.invariants.points.iter().any(|p| {
+            p.locals.iter().any(|l| {
+                l.local_index == 0
+                    && matches!(&l.value, AbstractValue::I32Interval(iv) if iv.lo == -1 && iv.hi == 10)
+            })
+        });
+        assert!(
+            found,
+            "memory.grow result must be the bounded [-1,10] (modelled, not degraded); points={:?}",
+            r.invariants.points
+        );
     }
 
     /// FEAT-034: scry determines its OWN fusion premises (verify-not-trust):

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -675,6 +675,10 @@ struct ModuleCtx<'a> {
     /// FEAT-038: first memory's declared initial / maximum page counts.
     memory_initial_pages: u64,
     memory_max_pages: Option<u64>,
+    /// FEAT-038: total memory count (precise `memory.size`/`grow` only when 1)
+    /// and whether memory index 0 is 64-bit (2^48-page ceiling + i64 result).
+    memory_count: u64,
+    memory_is_64: bool,
     /// Collected defined-function bodies (FEAT-007), indexed by
     /// defined-function index (absolute index minus
     /// `import_func_count`).
@@ -930,6 +934,13 @@ pub fn analyze(
     let mut memory_is_imported: bool = false;
     let mut memory_is_exported: bool = false;
     let mut memory_is_shared: bool = false;
+    // FEAT-038 soundness (clean-room): total memory count (imports + defined)
+    // and whether memory index 0 is 64-bit. `memory.size`/`memory.grow` are
+    // modelled precisely ONLY for the single-memory, memidx-0 case; >1 memory
+    // or a non-zero memidx ⇒ ⊤ (only index 0 is captured). A 64-bit memory
+    // grows to 2^48 pages, so its ceiling is 2^48, not the memory32 65536.
+    let mut memory_count: u64 = 0;
+    let mut memory_is_64: bool = false;
 
     // ── FEAT-021 shadow-stack state ──────────────────────────────
     // Indices of mutable i32 globals — the candidates for the C-style
@@ -1043,10 +1054,16 @@ pub fn analyze(
                     // sound lower bound `memory.size` must use) and mark it
                     // host-controlled / possibly-shared.
                     if let wasmparser::TypeRef::Memory(memty) = imp.ty {
-                        memory_is_imported = true;
-                        memory_initial_pages = memty.initial;
-                        memory_max_pages = memty.maximum;
-                        memory_is_shared |= memty.shared;
+                        // Imported memories occupy the low memory-index space, so
+                        // the first one is memory index 0. Capture index 0 only.
+                        if memory_count == 0 {
+                            memory_is_imported = true;
+                            memory_initial_pages = memty.initial;
+                            memory_max_pages = memty.maximum;
+                            memory_is_shared |= memty.shared;
+                            memory_is_64 = memty.memory64;
+                        }
+                        memory_count += 1;
                     }
                 }
             }
@@ -1088,17 +1105,25 @@ pub fn analyze(
                 // "default" region's size. Multi-memory
                 // (post-MVP) is not yet supported — we use
                 // the first entry only.
-                let mut first = true;
+                let mut first_defined = true;
                 for entry in reader {
                     let mem = entry
                         .map_err(|e| AnalyzeError::InvalidModule(format!("memory section: {e}")))?;
-                    if first {
+                    // The first DEFINED memory anchors the v0.3 region floor.
+                    if first_defined {
                         memory_min_bytes = mem.initial.saturating_mul(WASM_PAGE_SIZE);
+                        first_defined = false;
+                    }
+                    // FEAT-038: capture memory INDEX 0's limits. Imports precede
+                    // defined memories in the index space, so a defined memory is
+                    // index 0 only when no memory was imported (memory_count == 0).
+                    if memory_count == 0 {
                         memory_initial_pages = mem.initial;
                         memory_max_pages = mem.maximum;
                         memory_is_shared |= mem.shared;
-                        first = false;
+                        memory_is_64 = mem.memory64;
                     }
+                    memory_count += 1;
                 }
             }
             Payload::GlobalSection(reader) => {
@@ -1483,6 +1508,8 @@ pub fn analyze(
                 memory_size_constant,
                 memory_initial_pages,
                 memory_max_pages,
+                memory_count,
+                memory_is_64,
                 defined_funcs: &defined_funcs,
                 summaries: &summaries,
             };
@@ -1528,6 +1555,8 @@ pub fn analyze(
         memory_size_constant,
         memory_initial_pages,
         memory_max_pages,
+        memory_count,
+        memory_is_64,
         defined_funcs: &defined_funcs,
         summaries: &summaries,
     };
@@ -1823,6 +1852,38 @@ pub fn analyze(
 }
 
 // ───────────────────────── FEAT-037 (DD-017) ─────────────────────────
+
+/// FEAT-038: the page ceiling for memory index 0 — the declared maximum if any,
+/// else the architectural cap (2^48 for memory64, 65536 for memory32).
+#[inline]
+fn mem_page_ceiling(m: &ModuleCtx<'_>) -> i64 {
+    let arch_cap: u64 = if m.memory_is_64 { 1u64 << 48 } else { 65536 };
+    m.memory_max_pages.unwrap_or(arch_cap) as i64
+}
+
+/// FEAT-038: the abstract `memory.size` result for `memidx`. Precise only for
+/// memory index 0 of a single-memory module (the only memory scry captures);
+/// any other memidx or a multi-memory module is ⊤ (sound). The exact constant
+/// `initial` applies only to a provably-fixed module-private memory; otherwise
+/// the sound interval `[initial, ceiling]`. 64-bit memory returns an i64.
+#[inline]
+fn mem_size_value(m: &ModuleCtx<'_>, memidx: u32) -> AbstractValue {
+    if memidx != 0 || m.memory_count != 1 {
+        return AbstractValue::Unknown;
+    }
+    let lo = m.memory_initial_pages as i64;
+    let hi = if m.memory_size_constant {
+        lo
+    } else {
+        mem_page_ceiling(m)
+    };
+    let iv = Interval { lo, hi };
+    if m.memory_is_64 {
+        AbstractValue::I64Interval(iv)
+    } else {
+        AbstractValue::I32Interval(iv)
+    }
+}
 
 /// Integer bit width of a Wasm value type, or `None` for types the bits domain
 /// does not model (floats, v128, references).
@@ -3742,31 +3803,34 @@ fn interpret_op(
                 *table_index,
             );
         }
-        Operator::MemorySize { .. } => {
+        Operator::MemorySize { mem, .. } => {
             // FEAT-038: `memory.size` returns the current size in PAGES. Memory
-            // never shrinks, so size ∈ [initial, max]. When scry verified no
-            // `memory.grow` anywhere (bounded_memory), it is the exact constant
-            // `initial`. Modelled WITHOUT degrading the function (the prior
-            // `other` fallback scrubbed every local to ⊤).
-            let lo = module_ctx.memory_initial_pages as i64;
-            let hi = if module_ctx.memory_size_constant {
-                lo
-            } else {
-                // memory32 caps at 65536 pages (4 GiB) when no maximum is given.
-                module_ctx.memory_max_pages.unwrap_or(65536) as i64
-            };
-            ctx.operand_stack
-                .push(AbstractValue::I32Interval(Interval { lo, hi }));
+            // never shrinks, so size ∈ [initial, max]; the exact constant
+            // `initial` only for a provably-fixed module-private memory. We
+            // model precisely ONLY memory index 0 of a single-memory module
+            // (scry captures only index 0); any other memidx, or a multi-memory
+            // module, is ⊤ (sound). 64-bit memory caps at 2^48 pages and
+            // returns an i64. Modelled WITHOUT degrading the function.
+            let value = mem_size_value(module_ctx, *mem);
+            ctx.operand_stack.push(value);
         }
-        Operator::MemoryGrow { .. } => {
+        Operator::MemoryGrow { mem, .. } => {
             // FEAT-038: `memory.grow(delta)` pops the requested page delta and
             // pushes the PREVIOUS size on success or -1 on failure — so the
-            // result is in `[-1, max]`. Sound, and (unlike the prior fallback)
-            // does not degrade locals: a grow mutates linear memory, not locals.
+            // result is in `[-1, max]`. Does NOT degrade locals (a grow mutates
+            // linear memory, not locals). ⊤ for an unmodelled memidx/memory.
             let _ = ctx.operand_stack.pop();
-            let hi = module_ctx.memory_max_pages.unwrap_or(65536) as i64;
-            ctx.operand_stack
-                .push(AbstractValue::I32Interval(Interval { lo: -1, hi }));
+            let value = if *mem == 0 && module_ctx.memory_count == 1 {
+                let hi = mem_page_ceiling(module_ctx);
+                if module_ctx.memory_is_64 {
+                    AbstractValue::I64Interval(Interval { lo: -1, hi })
+                } else {
+                    AbstractValue::I32Interval(Interval { lo: -1, hi })
+                }
+            } else {
+                AbstractValue::Unknown
+            };
+            ctx.operand_stack.push(value);
         }
         other => {
             // Anything outside the supported set: emit a fallback
@@ -5735,6 +5799,48 @@ mod tests {
                 "exported memory is host-growable ⇒ not the constant 1: {iv:?}"
             );
         }
+    }
+
+    /// FEAT-038 SOUNDNESS REGRESSION (clean-room #1): a 64-bit memory grows to
+    /// 2^48 pages, not the memory32 cap of 65536. An exported memory64 (host-
+    /// growable, so not a constant) must report `memory.size ∈ [1, 2^48]` as an
+    /// i64 — the prior `unwrap_or(65536)` under-approximated.
+    #[test]
+    fn feat038_memory64_ceiling() {
+        let v = memory_size_value(
+            "(module (memory i64 1) (export \"m\" (memory 0)) \
+               (func (result i64) memory.size))",
+        );
+        match v {
+            AbstractValue::I64Interval(iv) => {
+                assert_eq!(iv.lo, 1);
+                assert_eq!(
+                    iv.hi,
+                    1i64 << 48,
+                    "memory64 ceiling is 2^48 pages, not 65536"
+                );
+            }
+            other => {
+                panic!("memory64 memory.size must be an i64 interval [1, 2^48], got {other:?}")
+            }
+        }
+    }
+
+    /// FEAT-038 SOUNDNESS REGRESSION (clean-room #2/#3): scry captures only
+    /// memory index 0 and does not model multi-memory, so `memory.size` in a
+    /// module with >1 memory is ⊤ (never memory 0's bounds reused for another
+    /// memidx, and never an imported memory 0's min clobbered by a defined one).
+    #[test]
+    fn feat038_multimemory_is_top() {
+        // memidx 1 read against a 2-memory module ⇒ ⊤ (Unknown), not [1,..].
+        let v = memory_size_value(
+            "(module (memory 1 5) (memory 3 9) (func (result i32) memory.size 1))",
+        );
+        assert!(
+            matches!(v, AbstractValue::Unknown),
+            "multi-memory memory.size must be ⊤ (only index 0 of a single-memory \
+             module is modelled), got {v:?}"
+        );
     }
 
     /// FEAT-034: scry determines its OWN fusion premises (verify-not-trust):

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -665,11 +665,13 @@ struct ModuleCtx<'a> {
     func_table: &'a FuncTable,
     /// Per-region metadata for the v0.3 memory ops.
     default_region: &'a RegionMeta,
-    /// FEAT-038: scry verified that no `memory.grow` occurs anywhere, so the
-    /// linear memory is fixed at `memory_initial_pages` and `memory.size`
-    /// returns that exact constant. When false, `memory.size` is bounded by
-    /// `[memory_initial_pages, memory_max_pages]` (or unbounded above).
-    bounded_memory: bool,
+    /// FEAT-038: the memory is provably fixed at `memory_initial_pages` — it is
+    /// module-private (not imported/exported/shared) and no defined function
+    /// grows it — so `memory.size` returns that exact constant. When false,
+    /// `memory.size` is the sound interval `[memory_initial_pages,
+    /// memory_max_pages-or-65536]` (memory may have been grown by this module,
+    /// the host, or another thread).
+    memory_size_constant: bool,
     /// FEAT-038: first memory's declared initial / maximum page counts.
     memory_initial_pages: u64,
     memory_max_pages: Option<u64>,
@@ -920,6 +922,14 @@ pub fn analyze(
     // (when declared) caps the size interval otherwise.
     let mut memory_initial_pages: u64 = 0;
     let mut memory_max_pages: Option<u64> = None;
+    // FEAT-038 soundness (clean-room): the constant-`memory.size` collapse is
+    // valid ONLY for a module-PRIVATE memory — not imported (host supplies and
+    // may grow it), not exported (host can grow it via the API), not shared
+    // (another thread may grow it). For any of those, `memory.size` is the
+    // sound interval `[initial, max]`, never a constant.
+    let mut memory_is_imported: bool = false;
+    let mut memory_is_exported: bool = false;
+    let mut memory_is_shared: bool = false;
 
     // ── FEAT-021 shadow-stack state ──────────────────────────────
     // Indices of mutable i32 globals — the candidates for the C-style
@@ -1027,6 +1037,17 @@ pub fn analyze(
                     if matches!(imp.ty, wasmparser::TypeRef::Table(_)) {
                         module_has_table = true;
                     }
+                    // FEAT-038 soundness: an imported memory is host-supplied —
+                    // its true size is ≥ the declared minimum and the host may
+                    // grow it. Capture its declared limits (the minimum is the
+                    // sound lower bound `memory.size` must use) and mark it
+                    // host-controlled / possibly-shared.
+                    if let wasmparser::TypeRef::Memory(memty) = imp.ty {
+                        memory_is_imported = true;
+                        memory_initial_pages = memty.initial;
+                        memory_max_pages = memty.maximum;
+                        memory_is_shared |= memty.shared;
+                    }
                 }
             }
             Payload::FunctionSection(reader) => {
@@ -1047,6 +1068,12 @@ pub fn analyze(
                         exported_funcs.push(ex.index);
                         // FEAT-027: keep the export name for readable metadata.
                         export_names.push((ex.index, alloc::string::String::from(ex.name)));
+                    }
+                    // FEAT-038 soundness: an exported memory can be grown by the
+                    // host through the embedder API, so `memory.size` is not a
+                    // constant even with no in-module `memory.grow`.
+                    if matches!(ex.kind, wasmparser::ExternalKind::Memory) {
+                        memory_is_exported = true;
                     }
                 }
             }
@@ -1069,6 +1096,7 @@ pub fn analyze(
                         memory_min_bytes = mem.initial.saturating_mul(WASM_PAGE_SIZE);
                         memory_initial_pages = mem.initial;
                         memory_max_pages = mem.maximum;
+                        memory_is_shared |= mem.shared;
                         first = false;
                     }
                 }
@@ -1415,6 +1443,13 @@ pub fn analyze(
             .any(|op| matches!(op, Operator::MemoryGrow { .. }))
     });
     let bounded_memory = !saw_memory_grow;
+    // FEAT-038 soundness (clean-room): `memory.size` is the EXACT initial-page
+    // constant only for a module-PRIVATE memory grown by no one — not imported,
+    // not exported, not shared, and with no in-module `memory.grow`. Then only
+    // this module's defined code could grow it, which `bounded_memory` rules
+    // out. Otherwise `memory.size` is the sound interval `[initial, max]`.
+    let memory_size_constant =
+        bounded_memory && !memory_is_imported && !memory_is_exported && !memory_is_shared;
 
     let sccs = tarjan_sccs(&static_callees);
     let recursive_flags = recursive_flags_from_sccs(&sccs, &static_callees, defined_funcs.len());
@@ -1445,7 +1480,7 @@ pub fn analyze(
                 import_func_count,
                 func_table: &func_table,
                 default_region: &default_region_meta,
-                bounded_memory,
+                memory_size_constant,
                 memory_initial_pages,
                 memory_max_pages,
                 defined_funcs: &defined_funcs,
@@ -1490,7 +1525,7 @@ pub fn analyze(
         import_func_count,
         func_table: &func_table,
         default_region: &default_region_meta,
-        bounded_memory,
+        memory_size_constant,
         memory_initial_pages,
         memory_max_pages,
         defined_funcs: &defined_funcs,
@@ -3714,7 +3749,7 @@ fn interpret_op(
             // `initial`. Modelled WITHOUT degrading the function (the prior
             // `other` fallback scrubbed every local to ⊤).
             let lo = module_ctx.memory_initial_pages as i64;
-            let hi = if module_ctx.bounded_memory {
+            let hi = if module_ctx.memory_size_constant {
                 lo
             } else {
                 // memory32 caps at 65536 pages (4 GiB) when no maximum is given.
@@ -5629,6 +5664,77 @@ mod tests {
             "memory.grow result must be the bounded [-1,10] (modelled, not degraded); points={:?}",
             r.invariants.points
         );
+    }
+
+    /// The abstract `memory.size` value via a one-function `(func (result i32)
+    /// memory.size)` — read off the function summary, unambiguous (no pre-set
+    /// program-point to confuse with the result).
+    #[cfg(test)]
+    fn memory_size_value(module_src: &str) -> AbstractValue {
+        let r = analyze_default(module_src);
+        // The defined function returning memory.size is the last summary.
+        r.function_summaries
+            .last()
+            .and_then(|s| s.result_summary.first().cloned())
+            .expect("a result summary with the memory.size value")
+    }
+
+    /// FEAT-038 SOUNDNESS REGRESSION (clean-room #A): an IMPORTED memory is
+    /// host-supplied — true size ≥ declared minimum and the host may grow it.
+    /// `memory.size` must be `[initial, max]`, never the constant (and never the
+    /// `[0,0]` an un-captured import default would give).
+    #[test]
+    fn feat038_imported_memory_size_not_constant() {
+        let v = memory_size_value(
+            "(module (import \"env\" \"mem\" (memory 1)) \
+               (func (result i32) memory.size))",
+        );
+        match v {
+            AbstractValue::I32Interval(iv) => {
+                assert_eq!(iv.lo, 1, "imported (memory 1) ⇒ size ≥ 1, never 0: {iv:?}");
+                assert!(iv.hi > 1, "host may grow ⇒ not a constant: {iv:?}");
+            }
+            other => panic!("expected a sound bounded interval, got {other:?}"),
+        }
+    }
+
+    /// FEAT-038 soundness reasoning (clean-room #B, resolved): a functional
+    /// import canNOT grow this module's PRIVATE memory — in core Wasm an
+    /// imported `(func)` has no handle to a non-imported/exported/shared memory
+    /// (memory is not a first-class value that can be passed). Only this
+    /// module's defined code can grow a private memory, which `bounded_memory`
+    /// already rules out. So the constant `[1,1]` here is SOUND despite the
+    /// functional import — the gate does not (and need not) require closed_world.
+    #[test]
+    fn feat038_private_memory_constant_despite_import() {
+        let v = memory_size_value(
+            "(module (import \"env\" \"f\" (func)) (memory 1) \
+               (func (result i32) call 0 memory.size))",
+        );
+        match v {
+            AbstractValue::I32Interval(iv) => assert!(
+                iv.lo == 1 && iv.hi == 1,
+                "private memory + grow-free module ⇒ size is the constant 1 \
+                 (an import cannot reach a private memory): {iv:?}"
+            ),
+            other => panic!("expected [1,1], got {other:?}"),
+        }
+    }
+
+    /// FEAT-038: an EXPORTED memory is host-growable via the embedder API, so
+    /// even with no in-module grow `memory.size` is not a constant.
+    #[test]
+    fn feat038_exported_memory_size_not_constant() {
+        let v = memory_size_value(
+            "(module (memory 1) (export \"mem\" (memory 0)) \
+               (func (result i32) memory.size))",
+        );
+        if let AbstractValue::I32Interval(iv) = v {
+            assert!(
+                !(iv.lo == 1 && iv.hi == 1),
+                "exported memory is host-growable ⇒ not the constant 1: {iv:?}"
+            );
+        }
     }
 
     /// FEAT-034: scry determines its OWN fusion premises (verify-not-trust):

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "2.3.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "2.4.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }


### PR DESCRIPTION
## FEAT-038 (#70) — spend FEAT-034's verified `bounded_memory`

**Investigation reframe** (documented in the rivet artifact): the original "tighten the region fixpoint" framing was a near-no-op under verify-not-trust (scry's own `bounded_memory` check = "no `memory.grow` seen", so a module with nothing to havoc already satisfies it). The *real* win is that `memory.size`/`memory.grow` fell to the unsupported-op fallback that **scrubs the whole function to ⊤** — so any function touching memory ops was fully degraded.

### Change
- Model `memory.size` → size in pages ∈ `[initial, max]`, and the **exact constant `initial`** under verified `bounded_memory` (no `memory.grow` anywhere; scry's own check).
- Model `memory.grow` → `[-1, max]`; mutates memory not locals, so no degrade.
- `bounded_memory` hoisted before the fixpoint (so `memory.size` uses it) and reused for `verified_premises`.

### Evidence
- `feat038_memory_size_constant_when_bounded` — `(memory 3)`, no grow ⇒ local = `[3,3]`, not degraded.
- `feat038_memory_grow_does_not_degrade` — grow result `[-1,10]` survives (pre-FEAT-038 it scrubbed the function).
- 29 scry-sai-core tests green; clippy + fmt clean.

Behavioral precision only — no API / WIT / frozen-JSON-contract change. Falsification statement in CHANGELOG. Lockstep bump 2.3.0 → 2.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)