### PR TITLE
release: v2.6.0 — observability (FEAT-040/041/042) + shadow-stack soundness (FEAT-043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.6.0] — 2026-06-30
+
+Headline: **"Make the analysis observable" — and harden the shadow-stack bound.**
+Four features land the v2.6.0 release (FEAT-040..043): scry stops emitting ⊤ as
+silence (machine-readable gap records), surfaces the relational octagon
+invariants it already proves, widens loops to syntactic thresholds, and weights
+the worst-case shadow-stack bound by the *resolved* `call_indirect` target set —
+the latter hardened against six independently-found soundness holes.
+
+### Added — FEAT-040 (traces REQ-017, evaluates TE-011) — observability
+
+- **Machine-readable gap records.** `AnalysisResult` carries an explicit
+  `gaps: Vec<Gap>` — `Gap { func_index, pc, op, kind }` with
+  `GapKind ∈ {UnsupportedOp, UnmodeledBranch, UnmodeledMemoryAddress,
+  UnmodeledControlFlow}` — emitted at every site where a fact degrades to ⊤
+  (unsupported op, `BrTable`, non-i32 memory address, havocked region with a
+  write or a call). No conservative site is silently omitted: `scrub_to_top`
+  now *requires* a `Gap`. Library-only field; a scry-viz gaps panel renders the
+  records and an aggregated count beside the SVG.
+
+### Added — FEAT-041 (traces REQ-016) — relational output
+
+- **Relational octagon invariants surfaced.** `ProgramPoint` carries
+  `relational: Vec<RelationalConstraint>` — the difference / sum bounds
+  (`RelKind ∈ {Diff, Sum}`) read off the strong-closed DBM, not just the unary
+  interval projection. Cashes in the v1.4–v1.9 octagon arc. Sound by
+  construction (the constraints are the closed DBM scry already proves).
+
+### Added — FEAT-042 (traces REQ-016) — precision
+
+- **Widening with thresholds.** Loop-header widening snaps to the nearest
+  enclosing syntactic threshold (constants + guard bounds in scope) before
+  falling to ±∞, recovering loop bounds the fixed iterate-then-widen
+  over-approximated to ⊤. Sound (widening still terminates).
+
+### Changed — FEAT-043 (traces REQ-001, G-005, FEAT-021, DD-016 slice-3) — SOUNDNESS
+
+- **Shadow-stack bound weighted by resolved `call_indirect` targets.** For a
+  function scry interprets with no gap, the worst-case longest-path is weighted
+  by the *resolved* table-0 target set (FEAT-006 index-interval resolution)
+  instead of the whole table — a precision win over slice-1/2.
+- **Six soundness holes found by adversarial clean-room and closed** (each could
+  report a finite `Bytes(n)` *below* the true peak — the cardinal error):
+  1. `call_ref` / `return_call_ref` ⇒ `Unknown` (unenumerable callee).
+  2. A havocked region containing a call records a gap, so its callee is not
+     dropped from the resolved set.
+  3. `call_indirect` against a **non-zero table** or a **growable** table-0 ⇒
+     `Unknown`.
+  4. A **runtime `table.set`/`copy`/`fill`/`init`/`grow`** on table 0 demotes it
+     to contents-unknown ⇒ `Unknown` (the static elem shape is only the
+     *initial* contents).
+  5. A **host-writable** table 0 — **imported** or **exported** — demotes to
+     contents-unknown ⇒ `Unknown` (the host can install an arbitrary-frame
+     callee with no `table.*` opcode scry can see).
+  6. A **constant SP decrement inside a loop body** with no per-iteration
+     restore ⇒ `Unbounded` (`detect_frame` was control-flow-insensitive; the
+     live frame is `frame × trip_count` — the alloca-in-a-loop pattern). A
+     per-iteration *balanced* alloc/free keeps the finite single-frame bound.
+
+### Posture
+
+- FEAT-040/041 are library-only `AnalysisResult`/`ProgramPoint` fields; the
+  `scry.wit` interface and the frozen v1 invariant-JSON contract are unchanged.
+  FEAT-043 only ever *raises* a reported bound (`Bytes` → `Unknown`/`Unbounded`)
+  where it was unsound; it never lowers one.
+- **Falsification statement.** scry claims `stack_usage.max_stack_bytes` is a
+  sound UPPER bound on the true peak `__stack_pointer` usage across all reachable
+  functions, and that every gap-degraded analysis site appears as an explicit
+  `Gap`. FALSE if any `.wat` exhibits a runtime peak shadow-stack strictly
+  greater than a finite reported `Bytes(n)`, or reaches ⊤ at a site with no
+  emitted `Gap`. Falsifier for the bound: a module with a host-/loop-/indirect-
+  dispatched callee whose measured peak exceeds the reported finite bound.
+- Three independent cold clean-room agents drove the FEAT-043 fixes; the final
+  pass confirmed the remaining surface sound (probes on direct imports, split
+  prologues, nested/dynamic decrements, recursion-through-indirect).
+
 ## [2.5.0] — 2026-06-27
 
 Headline: **`reachable_from_exports` is now sound in the OPEN world (FEAT-039,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1851,18 +1851,18 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-bits"
-version = "2.5.0"
+version = "2.6.0"
 
 [[package]]
 name = "scry-sai-core"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-interval",
@@ -1876,11 +1876,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "2.5.0"
+version = "2.6.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1889,19 +1889,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "2.5.0"
+version = "2.6.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "2.5.0"
+version = "2.6.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "2.5.0"
+version = "2.6.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "cpp_demangle 0.5.1",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "2.5.0" }
+scry-sai-interval = { path = "../scry-interval", version = "2.6.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,20 +43,20 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "2.5.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "2.5.0" }
+scry-sai-taint = { path = "../scry-taint", version = "2.6.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "2.6.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "2.5.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "2.6.0" }
 
 # Known-bits × interval-guarded congruence reduced product (FEAT-037 / DD-017):
 # an additive bit/alignment/stride companion computed in a straight-line-sound
 # pass, surfaced library-only on `AnalysisResult.bit_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-bits = { path = "../scry-bits", version = "2.5.0" }
+scry-sai-bits = { path = "../scry-bits", version = "2.6.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -566,7 +566,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "2.5.0";
+const SCRY_VERSION: &str = "2.6.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "2.5.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "2.6.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }


### PR DESCRIPTION
Cuts **v2.6.0** ("Make the analysis observable"). Version bump 2.5.0 → 2.6.0
(workspace + path-deps + `SCRY_VERSION`) and the CHANGELOG entry.

`rivet release status v2.6.0` → **✓ Cuttable** (4 artifacts, all accepted).

## Features in this release

- **FEAT-040** — machine-readable `Gap` records; ⊤ is no longer silent.
- **FEAT-041** — relational octagon invariants (Diff/Sum) surfaced on
  `ProgramPoint`.
- **FEAT-042** — widening with syntactic thresholds.
- **FEAT-043** — `call_indirect`-resolved shadow-stack weighting, hardened
  against **six** adversarial-clean-room-found soundness holes (call_ref,
  havocked-region calls, non-zero/growable tables, runtime `table.*` mutation,
  host-writable imported/exported tables, loop-carried SP decrements).

All shipped via #76–#80. FEAT-040/041 are library-only `AnalysisResult`/
`ProgramPoint` fields — `scry.wit` and the frozen v1 invariant-JSON contract
are unchanged. FEAT-043 only ever raises a reported bound where it was unsound.

## Falsification statement

scry claims `stack_usage.max_stack_bytes` is a sound UPPER bound on the true
peak `__stack_pointer` usage, and that every ⊤-degraded site appears as an
explicit `Gap`. FALSE if any `.wat` shows a runtime peak exceeding a finite
reported `Bytes(n)`, or reaches ⊤ with no emitted `Gap`.

Tagging `v2.6.0` on merge triggers crates.io publish + the Pages dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)