### PR TITLE
release: v3.0.0 — qualifiable + differentiated (FEAT-047/048/049/050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0] — 2026-07-01
+
+Headline: **"Qualifiable + differentiated"** — the strategic release. scry gains
+an IEEE-754 float domain, proves its `i32.add` sound against the OFFICIAL
+wrapping Wasm semantics, becomes the first sound analyzer to model
+Component-Model handle lifetimes, and ships an assessor-facing tool-qualification
+dossier. Four features (FEAT-047/048/049/050).
+
+### Added — FEAT-047 (REQ-015, AC-022) — IEEE-754 float domain
+
+- New zero-dep crate **`scry-sai-float`**: a sound f32/f64 abstraction (interval
+  `[lo,hi]` with `±∞` bounds + a `nan` flag). Round-to-nearest-aware transfers
+  (`add/sub/mul/neg/abs`): `f64` needs no widening (RN monotone + exact
+  endpoints), `f32` snaps outward onto the f32 grid + coerces operands; `±∞`/NaN
+  via a 4-corner hull (incl. interior `0·∞`). Exhaustive γ-sweep at f32+f64;
+  admit-free Rocq `Float.v` (lattice). Straight-line `compute_float_facts` pass →
+  library-only `AnalysisResult.float_facts`. Closes the scope hole where float
+  arithmetic was un-analyzed.
+
+### Added — FEAT-048 (REQ-002, G-005, TE-004) — mechanized soundness vs official semantics
+
+- **`proofs/rocq/WrapAdd.v`** (admit-free): scry's shipped `i32_add` is sound
+  against the OFFICIAL two's-complement wraparound semantics (`(z+2³¹) mod 2³² −
+  2³¹`), INCLUDING the wrap case — closing the REQ-002 "no-wrap only" gap. The
+  widen-to-⊤ branch is sound because ⊤ = all i32; the exact branch because an
+  in-range sum cannot wrap. (Models the semantics WasmCert-Coq mechanizes; a
+  literal WasmCert-Coq import remains deferred, per the dossier's honesty note.)
+- The recorded-false Verus join proof is confirmed repaired to the semantic
+  γ-equality statement (CI-verified).
+
+### Added — FEAT-049 (REQ-003, MF-007) — Component-Model handle-state (the moat)
+
+- New zero-dep crate **`scry-sai-handle`**: an affine handle-state lattice
+  (`Alive`/`Dropped`/`Top`) with drop/use transitions; admit-free Rocq
+  `Handle.v`. `compute_handle_findings` tracks handle locals across the
+  canonical-ABI `[resource-drop]` / `[method]` call sites and reports DEFINITE
+  use-after-drop / double-drop on `AnalysisResult.handle_findings`. Conservative
+  at control flow (no false report). The first sound Component-Model
+  handle-lifetime analysis (MF-007).
+
+### Added — FEAT-050 (G-005, CA-011) — tool-qualification dossier
+
+- **`docs/qualification-dossier-v1.md`**: maps every DO-330 TQL-5 and ISO
+  26262-8 §11 (derives TCL1) objective to a concrete scry artifact — the 17
+  admit-free Rocq proofs, the semantic Verus proof, the MC/DC gate, the live
+  kill-criteria, and the FEAT-040 gap report as the per-artifact scope oracle.
+  Honesty-first: test-/γ-sweep-validated evidence is labelled distinctly from
+  mechanized proof; an adversarial overclaim audit caught and fixed three
+  config-row overstatements before merge.
+
+### Posture
+
+- FEAT-047/049 are library-only `AnalysisResult` fields (`float_facts`,
+  `handle_findings`); `scry.wit` + the frozen v1 invariant-JSON contract are
+  unchanged. Two new crates (`scry-sai-float`, `scry-sai-handle`) join the
+  crates.io `scry-sai-*` namespace.
+- **Falsification statement.** scry claims: every float interval
+  over-approximates the IEEE-754 result (incl. rounding/NaN/±∞); `i32_add` is
+  machine-proven sound vs the official wrapping semantics (`WrapAdd.v`); every
+  reported handle fault is a definite use-after-drop / double-drop; and the
+  qualification dossier cites only artifacts that exist and are admit-free. FALSE
+  if any concrete float op escapes its interval, if `WrapAdd.v` does not hold, if
+  a handle fault is reported for a not-provably-dropped handle, or if any
+  dossier "mechanized" claim lacks a backing admit-free artifact. Each feature
+  passed an adversarial clean-room (FEAT-047's γ-sweep found four real numerical
+  bugs; the dossier audit found three overclaims — all fixed before merge).
+
 ## [2.7.0] — 2026-06-30
 
 Headline: **"Prove safety" — scry's first runtime-error verdicts.** The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "2.7.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1851,18 +1851,18 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "2.7.0"
+version = "3.0.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-bits"
-version = "2.7.0"
+version = "3.0.0"
 
 [[package]]
 name = "scry-sai-core"
-version = "2.7.0"
+version = "3.0.0"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-float",
@@ -1879,19 +1879,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-float"
-version = "2.7.0"
+version = "3.0.0"
 
 [[package]]
 name = "scry-sai-handle"
-version = "2.7.0"
+version = "3.0.0"
 
 [[package]]
 name = "scry-sai-interval"
-version = "2.7.0"
+version = "3.0.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "2.7.0"
+version = "3.0.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1900,23 +1900,23 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "2.7.0"
+version = "3.0.0"
 
 [[package]]
 name = "scry-sai-pentagon"
-version = "2.7.0"
+version = "3.0.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "2.7.0"
+version = "3.0.0"
 
 [[package]]
 name = "scry-sai-taint"
-version = "2.7.0"
+version = "3.0.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "2.7.0"
+version = "3.0.0"
 dependencies = [
  "cpp_demangle 0.5.1",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "2.7.0"
+version = "3.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "2.7.0" }
+scry-sai-interval = { path = "../scry-interval", version = "3.0.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,39 +43,39 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "2.7.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "2.7.0" }
+scry-sai-taint = { path = "../scry-taint", version = "3.0.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "3.0.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "2.7.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "3.0.0" }
 
 # Known-bits × interval-guarded congruence reduced product (FEAT-037 / DD-017):
 # an additive bit/alignment/stride companion computed in a straight-line-sound
 # pass, surfaced library-only on `AnalysisResult.bit_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-bits = { path = "../scry-bits", version = "2.7.0" }
