### PR TITLE
release: v2.7.0 — prove safety (FEAT-044/045/046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.7.0] — 2026-06-30
+
+Headline: **"Prove safety" — scry's first runtime-error verdicts.** The
+Astrée/Polyspace-style PROVEN-SAFE vs POTENTIAL-TRAP judgement scry entirely
+lacked (MF-006), built on a new cheap relational domain. Three features
+(FEAT-044/045/046).
+
+### Added — FEAT-044 (REQ-014, AC-014) — Pentagons domain
+
+- New zero-dep `#![no_std]` crate **`scry-sai-pentagon`** (Logozzo–Fähndrich):
+  per-variable intervals + a strict-less-than matrix, with the
+  interval-recovering join. The cheap relational layer (`index < length`)
+  behind OOB detection. Admit-free Rocq (`proofs/rocq/Pentagon.v`) for the join,
+  order, and `close` derivations; exhaustive γ-sweep tests.
+- `close()` returns canonical ⊥ on a strict cycle (self-loop after transitive
+  closure) before interval tightening — without that guard a cycle drives the
+  bounds toward the ±∞ sentinels ~2⁶³ steps (found by the soundness gate).
+- Analyzer pass `compute_pentagon_facts` records the `x < bound` guards from
+  `local.get i; (local.get j | const); lt_u/lt_s; if`, library-only on
+  `AnalysisResult.pentagon_facts`.
+
+### Added — FEAT-045 (REQ-014, MF-006) — division/overflow trap detection
+
+- Every `i32/i64.div_s/div_u/rem_s/rem_u` reached by the interval interpreter
+  gets a `DivByZero` verdict; every `div_s` additionally a `SignedOverflow`
+  verdict. `ProvenSafe` only when the divisor interval excludes `0` (resp. the
+  dividend excludes `INT_MIN` OR the divisor excludes `-1`); else
+  `PotentialTrap`. Surfaced on `AnalysisResult.trap_checks`.
+- Modelling div/rem in the interpreter (was the unsupported-op fallback) **stops
+  a division from degrading the whole function to ⊤**.
+- SOUNDNESS (clean-room): per-pass verdicts are reconciled per `(func, pc, kind)`
+  with `PotentialTrap` dominating `ProvenSafe` — a div in a loop body no longer
+  keeps a stale `ProvenSafe` from a pre-widening iterate.
+
+### Added — FEAT-046 (REQ-014, MF-006) — out-of-bounds memory trap detection
+
+- Every load/store gets an `OutOfBounds` verdict. `ProvenSafe` only when the
+  effective address (operand interval + `memarg.offset`) provably fits:
+  `addr ≥ 0` and `addr_hi + width ≤ size_bytes`, where `size_bytes` is the
+  memory's GUARANTEED size (initial pages × 64 KiB) — a sound floor since memory
+  only grows. Reuses the FEAT-045 reconciliation.
+- The 4 modelled ops (`i32/i64.load/store`) get precise verdicts; every other
+  load/store (narrow / float / degraded-state) gets `PotentialTrap` — never
+  silently dropped.
+
+### Posture
+
+- All three are library-only `AnalysisResult` fields (`pentagon_facts`,
+  `trap_checks`); the `scry.wit` interface and the frozen v1 invariant-JSON
+  contract are unchanged. scry-viz gained relational-guard + trap-check panels.
+- Trap verdicts only ever move toward conservatism (`ProvenSafe` only when
+  proven); precision over-approximations (loop-widened divisors/addresses,
+  imported/growable memory, narrow/float widths) are sound `PotentialTrap`s.
+- **Falsification statement.** scry claims a `ProvenSafe` div/rem never traps on
+  div-by-zero (resp. `INT_MIN/-1`), and a `ProvenSafe` load/store never accesses
+  out of bounds, on any concrete run. FALSE if any `.wat` has a `ProvenSafe`
+  operator that traps at runtime. Each feature was driven through an adversarial
+  clean-room (FEAT-044 found a `close` non-termination; FEAT-045 found a
+  loop-carried stale `ProvenSafe`; both fixed with regressions before merge).
+
 ## [2.6.0] — 2026-06-30
 
 Headline: **"Make the analysis observable" — and harden the shadow-stack bound.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1851,18 +1851,18 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-bits"
