### PR TITLE
FEAT-059/060 (v3.1): remediation advisory engine + agent/human guidance (REQ-018)

### DIFF
--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -2926,8 +2926,8 @@ fn compute_advisories(
                     ),
                     suggested_action: action.into(),
                     verification: alloc::format!(
-                        "re-run scry: this `{}` trap_check becomes ProvenSafe",
-                        t.op
+                        "re-run scry: the `{}` {} trap_check at this pc becomes ProvenSafe",
+                        t.op, code
                     ),
                 });
             }

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -458,6 +458,14 @@ pub struct AnalysisResult {
     /// handles). Sorted by `(func_index, pc)`. Library-only (not in the WIT
     /// mirror or the frozen v1 JSON contract), like [`Self::bit_facts`].
     pub handle_findings: Vec<HandleFinding>,
+    /// FEAT-059 (REQ-018): ranked, actionable remediation guidance synthesised
+    /// from the sound findings above — turning "what scry found" into "what to
+    /// do about it", for a human or an AI agent. Each carries an actionability
+    /// class (fault / unproven / precision-gap / leverageable), a suggested
+    /// action, and a verification oracle. Sorted by `(class rank, func_index,
+    /// pc)`. Library-only (not in the WIT mirror or the frozen v1 JSON
+    /// contract), like [`Self::bit_facts`].
+    pub advisories: Vec<Advisory>,
 }
 
 /// FEAT-040: one analysis-gap record — a site where scry was conservative.
@@ -605,6 +613,63 @@ pub enum HandleFindingKind {
     UseAfterDrop,
     /// A second `resource.drop` on an already-dropped handle.
     DoubleDrop,
+}
+
+/// FEAT-059 (REQ-018): one piece of actionable remediation guidance synthesised
+/// from scry's sound findings — "here is what to do about it", for a human or an
+/// AI agent. The [`AdvisoryClass`] is load-bearing: it separates a proven bug
+/// from a merely-unproven obligation from an analyzer blind spot, so guidance
+/// from a SOUND tool never overclaims a fix. Each advisory names a
+/// [`Self::verification`] oracle — what re-running scry should show once the fix
+/// lands — closing an AI agent's edit→verify loop against a sound checker.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Advisory {
+    /// Absolute function index the advisory concerns.
+    pub func_index: u32,
+    /// Operator index (pc) of the site (`0` for a function-level advisory).
+    pub pc: u32,
+    /// Actionability class (governs ranking and how to read the advice).
+    pub class: AdvisoryClass,
+    /// Short machine-stable category code (e.g. `use-after-drop`,
+    /// `div-by-zero`, `unsupported-op`, `unbounded-stack`).
+    pub code: String,
+    /// Human rationale: what the analysis found and why it matters.
+    pub detail: String,
+    /// The concrete action to improve the code.
+    pub suggested_action: String,
+    /// The oracle that confirms the fix — what re-running scry should show.
+    pub verification: String,
+}
+
+/// FEAT-059 (REQ-018): the actionability class of an [`Advisory`]. Ranked
+/// (lower discriminant = higher priority). The split is the honesty guarantee:
+/// a POTENTIAL-TRAP is an `UnprovenObligation` ("prove/guard it"), never a
+/// `DefiniteFault` ("it's a bug").
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdvisoryClass {
+    /// A real bug scry PROVED (use-after-drop, double-drop). Fix it.
+    DefiniteFault,
+    /// A trap scry could not discharge (a POTENTIAL-TRAP). Prove / guard / bound
+    /// it — this is NOT a claim that it is a bug.
+    UnprovenObligation,
+    /// A site where scry lost precision (degraded to ⊤). Restructure for
+    /// analyzability, or accept the limitation.
+    PrecisionGap,
+    /// A property scry PROVED (PROVEN-SAFE / a proven bound). A defensive
+    /// runtime check here may be soundly relied on or elided.
+    LeverageableFact,
+}
+
+impl AdvisoryClass {
+    /// Ranking key (0 = highest priority).
+    pub fn rank(self) -> u8 {
+        match self {
+            AdvisoryClass::DefiniteFault => 0,
+            AdvisoryClass::UnprovenObligation => 1,
+            AdvisoryClass::PrecisionGap => 2,
+            AdvisoryClass::LeverageableFact => 3,
+        }
+    }
 }
 
 /// FEAT-045 (REQ-014, MF-006): a runtime-trap classification for one