+scry-sai-bits = { path = "../scry-bits", version = "3.0.0" }
 
 # Pentagons weakly-relational domain (FEAT-044 / AC-014): intervals + strict
 # `x < y` facts, the cheap relational layer behind sound out-of-bounds-trap
 # detection (FEAT-046). An additive guard-recording pass surfaces proven
 # strict relations library-only on `AnalysisResult.pentagon_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-pentagon = { path = "../scry-pentagon", version = "2.7.0" }
+scry-sai-pentagon = { path = "../scry-pentagon", version = "3.0.0" }
 
 # IEEE-754 float-interval domain (FEAT-047 / AC-022): sound f32/f64 abstraction
 # with NaN/±inf tracking + round-to-nearest-aware widening. An additive
 # straight-line pass surfaces sound float intervals library-only on
 # `AnalysisResult.float_facts`. Same pure `#![no_std]` dual-compile crate.
-scry-sai-float = { path = "../scry-float", version = "2.7.0" }
+scry-sai-float = { path = "../scry-float", version = "3.0.0" }
 
 # Affine Component-Model handle-state lattice (FEAT-049 / MF-007): tracks
 # own/borrow resource-handle state to flag use-after-drop / double-drop. A
 # straight-line pass over the canonical-ABI `[resource-drop]` call sites
 # surfaces findings library-only on `AnalysisResult.handle_findings`.
-scry-sai-handle = { path = "../scry-handle", version = "2.7.0" }
+scry-sai-handle = { path = "../scry-handle", version = "3.0.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -738,7 +738,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "2.7.0";
+const SCRY_VERSION: &str = "3.0.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "2.7.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "3.0.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }


### PR DESCRIPTION
Cuts **v3.0.0** — the strategic capstone of Roadmap 3.0. Version bump 2.7.0 →
3.0.0 (workspace + path-deps incl. the two new crates `scry-sai-float` /
`scry-sai-handle` + `SCRY_VERSION`) and the CHANGELOG.

`rivet release status v3.0.0` → **✓ Cuttable** (4 artifacts, all accepted).

## Features (all merged: #86 / #87 / #88 / #89)

- **FEAT-047** — IEEE-754 float-interval domain (new crate + Rocq lattice).
- **FEAT-048** — `i32.add` mechanized sound vs the OFFICIAL wrapping semantics
  (`WrapAdd.v`); Verus join proof repaired.
- **FEAT-049** — Component-Model handle-state / use-after-drop (the moat).
- **FEAT-050** — DO-330 TQL-5 / ISO 26262-8 §11 tool-qualification dossier.

## Falsification statement

Every float interval over-approximates the IEEE-754 result; `i32_add` is
machine-proven sound vs the official wrapping semantics; every reported handle
fault is a definite use-after-drop / double-drop; the dossier cites only
admit-free artifacts that exist. FALSE if any of those is violated.

Tagging `v3.0.0` on merge triggers crates.io publish (now incl. `scry-sai-float`
+ `scry-sai-handle`) + the Pages dashboard. Each feature passed an adversarial
clean-room; the strategic honesty-critical work (WrapAdd.v, the dossier) was
mechanically verified / overclaim-audited before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)