### PR TITLE
v2.5.0 (FEAT-039, scry#71): SOUNDNESS — open-world reachable_from_exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.5.0] — 2026-06-27
+
+Headline: **`reachable_from_exports` is now sound in the OPEN world (FEAT-039,
+scry#71).** Fixes a latent under-approximation: a function reachable only via an
+escaped funcref was wrongly omitted, making the SCRY-001 "prune the complement"
+contract unsound outside a closed module.
+
+### Fixed — FEAT-039 (traces REQ-001, REQ-011, G-005, FEAT-034) — SOUNDNESS
+
+- **`reachable_from_exports` could under-approximate** (present since FEAT-022).
+  A function reachable only through an escaped funcref — placed in an **exported
+  funcref table** (with no in-module `call_indirect`), held in an **exported
+  funcref global**, or **passed as a funcref to an imported function** — was
+  omitted from the set, even though the host or an import can dispatch it.
+  Pruning the complement (synth#383 / VCR-MEM-001 shadow-stack reservation)
+  could then drop a genuinely reachable function. Now: when funcrefs can escape
+  (the FEAT-036 `callers_fully_known` predicate is false — i.e. the module has a
+  table or any `ref.func`), every **address-taken** function (every `ref.func`
+  target in a body / global init / element item, and every element-segment-named
+  function) is added as a reachability **root**, keeping the result a sound
+  superset.
+- The original "consume `closed_world`" framing was disproved: gating on
+  `closed_world` alone is **insufficient** (an exported funcref table leaks with
+  `closed_world == true`). The correct gate is the funcref-escape predicate.
+- **Precision retained**: in a provably closed-and-escape-free module (no table,
+  no `ref.func`), the tight exports+start seed is kept — a genuinely dead
+  function is still pruned.
+
+### Posture
+
+- Soundness fix (the reported set only grows where it was unsound); the consumer
+  contract (SCRY-001) is now honored in the open world. No API / WIT / frozen-
+  JSON-contract change.
+- **Falsification statement.** scry claims every function callable on some
+  concrete run from a host/import/export entry is in `reachable_from_exports`.
+  FALSE if a function reachable via any funcref-dispatch path is absent.
+  Falsifier: a `.wat` whose function runs at runtime (host `call_indirect` on an
+  exported table, etc.) but is not in the set.
+
 ## [2.4.0] — 2026-06-27
 
 Headline: **`memory.size` / `memory.grow` modelled; verified `bounded_memory`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1851,18 +1851,18 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-bits"
-version = "2.4.0"
+version = "2.5.0"
 
 [[package]]
 name = "scry-sai-core"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-interval",
@@ -1876,11 +1876,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "2.4.0"
+version = "2.5.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1889,19 +1889,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "2.4.0"
+version = "2.5.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "2.4.0"
+version = "2.5.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "2.4.0"
+version = "2.5.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "cpp_demangle 0.5.1",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "2.4.0"
+version = "2.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/artifacts/roadmap-2.0.yaml
+++ b/artifacts/roadmap-2.0.yaml
@@ -1914,24 +1914,38 @@ artifacts:
 
   - id: FEAT-039
     type: feature
-    title: "v2.x — Consume verified closed_world to tighten reachable_from_exports (scry#71)"
-    status: proposed
+    title: "v2.x — Sound open-world reachable_from_exports (escaped funcrefs as roots) (scry#71)"
+    status: accepted
     description: >
-      Make FEAT-034's verified `closed_world` premise PAY OFF for the
-      reachability footprint (synth#383 / VCR-MEM-001). `reachable_from_exports`
-      (FEAT-022) is a sound superset seeded by exports + start AND
-      over-approximated import/host entry points. When `closed_world` holds (no
-      functional imports — scry's own check) there is no external/host caller,
-      so the import-driven over-approximation can be dropped, shrinking the
-      reachable set toward the true one (a tighter shadow-stack / linear-memory
-      reservation). The `call_indirect` whole-table over-approximation is
-      RETAINED (closed_world does not bound indirect targets — that is the
-      FEAT-036 funcref-escape story). Stays a sound superset (SCRY-001).
-    tags: [capability, precision, analysis, premise-consumption, v2.x]
+      INVESTIGATION REFRAME (v2.5.0) — what looked like a `closed_world`
+      precision tweak is actually a SOUNDNESS FIX. A clean-room confirmed that
+      `reachable_from_exports` (FEAT-022), documented as a sound SUPERSET so a
+      consumer may "prune the complement" (SCRY-001; synth#383 / VCR-MEM-001),
+      could UNDER-approximate in an OPEN world: a function reachable only via an
+      escaped funcref — e.g. one placed in an EXPORTED funcref table with no
+      in-module `call_indirect`, held in an exported funcref global, or passed as
+      a funcref to an imported function — was OMITTED, yet the host or an import
+      can dispatch it. Pruning it would be unsound (a real frame unreserved).
+
+      Also disproved the original framing: gating on `closed_world` ALONE is
+      INSUFFICIENT (an exported funcref table leaks with `closed_world == true`).
+      The correct gate is FEAT-036's funcref-escape predicate
+      `callers_fully_known` (= no table, no `ref.func`, no const-position
+      funcref): exactly when NO funcref to a defined function can exist outside
+      the recorded call edges.
+
+      FIX: when `callers_fully_known` is FALSE, add every address-taken function
+      (a `ref.func` target in a body / global init / element item, and every
+      element-segment-named function) as a reachability ROOT — the host/import
+      may dispatch any of them. When TRUE (provably closed-and-escape-free), the
+      tight exports+start seed is correct — the precision the premise licenses.
+      Stays a sound superset (over-approximation only ADDS functions).
+    tags: [capability, soundness, analysis, premise-consumption, v2.x]
     fields:
       phase: phase-2
       acceptance-criteria:
-        - "Given a module with NO functional imports (verified_premises.closed_world true), When scry computes reachable_from_exports, Then import/host-entry roots are excluded so the reported set is no larger than exports+start reachability — while remaining a sound superset (never drops a concretely-reachable function), and a module WITH a functional import keeps the conservative seed."
+        - "Given a module where a function is reachable ONLY via an escaped funcref (in an exported funcref table with no in-module call_indirect, in an exported funcref global, or passed to an imported function), When scry computes reachable_from_exports, Then that function IS in the set (sound superset — never omits a host/import-dispatchable function)."
+        - "Given a module that is provably closed-and-escape-free (no table, no ref.func anywhere — callers_fully_known), When scry computes reachable_from_exports, Then a genuinely dead (unexported, uncalled) function is EXCLUDED — the tight seed the escape-free property licenses."
     links:
       - type: traces-to
         target: REQ-001

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "2.4.0" }
+scry-sai-interval = { path = "../scry-interval", version = "2.5.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,20 +43,20 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "2.4.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "2.4.0" }
+scry-sai-taint = { path = "../scry-taint", version = "2.5.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "2.5.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "2.4.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "2.5.0" }
 
 # Known-bits × interval-guarded congruence reduced product (FEAT-037 / DD-017):
 # an additive bit/alignment/stride companion computed in a straight-line-sound
 # pass, surfaced library-only on `AnalysisResult.bit_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-bits = { path = "../scry-bits", version = "2.4.0" }
+scry-sai-bits = { path = "../scry-bits", version = "2.5.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -484,7 +484,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "2.4.0";
+const SCRY_VERSION: &str = "2.5.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).
@@ -989,6 +989,14 @@ pub fn analyze(
     // a `call_ref`/host call the param-range gate cannot bound, and the
     // body-only operator scan would miss it. (Third clean-room finding.)
     let mut func_ref_taken_in_const: bool = false;
+    // FEAT-039: every function whose address is taken anywhere (a `ref.func` in
+    // a body / global init / element item, or a bare element-segment func index)
+    // — absolute indices. When funcrefs can escape (open world, NOT
+    // `callers_fully_known`), these are added as reachability roots so
+    // `reachable_from_exports` stays a sound SUPERSET (the host / an import may
+    // dispatch any escaped funcref). May contain duplicates / imports; filtered
+    // when seeded.
+    let mut address_taken_funcs: Vec<u32> = Vec::new();
     // Active element segments targeting table 0 with a constant
     // i32 offset: (offset, [func indices]). Collected here, then
     // baked into the `FuncTable` after we know the table length.
@@ -1148,6 +1156,8 @@ pub fn analyze(
                     if const_expr_takes_func_ref(&g.init_expr) {
                         func_ref_taken_in_const = true;
                     }
+                    // FEAT-039: collect the addressed function(s) as escape roots.
+                    const_expr_ref_func_targets(&g.init_expr, &mut address_taken_funcs);
                     gidx = gidx.saturating_add(1);
                 }
             }
@@ -1198,6 +1208,10 @@ pub fn analyze(
                     if element_items_take_func_ref(&element.items)? {
                         func_ref_taken_in_const = true;
                     }
+                    // FEAT-039: collect the named functions as escape roots (any
+                    // table / segment kind — host or `call_indirect` may reach
+                    // them once funcrefs escape).
+                    element_items_ref_func_targets(&element.items, &mut address_taken_funcs);
                     match &element.kind {
                         wasmparser::ElementKind::Active {
                             table_index,
@@ -1782,13 +1796,31 @@ pub fn analyze(
         });
     }
 
-    // FEAT-022 slice-1: reachability from the module's entry points, over the
-    // same over-approximated static call graph used for the summary pass.
+    // FEAT-039: complete the address-taken set with `ref.func` operands in
+    // function BODIES (the const-position ones were collected during parsing).
+    for f in &defined_funcs {
+        for op in &f.ops {
+            if let Operator::RefFunc { function_index } = op {
+                address_taken_funcs.push(*function_index);
+            }
+        }
+    }
+
+    // FEAT-022 slice-1 + FEAT-039: reachability from the module's entry points
+    // over the over-approximated static call graph. SOUNDNESS (FEAT-039): when
+    // funcrefs can escape to a caller scry cannot see (open world — NOT
+    // `callers_fully_known`, the FEAT-036 escape predicate), the host or an
+    // import may dispatch ANY address-taken function, so those are added as
+    // reachability roots to keep the result a sound SUPERSET (SCRY-001). When
+    // the module is provably closed-and-escape-free, the tight exports+start
+    // seed is correct — the precision the premise licenses.
     let reachable_from_exports = compute_reachable_from_exports(
         &static_callees,
         import_func_count,
         &exported_funcs,
         start_func,
+        callers_fully_known,
+        &address_taken_funcs,
     );
 
     let function_meta = build_function_meta(
@@ -3211,11 +3243,22 @@ fn build_static_call_graph(
 /// SUPERSET of the concretely-reachable functions (REQ-011/SCRY-001): an edge
 /// the analyzer over-approximates only ever ADDS a function, never drops a
 /// reachable one. A consumer may soundly prune any function NOT in this set.
+///
+/// FEAT-039: `callers_fully_known` (the FEAT-036 funcref-escape predicate) is
+/// true exactly when no funcref to a defined function can exist outside the
+/// recorded call edges. When it is FALSE — an open world where a funcref may
+/// have escaped to the host or an import — every address-taken function
+/// (`address_taken_funcs`, absolute indices) is added as a reachability root,
+/// because such a caller can dispatch any escaped funcref. This keeps the set a
+/// sound superset; without it a function reachable only via, e.g., an exported
+/// funcref table (with no in-module `call_indirect`) would be wrongly omitted.
 fn compute_reachable_from_exports(
     static_callees: &[Vec<usize>],
     import_func_count: u32,
     exported_funcs: &[u32],
     start_func: Option<u32>,
+    callers_fully_known: bool,
+    address_taken_funcs: &[u32],
 ) -> Vec<u32> {
     let n = static_callees.len();
     let mut reachable_defined = alloc::vec![false; n];
@@ -3240,6 +3283,12 @@ fn compute_reachable_from_exports(
     }
     if let Some(s) = start_func {
         seed(s, &mut work, &mut out, &mut reachable_defined);
+    }
+    // FEAT-039: in an open world, any escaped funcref is host/import-dispatchable.
+    if !callers_fully_known {
+        for &abs in address_taken_funcs {
+            seed(abs, &mut work, &mut out, &mut reachable_defined);
+        }
     }
     // BFS/DFS over the over-approximated static call graph.
     while let Some(d) = work.pop() {
@@ -4189,6 +4238,37 @@ fn element_items_take_func_ref(items: &wasmparser::ElementItems<'_>) -> Result<b
                 }
             }
             Ok(false)
+        }
+    }
+}
+
+/// FEAT-039: collect the function indices a constant expression takes the
+/// address of via `ref.func` (global init / element item). Used to seed
+/// reachability roots when funcrefs can escape (the open-world case).
+fn const_expr_ref_func_targets(expr: &wasmparser::ConstExpr<'_>, out: &mut Vec<u32>) {
+    for op in expr.get_operators_reader() {
+        if let Ok(Operator::RefFunc { function_index }) = op {
+            out.push(function_index);
+        }
+    }
+}
+
+/// FEAT-039: collect the function indices an element segment names (bare
+/// `Functions` items and `ref.func` `Expressions` items). A malformed segment
+/// is ignored for collection (the boolean escape flag already forces the
+/// conservative path; this set only ADDS roots, so a miss here cannot make the
+/// reachable set under-approximate beyond what the boolean already guards).
+fn element_items_ref_func_targets(items: &wasmparser::ElementItems<'_>, out: &mut Vec<u32>) {
+    match items {
+        wasmparser::ElementItems::Functions(funcs) => {
+            for idx in funcs.clone().into_iter().flatten() {
+                out.push(idx);
+            }
+        }
+        wasmparser::ElementItems::Expressions(_, exprs) => {
+            for expr in exprs.clone().into_iter().flatten() {
+                const_expr_ref_func_targets(&expr, out);
+            }
         }
     }
 }
@@ -5451,6 +5531,68 @@ mod tests {
         assert_eq!(
             sorted, res.reachable_from_exports,
             "set is sorted + deduped"
+        );
+    }
+
+    /// FEAT-039 SOUNDNESS REGRESSION (clean-room): in an OPEN world a function
+    /// reachable only via an escaped funcref (exported table / exported global /
+    /// passed to an import) was wrongly OMITTED from reachable_from_exports —
+    /// making the SCRY-001 "prune the complement" contract unsound. It must now
+    /// be INCLUDED. And in a closed-and-escape-free module, a genuinely dead
+    /// function must still be EXCLUDED (the precision the escape gate licenses).
+    #[test]
+    fn feat039_exported_table_func_is_reachable() {
+        // func 0 = main (export); func 1 = F, only in an EXPORTED funcref table,
+        // no in-module call_indirect. Host can call_indirect it ⇒ reachable.
+        let r = analyze_default(
+            "(module (table (export \"t\") 1 funcref) (elem (i32.const 0) 1) \
+               (func (export \"main\")) (func (result i32) i32.const 7))",
+        );
+        assert!(
+            r.reachable_from_exports.contains(&1),
+            "F in an exported funcref table is host-dispatchable ⇒ reachable; got {:?}",
+            r.reachable_from_exports
+        );
+    }
+
+    #[test]
+    fn feat039_exported_global_funcref_is_reachable() {
+        // func 1 (F) addressed by ref.func in an exported global's init expr.
+        let r = analyze_default(
+            "(module (func (export \"main\")) (func (result i32) i32.const 7) \
+               (global (export \"g\") funcref (ref.func 1)))",
+        );
+        assert!(
+            r.reachable_from_exports.contains(&1),
+            "F held in an exported funcref global is host-callable ⇒ reachable; got {:?}",
+            r.reachable_from_exports
+        );
+    }
+
+    #[test]
+    fn feat039_reffunc_to_import_is_reachable() {
+        // import cb=0; main=1 (export) passes ref.func 2 to the import; F=2.
+        let r = analyze_default(
+            "(module (import \"e\" \"cb\" (func (param funcref))) \
+               (func (export \"main\") ref.func 2 call 0) \
+               (func (result i32) i32.const 7))",
+        );
+        assert!(
+            r.reachable_from_exports.contains(&2),
+            "F passed as a funcref to an import can be called back ⇒ reachable; got {:?}",
+            r.reachable_from_exports
+        );
+    }
+
+    #[test]
+    fn feat039_closed_world_dead_func_still_excluded() {
+        // No table, no ref.func ⇒ callers_fully_known ⇒ tight seed; func 1 dead.
+        let r =
+            analyze_default("(module (func (export \"main\")) (func (result i32) i32.const 7))");
+        assert!(
+            !r.reachable_from_exports.contains(&1),
+            "a genuinely dead func in a closed/escape-free module must stay pruned; got {:?}",
+            r.reachable_from_exports
         );
     }
 

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "2.4.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "2.5.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }


### PR DESCRIPTION
## FEAT-039 (#71) — soundness fix for `reachable_from_exports`

**Reframe (clean-room confirmed): this is a soundness fix, not a precision tweak.** `reachable_from_exports` (FEAT-022), documented as a sound SUPERSET so a consumer may "prune the complement" (SCRY-001; synth#383 / VCR-MEM-001 shadow-stack reservation), could **under-approximate** in the open world. A function reachable only via an escaped funcref — an **exported funcref table** (with no in-module `call_indirect`), an **exported funcref global**, or **passed to an imported function** — was omitted, though the host/import can dispatch it. Pruning it would drop a genuinely reachable frame.

The original "consume `closed_world`" framing was disproved: `closed_world` alone is **insufficient** (an exported funcref table leaks with `closed_world == true`). The correct gate is FEAT-036's funcref-escape predicate `callers_fully_known`.

### Fix
- Collect every **address-taken** function (`ref.func` target in a body / global init / element item, and every element-segment-named function) → `address_taken_funcs`.
- When `callers_fully_known` is **false** (funcrefs can escape), seed all of them as reachability **roots** → sound superset.
- When **true** (closed + escape-free), keep the tight exports+start seed → precision retained (dead funcs still pruned).

### Evidence
- `feat039_exported_table_func_is_reachable`, `feat039_exported_global_funcref_is_reachable`, `feat039_reffunc_to_import_is_reachable` — the omitted functions are now included.
- `feat039_closed_world_dead_func_still_excluded` — control: a dead func in an escape-free module is still pruned.
- 38 scry-sai-core tests green; clippy + fmt clean.

Soundness fix (the set only grows where it was unsound); no API / WIT / frozen-JSON-contract change. Falsification statement in CHANGELOG. Lockstep bump 2.4.0 → 2.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)