-version = "2.6.0"
+version = "2.7.0"
 
 [[package]]
 name = "scry-sai-core"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-interval",
@@ -1877,11 +1877,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "2.6.0"
+version = "2.7.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1890,23 +1890,23 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "2.6.0"
+version = "2.7.0"
 
 [[package]]
 name = "scry-sai-pentagon"
-version = "2.6.0"
+version = "2.7.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "2.6.0"
+version = "2.7.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "2.6.0"
+version = "2.7.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "cpp_demangle 0.5.1",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "2.6.0"
+version = "2.7.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "2.6.0" }
+scry-sai-interval = { path = "../scry-interval", version = "2.7.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,27 +43,27 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "2.6.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "2.6.0" }
+scry-sai-taint = { path = "../scry-taint", version = "2.7.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "2.7.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "2.6.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "2.7.0" }
 
 # Known-bits × interval-guarded congruence reduced product (FEAT-037 / DD-017):
 # an additive bit/alignment/stride companion computed in a straight-line-sound
 # pass, surfaced library-only on `AnalysisResult.bit_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-bits = { path = "../scry-bits", version = "2.6.0" }
+scry-sai-bits = { path = "../scry-bits", version = "2.7.0" }
 
 # Pentagons weakly-relational domain (FEAT-044 / AC-014): intervals + strict
 # `x < y` facts, the cheap relational layer behind sound out-of-bounds-trap
 # detection (FEAT-046). An additive guard-recording pass surfaces proven
 # strict relations library-only on `AnalysisResult.pentagon_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-pentagon = { path = "../scry-pentagon", version = "2.6.0" }
+scry-sai-pentagon = { path = "../scry-pentagon", version = "2.7.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -659,7 +659,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "2.6.0";
+const SCRY_VERSION: &str = "2.7.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "2.6.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "2.7.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -42,6 +42,7 @@ const CRATES_TO_PUBLISH: &[(&str, &str)] = &[
     ("scry-taint", "scry-sai-taint"),
     ("scry-octagon", "scry-sai-octagon"),
     ("scry-bits", "scry-sai-bits"),
+    ("scry-pentagon", "scry-sai-pentagon"),
     ("scry-provenance", "scry-sai-provenance"),
     // Depends on the pure leaves — publish before its own consumers.
     ("scry-analyze-core", "scry-sai-core"),


### PR DESCRIPTION
Cuts **v2.7.0** ("prove safety"). Version bump 2.6.0 → 2.7.0 (workspace +
path-deps incl. the new `scry-sai-pentagon` + `SCRY_VERSION`) and the CHANGELOG.

`rivet release status v2.7.0` → **✓ Cuttable** (3 artifacts, all accepted).

## Features (all merged: #82 / #83 / #84)

- **FEAT-044** — Pentagons weakly-relational domain (new crate + admit-free Rocq).
- **FEAT-045** — division-by-zero + signed-overflow trap detection.
- **FEAT-046** — out-of-bounds linear-memory trap detection.

scry's first PROVEN-SAFE vs POTENTIAL-TRAP runtime-error verdicts (the
Astrée/Polyspace headline, MF-006). All library-only `AnalysisResult` fields —
`scry.wit` + frozen v1 JSON contract unchanged.

## Falsification statement

A `ProvenSafe` div/rem never traps on div-by-zero (resp. `INT_MIN/-1`); a
`ProvenSafe` load/store never accesses out of bounds — on any concrete run.
FALSE if any `.wat` has a `ProvenSafe` operator that traps at runtime.

Tagging `v2.7.0` on merge triggers crates.io publish (now incl. scry-sai-pentagon)
+ the Pages dashboard. Each feature passed an adversarial clean-room; two real
soundness defects were found and fixed with regressions before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)