### PR TITLE
fix(clippy): byte-char-slices lint on scry-sai-provenance

### DIFF
--- a/crates/scry-provenance/src/lib.rs
+++ b/crates/scry-provenance/src/lib.rs
@@ -479,7 +479,7 @@ mod tests {
         assert_eq!(
             decode(&bytes),
             Err(DecodeError::BadMagic {
-                found: [b'S', b'X', b'P', b'V']
+                found: *b"SXPV"
             })
         );
     }


### PR DESCRIPTION
CI's `stable` clippy advanced past 0.1.96 and now applies `clippy::byte_char_slices` as a default `-D warnings` error, turning `main` red on the Clippy job (surfaced by the artifact-only plan PR #96, which touched no code).

Fix: the `BadMagic` test built its expected `[u8; 4]` as `[b'S', b'X', b'P', b'V']`; replaced with the byte-string form `*b"SXPV"` — identical value and type, lint-clean. No behavior change.

Greens `main` ahead of the v3.2 segmentation build loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)