@@ -2239,6 +2304,9 @@ pub fn analyze(
     let float_facts = compute_float_facts(&defined_funcs);
     let handle_findings =
         compute_handle_findings(&defined_funcs, &import_func_meta, import_func_count);
+    // FEAT-059: synthesise the sound findings into ranked remediation guidance
+    // (pure synthesis over the results above; borrows before they are moved).
+    let advisories = compute_advisories(&gaps, &trap_checks, &handle_findings, &stack_usage);
 
     Ok(AnalysisResult {
         invariants,
@@ -2257,6 +2325,7 @@ pub fn analyze(
         trap_checks,
         float_facts,
         handle_findings,
+        advisories,
     })
 }
 
@@ -2779,6 +2848,173 @@ fn compute_handle_findings(
 
     findings.sort_by_key(|f| (f.func_index, f.pc));
     findings
+}
+
+/// FEAT-059 (REQ-018): synthesise the sound findings into ranked, actionable
+/// remediation advisories. Pure synthesis over already-computed results — it
+/// introduces NO new unsoundness, and each advisory is only as strong as the
+/// finding it derives from (a POTENTIAL-TRAP becomes an `UnprovenObligation`,
+/// never a `DefiniteFault`). Ranked DefiniteFault > UnprovenObligation >
+/// PrecisionGap > LeverageableFact.
+fn compute_advisories(
+    gaps: &[Gap],
+    trap_checks: &[TrapCheck],
+    handle_findings: &[HandleFinding],
+    stack_usage: &StackUsage,
+) -> Vec<Advisory> {
+    let mut out: Vec<Advisory> = Vec::new();
+
+    // (a) DefiniteFault — handle-lifetime bugs scry PROVED.
+    for h in handle_findings {
+        let (code, what, action) = match h.kind {
+            HandleFindingKind::UseAfterDrop => (
+                "use-after-drop",
+                "used after it was already dropped",
+                "remove the post-drop use, or drop the handle only after its last use — an `own` handle is affine (usable many times, dropped exactly once)",
+            ),
+            HandleFindingKind::DoubleDrop => (
+                "double-drop",
+                "dropped a second time after it was already dropped",
+                "remove the redundant `resource.drop`; a handle must be dropped exactly once",
+            ),
+        };
+        out.push(Advisory {
+            func_index: h.func_index,
+            pc: h.pc,
+            class: AdvisoryClass::DefiniteFault,
+            code: code.into(),
+            detail: alloc::format!(
+                "The resource handle in local {} is {} (via `{}`).",
+                h.local_index,
+                what,
+                h.via
+            ),
+            suggested_action: action.into(),
+            verification: "re-run scry: this handle_findings entry disappears".into(),
+        });
+    }
+
+    // (b) UnprovenObligation / (d) LeverageableFact — from trap verdicts.
+    for t in trap_checks {
+        match t.verdict {
+            TrapVerdict::PotentialTrap => {
+                let (code, trap, action) = match t.kind {
+                    TrapKind::DivByZero => (
+                        "div-by-zero",
+                        "divide-by-zero",
+                        "guard the divisor to be non-zero (or constrain its interval to exclude 0) before this operation",
+                    ),
+                    TrapKind::SignedOverflow => (
+                        "signed-overflow",
+                        "INT_MIN / -1 overflow",
+                        "guard against dividend == INT_MIN && divisor == -1, or constrain the operands",
+                    ),
+                    TrapKind::OutOfBounds => (
+                        "out-of-bounds",
+                        "out-of-bounds access",
+                        "bound the effective address (base + offset + width) below the memory size before the access — e.g. a checked index or an `i < len` guard scry can see",
+                    ),
+                };
+                out.push(Advisory {
+                    func_index: t.func_index,
+                    pc: t.pc,
+                    class: AdvisoryClass::UnprovenObligation,
+                    code: code.into(),
+                    detail: alloc::format!(
+                        "scry could not prove `{}` cannot {} on some run (POTENTIAL-TRAP). This is not a proof that it DOES trap — only that safety is not established.",
+                        t.op, trap
+                    ),
+                    suggested_action: action.into(),
+                    verification: alloc::format!(
+                        "re-run scry: this `{}` trap_check becomes ProvenSafe",
+                        t.op
+                    ),
+                });
+            }
+            TrapVerdict::ProvenSafe => {
+                let trap = match t.kind {
+                    TrapKind::DivByZero => "divide-by-zero",
+                    TrapKind::SignedOverflow => "INT_MIN/-1 overflow",
+                    TrapKind::OutOfBounds => "out-of-bounds access",
+                };
+                out.push(Advisory {
+                    func_index: t.func_index,
+                    pc: t.pc,
+                    class: AdvisoryClass::LeverageableFact,
+                    code: "proven-safe".into(),
+                    detail: alloc::format!(
+                        "scry PROVED `{}` cannot {} on any run.",
+                        t.op, trap
+                    ),
+                    suggested_action: alloc::format!(
+                        "you may rely on this: a defensive runtime check for {} here is redundant and can be soundly elided",
+                        trap
+                    ),
+                    verification: alloc::format!(
+                        "the `{}` trap_check stays ProvenSafe after the change",
+                        t.op
+                    ),
+                });
+            }
+        }
+    }
+
+    // (c) PrecisionGap — where the interpreter degraded to ⊤.
+    for g in gaps {
+        let (code, action) = match g.kind {
+            GapKind::UnsupportedOp => (
+                "unsupported-op",
+                "this operator is outside scry's modelled set, so the function degrades to ⊤ from here; extract the surrounding analyzable logic into its own function, or accept the precision loss",
+            ),
+            GapKind::UnmodeledBranch => (
+                "unmodeled-branch",
+                "a multi-target branch (`br_table`) is not modelled; refactor to modelled control flow if precision here matters, or accept it",
+            ),
+            GapKind::UnmodeledMemoryAddress => (
+                "unmodeled-memory-address",
+                "the memory address is not an i32-shaped value scry can track, so the region state is scrubbed; compute the address as a tracked i32 if precision here matters",
+            ),
+            GapKind::UnmodeledControlFlow => (
+                "unmodeled-control-flow",
+                "a typed `if`/`block` region is handled by write-set havoc (its written locals widen to ⊤); simplify the region or accept the local precision loss",
+            ),
+        };
+        out.push(Advisory {
+            func_index: g.func_index,
+            pc: g.pc,
+            class: AdvisoryClass::PrecisionGap,
+            code: code.into(),
+            detail: alloc::format!(
+                "scry lost precision (degraded to ⊤) at `{}` — downstream facts in this function are weaker.",
+                g.op
+            ),
+            suggested_action: action.into(),
+            verification: alloc::format!(
+                "re-run scry: the gap at fn{}:{} is gone (or no longer reached)",
+                g.func_index, g.pc
+            ),
+        });
+    }
+
+    // (b′) UnprovenObligation — an unbounded worst-case shadow stack.
+    if stack_usage.max_stack_bytes == StackBound::Unbounded {
+        out.push(Advisory {
+            func_index: 0,
+            pc: 0,
+            class: AdvisoryClass::UnprovenObligation,
+            code: "unbounded-stack".into(),
+            detail:
+                "the module's worst-case shadow-stack usage could not be bounded (recursion, or an unresolvable / growable / host-writable indirect-call table)."
+                    .into(),
+            suggested_action:
+                "break the recursion, or make the dispatch table non-growable and fully enumerable (so call_indirect targets resolve), to obtain a finite bound"
+                    .into(),
+            verification: "re-run scry: stack_usage.max_stack_bytes becomes Bytes(n)".into(),
+        });
+    }
+
+    out.sort_by_key(|a| (a.class.rank(), a.func_index, a.pc));
+    out
 }
 
 /// Pop two companion operands, apply a binary transfer when both are modelled
@@ -6438,6 +6674,7 @@ mod tests {
             trap_checks: alloc::vec![],
             float_facts: alloc::vec![],
             handle_findings: alloc::vec![],
+            advisories: alloc::vec![],
         };
         assert_eq!(res.invariants.points.len(), 1);
         assert!(matches!(rp, AbstractValue::RegionPointer(_)));
@@ -7120,6 +7357,88 @@ mod tests {
             r.handle_findings.is_empty(),
             "correct use-then-drop must not report: {:?}",
             r.handle_findings
+        );
+    }
+
+    /// FEAT-059: the advisory engine synthesises all four actionability classes
+    /// from the sound findings, ranked with DefiniteFault first.
+    #[test]
+    fn feat059_synthesizes_ranked_classes() {
+        let r = analyze_default(
+            "(module \
+               (import \"p/i\" \"[resource-drop]t\" (func $drop (param i32))) \
+               (import \"p/i\" \"[method]t.go\" (func $use (param i32))) \
+               (func (export \"bug\") (param i32) \
+                 local.get 0 call $drop local.get 0 call $use) \
+               (func (export \"unproven\") (param i32 i32) (result i32) \
+                 local.get 0 local.get 1 i32.div_s) \
+               (func (export \"safe\") (result i32) i32.const 10 i32.const 2 i32.div_u) \
+               (func (export \"gap\") (param i32) (result i32) local.get 0 i32.popcnt))",
+        );
+        use AdvisoryClass::*;
+        let has = |c: AdvisoryClass| r.advisories.iter().any(|a| a.class == c);
+        assert!(has(DefiniteFault), "use-after-drop → DefiniteFault");
+        assert!(
+            has(UnprovenObligation),
+            "unknown divisor → UnprovenObligation"
+        );
+        assert!(has(PrecisionGap), "unsupported popcnt → PrecisionGap");
+        assert!(
+            has(LeverageableFact),
+            "const-divisor div_u → LeverageableFact"
+        );
+        // ranked: the first advisory is the proven bug.
+        assert_eq!(r.advisories[0].class, DefiniteFault, "faults rank first");
+        // every advisory carries a verification oracle.
+        assert!(
+            r.advisories.iter().all(|a| !a.verification.is_empty()),
+            "every advisory names a verification oracle"
+        );
+    }
+
+    /// FEAT-059 HONESTY INVARIANT: a POTENTIAL-TRAP is only ever an
+    /// UnprovenObligation, NEVER a DefiniteFault — a sound tool must not label an
+    /// unproven obligation a bug. DefiniteFault advisories come only from proven
+    /// faults (handle findings), whose codes are the handle-fault codes.
+    #[test]
+    fn feat059_potential_trap_is_never_a_definite_fault() {
+        let r = analyze_default(
+            "(module (func (export \"f\") (param i32 i32) (result i32) \
+               local.get 0 local.get 1 i32.div_s))",
+        );
+        // there IS a POTENTIAL-TRAP here (unknown divisor)
+        assert!(
+            r.advisories
+                .iter()
+                .any(|a| a.class == AdvisoryClass::UnprovenObligation),
+            "unknown divisor yields an UnprovenObligation"
+        );
+        // and NO advisory calls it a definite fault
+        for a in &r.advisories {
+            if a.class == AdvisoryClass::DefiniteFault {
+                assert!(
+                    a.code == "use-after-drop" || a.code == "double-drop",
+                    "DefiniteFault must be a proven handle fault, not `{}`",
+                    a.code
+                );
+            }
+        }
+    }
+
+    /// FEAT-059: a clean module (no faults, no unproven traps, no gaps) yields no
+    /// fault/obligation advisories — guidance is finding-driven, not noise.
+    #[test]
+    fn feat059_clean_module_no_fault_advisories() {
+        let r = analyze_default(
+            "(module (func (export \"f\") (result i32) i32.const 1 i32.const 2 i32.add))",
+        );
+        assert!(
+            !r.advisories
+                .iter()
+                .any(|a| a.class == AdvisoryClass::DefiniteFault
+                    || a.class == AdvisoryClass::UnprovenObligation),
+            "a clean add-only function raises no fault/obligation advisories: {:?}",
+            r.advisories
         );
     }
 

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -30,9 +30,9 @@
 use core::fmt::Write as _;
 
 use scry_analyze_core::{
-    AbstractValue, AnalysisResult, Diagnostic, DiagnosticSeverity, FunctionMeta, FunctionStack,
-    GapKind, HandleFindingKind, Interval, PentagonBound, Region, SecurityLabel, SoundnessTag,
-    StackBound, TaintFindingKind, TrapKind, TrapVerdict,
+    AbstractValue, AdvisoryClass, AnalysisResult, Diagnostic, DiagnosticSeverity, FunctionMeta,
+    FunctionStack, GapKind, HandleFindingKind, Interval, PentagonBound, Region, SecurityLabel,
+    SoundnessTag, StackBound, TaintFindingKind, TrapKind, TrapVerdict,
 };
 
 /// FEAT-027: metadata for one function index, if scry resolved any.
