### PR TITLE
release: v3.2.0 — content-sensitive memory (FEAT-058)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.2.0] — 2026-07-11
+
+Headline: **"Content-sensitive memory"** — scry stops treating linear memory as
+one havoc'd ⊤ blob and starts tracking the **values stored at individual
+offsets**. First of the two big-domain-bet releases (v3.2 segmentation → v3.3
+polyhedra), FEAT-058 (REQ-019). Additive / library-only.
+
+### Added — FEAT-058 (REQ-019, DD-018) — linear-memory segmentation
+
+- New published crate **`scry-sai-segment`** (the 11th `scry-sai-*` crate): a
+  pure, Wasm-agnostic content-sensitive memory abstraction — an ordered map from
+  byte offsets to `scry-interval` content, with `top / leq / join / widen /
+  strong+weak store / load` via a boundary-walk range algebra.
+- **Wired into the interpreter** (`scry-analyze-core`): an `i32.store` of a
+  bounded value to a **singleton in-bounds** address is recorded; an `i32.load`
+  at that address returns the tracked interval instead of ⊤ — the struct-field /
+  spill round-trip. The memory abstraction rides the CFG fixpoint in lockstep
+  with the octagon (joined at every merge, widened at every loop header).
+
+### Soundness
+
+- **Type-punning keystone:** every store first invalidates the overlapping byte
+  window `[a−7, a+w)` to ⊤, so no stale or mis-punned cell of any width survives
+  an overlapping write. Any call, degrade, havoc, or non-singleton / other-width
+  / unknown address forgets or ⊤s content.
+- **Mechanized:** `proofs/rocq/Segment.v` (admit-free, `//proofs/rocq:segment_test`)
+  proves the constraint-function join / order / strong+weak store / load γ-sound.
+- **γ-sweep:** the crate exhaustively enumerates concrete memories to falsify the
+  lattice laws + store/load soundness (10 tests).
+- Two independent **clean-room** reviews (the pure domain, and the fixpoint
+  wiring) each **CONFIRMED SOUND** — no under-approximation; every octagon-merge
+  site verified to merge memory in lockstep.
+
+### Scope (honest)
+
+- Content is tracked for **singleton in-bounds i32 (4-byte)** accesses. A
+  loop-range (non-singleton) fill is soundly **invalidated to ⊤**, not recorded —
+  recording range content needs stride/alignment integration (FEAT-037) and is
+  deferred to **FEAT-061**. FEAT-058's original range-fill AC is explicitly marked
+  deferred; v3.2.0 does not claim it.
+
+### Falsification
+
+- An `i32.store; i32.load` at the same singleton in-bounds address must yield the
+  stored interval, not ⊤ (`feat058_store_then_load_round_trips`). An overlapping
+  wider store, or an intervening call, must make the later load ⊤ — a retained
+  `[42,42]` would be **unsound** (`feat058_overlapping_wider_store_invalidates`,
+  `feat058_call_forgets_memory`). `Segment.v` must build with 0 admits / 0 axioms.
+
 ## [3.1.0] — 2026-07-08
 
 Headline: **"Actionable"** — scry stops at *reporting* sound findings and starts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1851,18 +1851,18 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-bits"
-version = "3.1.0"
+version = "3.2.0"
 
 [[package]]
 name = "scry-sai-core"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-float",
@@ -1880,19 +1880,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-float"
-version = "3.1.0"
+version = "3.2.0"
 
 [[package]]
 name = "scry-sai-handle"
-version = "3.1.0"
+version = "3.2.0"
 
 [[package]]
 name = "scry-sai-interval"
-version = "3.1.0"
+version = "3.2.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1901,30 +1901,30 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "3.1.0"
+version = "3.2.0"
 
 [[package]]
 name = "scry-sai-pentagon"
-version = "3.1.0"
+version = "3.2.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "3.1.0"
+version = "3.2.0"
 
 [[package]]
 name = "scry-sai-segment"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "scry-sai-interval",
 ]
 
 [[package]]
 name = "scry-sai-taint"
-version = "3.1.0"
+version = "3.2.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "cpp_demangle 0.5.1",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "3.1.0"
+version = "3.2.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -715,7 +715,7 @@ artifacts:
   - id: FEAT-058
     type: feature
     title: "v3.2 — Linear-memory segmentation (content-sensitive memory)"
-    status: proposed
+    status: accepted
     release: v3.2.0
     description: >
       Give scry's flat linear-memory region per-segment content sensitivity via
@@ -723,33 +723,66 @@ artifacts:
       a memory region becomes an ordered sequence of segments with symbolic
       bounds (from the interval/octagon domain) and a plugged-in content domain
       (intervals first). Closes REQ-019 and lifts the biggest current ⊤-cliff.
-      Planned slices:
+      Slices as shipped (v3.2.0):
         1. New pure crate `scry-sai-segment` — the segmentation functor over
-           intervals: split / merge / join / weak+strong store / load, with
+           intervals: top / leq / join / widen / strong+weak store / load, with
            admit-free Rocq soundness (proofs/rocq/Segment.v) for the core ops
-           and a native γ-sweep falsifier. NOT yet analyzer-wired.
-        2. Wire into the interpreter's memory model: memory.store at a constant
-           /interval offset updates the covering segment (STRONG when the offset
-           is a singleton, WEAK otherwise); memory.load reads it. End-to-end
-           fixture: store a bounded value into a range, then load it — interval
-           preserved, not ⊤.
-        3. Feed segment bounds into OOB-trap classification (FEAT-046) and shrink
-           the FEAT-040 memory-address gaps; live kill-criterion.
-      Soundness discipline: a store through a non-singleton offset is a WEAK
-      update (join into every possibly-touched segment), never strong; unknown /
-      growable / imported memory stays ⊤ (as today). Library-only output
-      initially (AnalysisResult); WIT surfacing deferred to FEAT-054.
+           and a native γ-sweep falsifier. (#99)
+        2. Wired into the interpreter's memory model: `i32.store` to a SINGLETON
+           in-bounds address records the stored interval; `i32.load` at a
+           singleton in-bounds address returns it (the round-trip that lifts the
+           ⊤ cliff). Carried through the CFG fixpoint in lockstep with the
+           octagon. (#100)
+      Soundness discipline (as shipped): content is recorded ONLY for a singleton
+      in-bounds i32 (4-byte) store of a plain i32 value; every store first
+      INVALIDATES the overlapping byte window `[a−7, a+w)` to ⊤ (the type-punning
+      keystone — no stale/mis-punned cell survives an overlapping write); any
+      call, degrade, havoc, or non-singleton/other-width/unknown address forgets
+      or ⊤s content. Library-only output (loads return tighter intervals into the
+      existing result); WIT surfacing deferred to FEAT-054.
+      DEFERRED (not v3.2.0): recording content for a loop-range (non-singleton)
+      fill — needs stride/alignment info to be sound (FEAT-037), tracked as
+      FEAT-061; and feeding segment facts into OOB-trap/gap reduction beyond the
+      precision that already falls out of tighter loaded values.
     tags: [memory, array, segmentation, content-sensitivity, v3.2]
     fields:
       phase: phase-3
       acceptance-criteria:
-        - "Given a loop that fills a memory range with a bounded value, When scry analyzes it, Then the segmentation domain tracks the per-segment content bound instead of widening loaded values to ⊤."
-        - "Given a store through a non-singleton (interval) offset, When scry updates memory, Then it performs a WEAK update over every possibly-touched segment (sound), never a strong overwrite."
-        - "Given proofs/rocq/Segment.v, When built, Then the segmentation core ops (split/merge/join/store/load) are γ-sound with 0 admits / 0 axioms."
+        - "Given an i32.store of a bounded value to a SINGLETON in-bounds address followed by an i32.load at that address, When scry analyzes it, Then the loaded value is the tracked interval (e.g. [42,42]) instead of ⊤. (Shipped v3.2.0: feat058_store_then_load_round_trips.)"
+        - "Given a store whose bytes may overlap a tracked cell (a wider store, a non-singleton/unknown address, or an intervening call), When scry updates memory, Then every possibly-overlapping cell is INVALIDATED to ⊤ — a stale or mis-punned value is never read (the soundness keystone). (Shipped v3.2.0: feat058_overlapping_wider_store_invalidates, feat058_call_forgets_memory.)"
+        - "Given proofs/rocq/Segment.v, When built, Then the segmentation core ops (join/leq/strong+weak store/load) are γ-sound with 0 admits / 0 axioms. (Shipped v3.2.0: //proofs/rocq:segment_test.)"
+        - "DEFERRED (not v3.2.0, tracked FEAT-061): a loop that fills a memory RANGE with a bounded value tracks the per-segment content bound — requires stride/alignment integration (FEAT-037) to record range content soundly."
     links:
       - type: traces-to
         target: REQ-019
       - type: traces-to
         target: REQ-001
+      - type: references-paper
+        target: AC-015
+
+  # ── FEAT-058 follow-up (deferred from v3.2.0) ─────────────────────────
+
+  - id: FEAT-061
+    type: feature
+    title: "Backlog — Alignment-aware range-fill memory content (FEAT-058 follow-up)"
+    status: proposed
+    description: >
+      Record segmentation CONTENT for a loop-range (non-singleton address) fill
+      rather than only invalidating it — closing FEAT-058's deferred AC. Sound
+      range-fill needs stride/alignment: writing a value V to every byte offset in
+      the range is unsound (a mis-aligned load could read V where the real value
+      spans two slots), so the store must know the access is width-aligned to
+      record V only at genuine value bases. scry already computes alignment/stride
+      via the known-bits × congruence domain (FEAT-037); this feeds that into the
+      segmentation weak store so an array-fill loop tracks its per-segment content
+      bound instead of ⊤.
+    tags: [memory, segmentation, alignment, content-sensitivity, backlog]
+    fields:
+      phase: future
+      acceptance-criteria:
+        - "Given a loop that fills an i32 array with a bounded value at a width-aligned stride, When scry analyzes it, Then a load from the filled range returns the per-segment content bound instead of ⊤ — soundly, using the FEAT-037 alignment facts."
+    links:
+      - type: traces-to
+        target: REQ-019
       - type: references-paper
         target: AC-015

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "3.1.0" }
+scry-sai-interval = { path = "../scry-interval", version = "3.2.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,44 +43,44 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "3.1.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "3.1.0" }
+scry-sai-taint = { path = "../scry-taint", version = "3.2.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "3.2.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "3.1.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "3.2.0" }
 
 # Known-bits × interval-guarded congruence reduced product (FEAT-037 / DD-017):
 # an additive bit/alignment/stride companion computed in a straight-line-sound
 # pass, surfaced library-only on `AnalysisResult.bit_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-bits = { path = "../scry-bits", version = "3.1.0" }
+scry-sai-bits = { path = "../scry-bits", version = "3.2.0" }
 
 # Pentagons weakly-relational domain (FEAT-044 / AC-014): intervals + strict
 # `x < y` facts, the cheap relational layer behind sound out-of-bounds-trap
 # detection (FEAT-046). An additive guard-recording pass surfaces proven
 # strict relations library-only on `AnalysisResult.pentagon_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-pentagon = { path = "../scry-pentagon", version = "3.1.0" }
+scry-sai-pentagon = { path = "../scry-pentagon", version = "3.2.0" }
 
 # IEEE-754 float-interval domain (FEAT-047 / AC-022): sound f32/f64 abstraction
 # with NaN/±inf tracking + round-to-nearest-aware widening. An additive
 # straight-line pass surfaces sound float intervals library-only on
 # `AnalysisResult.float_facts`. Same pure `#![no_std]` dual-compile crate.
-scry-sai-float = { path = "../scry-float", version = "3.1.0" }
+scry-sai-float = { path = "../scry-float", version = "3.2.0" }
 
 # Affine Component-Model handle-state lattice (FEAT-049 / MF-007): tracks
 # own/borrow resource-handle state to flag use-after-drop / double-drop. A
 # straight-line pass over the canonical-ABI `[resource-drop]` call sites
 # surfaces findings library-only on `AnalysisResult.handle_findings`.
-scry-sai-handle = { path = "../scry-handle", version = "3.1.0" }
+scry-sai-handle = { path = "../scry-handle", version = "3.2.0" }
 
 # FEAT-058: the linear-memory segmentation domain (content-sensitive memory).
 # The interpreter tracks per-offset interval content for i32 loads/stores
 # instead of degrading every load to ⊤.
-scry-sai-segment = { path = "../scry-segment", version = "3.1.0" }
+scry-sai-segment = { path = "../scry-segment", version = "3.2.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -835,7 +835,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "3.1.0";
+const SCRY_VERSION: &str = "3.2.0";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).

--- a/crates/scry-segment/Cargo.toml
+++ b/crates/scry-segment/Cargo.toml
@@ -20,4 +20,4 @@ path = "src/lib.rs"
 # The per-segment content domain. Path dep carries `version` so `cargo publish`
 # rewrites it to the crates.io coordinate; the version equals the workspace
 # version and is bumped in lockstep.
-scry-sai-interval = { path = "../scry-interval", version = "3.1.0" }
+scry-sai-interval = { path = "../scry-interval", version = "3.2.0" }

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "3.1.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "3.2.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }


### PR DESCRIPTION
Cuts **v3.2.0**, the first of the two big-domain-bet releases (v3.2 segmentation → v3.3 polyhedra). Ships FEAT-058 (slices #99 + #100 already merged): scry tracks per-offset i32 memory content instead of one havoc'd ⊤ blob.

## In this PR (release-prep only)
- **Version bump** 3.1.0 → 3.2.0: workspace + `SCRY_VERSION` + all path-dep versions + `Cargo.lock`. `scry-sai-segment` is the **11th published `scry-sai-*` crate** (already in `scripts/publish.rs`, leaf-after-interval).
- **FEAT-058 → `accepted`**, ACs rewritten to the **shipped** scope, with the loop-range-fill AC explicitly **deferred** to new backlog **FEAT-061** (needs FEAT-037 alignment to be sound). `rivet release status v3.2.0` = **✓ Cuttable**.
- **CHANGELOG** 3.2.0 with falsification statement.

## What shipped (in #99/#100, already on main)
- `scry-sai-segment` pure crate + admit-free `proofs/rocq/Segment.v` + 10-test γ-sweep.
- Interpreter wiring: singleton in-bounds `i32.store`→`i32.load` round-trip; memory rides the fixpoint in lockstep with the octagon.
- **Soundness:** type-punning invalidation keystone; call/degrade/havoc forget content. Two independent clean-room reviews CONFIRMED SOUND.

## Honest scope
Content is tracked for **singleton in-bounds i32** accesses. Loop-range fill is soundly invalidated to ⊤ (not recorded) — deferred to FEAT-061. v3.2.0 does not claim the range-fill AC.

rivet validate PASS; 95 core + 10 segment tests; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)