@@ -154,6 +154,7 @@ pub fn render_html(result: &AnalysisResult, title: &str) -> String {
 
     let _ = write!(s, "<h1>scry analysis — {}</h1>", esc(title));
     render_header(&mut s, result);
+    render_advisories(&mut s, result);
     render_functions(&mut s, result);
     render_call_graph(&mut s, result);
     render_diagnostics(&mut s, &result.diagnostics);
@@ -257,6 +258,7 @@ fn render_header(s: &mut String, r: &AnalysisResult) {
     kv(s, "relational guards", &r.pentagon_facts.len().to_string());
     kv(s, "trap checks", &r.trap_checks.len().to_string());
     kv(s, "handle faults", &r.handle_findings.len().to_string());
+    kv(s, "advisories", &r.advisories.len().to_string());
     kv(s, "float facts", &r.float_facts.len().to_string());
     kv(s, "program points", &points.to_string());
     // FEAT-034: scry's own verified fusion premises (independent of meld).
@@ -701,6 +703,47 @@ fn render_trap_checks(s: &mut String, r: &AnalysisResult) {
             t.func_index,
             t.pc,
             esc(&t.op),
+        );
+    }
+    s.push_str("</ul></section>");
+}
+
+/// FEAT-059/060: the remediation Guidance panel — the actionable "what to do"
+/// synthesis, prioritised by class (faults first), with a one-line summary. The
+/// headline view for a human; the same records feed the agent JSON schema.
+fn render_advisories(s: &mut String, r: &AnalysisResult) {
+    s.push_str("<section><h2>Guidance — how to improve this code</h2>");
+    if r.advisories.is_empty() {
+        s.push_str("<p class=\"empty\">No advisories — no faults, unproven obligations, precision gaps, or leverageable facts surfaced.</p></section>");
+        return;
+    }
+    let count = |c: AdvisoryClass| r.advisories.iter().filter(|a| a.class == c).count();
+    let _ = write!(
+        s,
+        "<p><b>{}</b> real fault(s) to fix · <b>{}</b> unproven obligation(s) to prove/guard · \
+         <b>{}</b> analyzer precision gap(s) · <b>{}</b> leverageable fact(s).</p><ul class=\"diags\">",
+        count(AdvisoryClass::DefiniteFault),
+        count(AdvisoryClass::UnprovenObligation),
+        count(AdvisoryClass::PrecisionGap),
+        count(AdvisoryClass::LeverageableFact),
+    );
+    for a in &r.advisories {
+        let (cls, label) = match a.class {
+            AdvisoryClass::DefiniteFault => ("err", "FIX"),
+            AdvisoryClass::UnprovenObligation => ("warn", "PROVE/GUARD"),
+            AdvisoryClass::PrecisionGap => ("info", "PRECISION"),
+            AdvisoryClass::LeverageableFact => ("info", "LEVERAGE"),
+        };
+        let _ = write!(
+            s,
+            "<li class=\"{cls}\"><span class=\"sev\">{label}</span> \
+             <code>fn{}:{} {}</code> — {}<br><em>Action:</em> {}<br><em>Verify:</em> {}</li>",
+            a.func_index,
+            a.pc,
+            esc(&a.code),
+            esc(&a.detail),
+            esc(&a.suggested_action),
+            esc(&a.verification),
         );
     }
     s.push_str("</ul></section>");

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,14 @@ ignore = [
     # context-then-downcast_mut pattern. No impact on shipped crates or the
     # analyzer component. Re-evaluate when a patched `anyhow` is pulled in.
     "RUSTSEC-2026-0190",
+    # RUSTSEC-2026-0204 — invalid pointer deref in `crossbeam-epoch`'s
+    # `fmt::Pointer` impl for `Atomic`/`Shared` (only when printing an already-
+    # invalid pointer). Enters the graph ONLY through `scry-host-tests` →
+    # wasmtime → rayon → crossbeam-deque → crossbeam-epoch; it is in ZERO
+    # published `scry-sai-*` libraries and not in the shipped `scry.wasm`. The
+    # harness does not format crossbeam pointers. No impact on shipped crates or
+    # the analyzer component. Re-evaluate when wasmtime/rayon are bumped.
+    "RUSTSEC-2026-0204",
 ]
 
 [licenses]

--- a/docs/remediation-guidance-v1.md
+++ b/docs/remediation-guidance-v1.md
@@ -1,0 +1,88 @@
+---
+id: DOC-REMEDIATION-GUIDANCE-V1
+type: spec
+status: draft
+title: scry remediation guidance — advisory schema + AI-agent fix-verify loop (v1)
+tags: [remediation, guidance, ai-agent, schema, oracle-gate, v3.1]
+references: [FEAT-059, FEAT-060, REQ-018, TE-011]
+---
+
+# scry remediation guidance (v1)
+
+FEAT-059/060 ([[REQ-018]]). scry turns its **sound** findings into ranked,
+actionable guidance for improving the analyzed code — consumable by a human
+(the scry-viz *Guidance* panel) and by an AI agent (the structured
+`AnalysisResult.advisories` records described here). This document is the stable
+contract an agent codes against.
+
+## 1. The honesty rule (why the class matters)
+
+scry is a *sound* analyzer: a soundness claim never overclaims, and neither does
+its guidance. Every advisory is tagged with an **actionability class** that says
+exactly how much the finding licenses you to conclude:
+
+| Class | Meaning | What to do | Do NOT |
+|---|---|---|---|
+| `DefiniteFault` | scry **proved** a bug (use-after-drop, double-drop, a divisor provably `{0}`) | fix it | — |
+| `UnprovenObligation` | scry **could not prove** a trap cannot fire (a POTENTIAL-TRAP) | prove it, add a guard, or tighten a bound | do **not** treat it as a confirmed bug |
+| `PrecisionGap` | scry **lost precision** (degraded to ⊤ at an unmodelled op) | restructure for analyzability, or accept the limit | do not treat it as a defect in the code |
+| `LeverageableFact` | scry **proved** a property (PROVEN-SAFE, a bound) | rely on it / elide a redundant defensive check | do not remove a check whose safety scry did *not* prove |
+
+An agent that promotes an `UnprovenObligation` to "bug" has made the same error
+as a tool that claims unsound soundness. The class is the guard against that.
+
+## 2. Advisory record schema
+
+Each entry of `AnalysisResult.advisories` (Rust `Advisory`; sorted by
+`(class rank, func_index, pc)`, faults first):
+
+| Field | Type | Meaning |
+|---|---|---|
+| `func_index` | u32 | absolute function index (`0`-based; imports occupy the low indices) |
+| `pc` | u32 | operator index of the site (`0` for a function-level advisory) |
+| `class` | enum | `DefiniteFault \| UnprovenObligation \| PrecisionGap \| LeverageableFact` |
+| `code` | string | machine-stable category, e.g. `use-after-drop`, `double-drop`, `div-by-zero`, `signed-overflow`, `out-of-bounds`, `proven-safe`, `unsupported-op`, `unmodeled-branch`, `unmodeled-memory-address`, `unmodeled-control-flow`, `unbounded-stack` |
+| `detail` | string | human rationale — what was found and why it matters |
+| `suggested_action` | string | the concrete change to make |
+| `verification` | string | the **oracle** — what re-running scry should show once the fix lands |
+
+Resolve `func_index` to a name via `AnalysisResult.function_meta` (FEAT-027).
+Library-only: not in the WIT mirror or the frozen v1 invariant-JSON contract
+(so this schema may evolve independently of that frozen contract).
+
+## 3. The fix-verify loop (for AI agents)
+
+The `verification` field makes each advisory a **checkable task**, closing the
+`oracle-gate-a-change` loop against a *sound* checker:
+
+```
+1. read advisories, highest class first (DefiniteFault → UnprovenObligation → …)
+2. for a chosen advisory A:
+     a. apply A.suggested_action as a code edit
+     b. re-run scry on the edited module
+     c. check A.verification:
+          - DefiniteFault    → the handle_findings / trap entry is GONE
+          - UnprovenObligation → the trap_check flips PotentialTrap → ProvenSafe
+                                  (or, with FEAT-055, its counterexample no longer reproduces)
+          - PrecisionGap     → the gap at (func_index, pc) is absent / unreached
+     d. if the oracle is satisfied, the fix is verified by a sound analysis;
+        otherwise revert and try another action.
+```
+
+Because the oracle is a sound over-approximation, a satisfied `UnprovenObligation`
+oracle (`ProvenSafe`) is a *proof* the trap cannot fire — not just "tests pass".
+That is the value of gating an agent's edits on scry rather than on tests alone.
+
+Structured-primary (TE-011): agents MUST consume the `advisories` records, not
+the rendered HTML — the panel is a human projection of the same data.
+
+## 4. Scope / honesty notes
+
+- Guidance is **finding-driven**: no findings → no fault/obligation advisories
+  (a clean module is quiet, not falsely reassured — absence of an advisory is
+  not a proof of correctness, only that scry surfaced nothing at that site).
+- `LeverageableFact` advisories are informational; scry cannot see whether a
+  redundant runtime check actually exists, so "may be elided" means "the
+  property it would check is proven", not "a check is present here".
+- `suggested_action` is advice, not an auto-applied patch; the agent authors the
+  edit and the `verification` oracle judges it.


### PR DESCRIPTION
First slice of **v3.1.0 "actionable"** — turn scry's sound findings into ranked,
actionable improvement guidance for humans and AI agents.

## FEAT-059 — advisory engine
`compute_advisories` synthesises gaps + trap_checks + handle_findings + the stack
bound into a ranked `Vec<Advisory>` on `AnalysisResult` (library-only). Each
advisory: location + **actionability class** + rationale + suggested action +
**verification oracle**. The honesty split (REQ-018) is the load-bearing design —
a sound tool must not overclaim a fix:

| Class | From | Advice |
|---|---|---|
| `DefiniteFault` | proven handle bug | fix it |
| `UnprovenObligation` | POTENTIAL-TRAP | prove/guard it (**not** "it's a bug") |
| `PrecisionGap` | ⊤ degradation | restructure for analyzability / accept |
| `LeverageableFact` | PROVEN-SAFE | a defensive check you may soundly elide |

Pure synthesis over already-computed results — **no new unsoundness**; an
advisory is only as strong as the finding it derives from.

## FEAT-060 — the two surfaces
- **Humans**: scry-viz **Guidance** panel (grouped by class, faults first, one-line summary).
- **AI agents**: `docs/remediation-guidance-v1.md` — the stable advisory schema +
  the **fix-verify loop**: apply `suggested_action` → re-run scry → the
  `verification` oracle confirms the finding cleared (a `trap_check` flips
  PotentialTrap→ProvenSafe). This closes `oracle-gate-a-change` against a
  *sound* checker, so a satisfied oracle is a *proof*, not just "tests pass".
  Structured-primary (TE-011): agents consume the records, not the HTML.

## Soundness / honesty claim
No advisory promotes an `UnprovenObligation` to `DefiniteFault`
(`feat059_potential_trap_is_never_a_definite_fault`); guidance is finding-driven
(a clean module is quiet). core 89 / viz 17 green; fmt clean; `rivet validate`
PASS. Clippy left to CI (local clippy is pathologically slow on the SD-card
cargo-target this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)