### PR TITLE
FEAT-062: surface + visualize linear-memory content (FEAT-058 observability)

### DIFF
--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -786,3 +786,34 @@ artifacts:
         target: REQ-019
       - type: references-paper
         target: AC-015
+
+  # ── FEAT-058 observability (make the tracked memory visible) ──────────
+
+  - id: FEAT-062
+    type: feature
+    title: "v3.2.1 — Surface + visualize linear-memory content (FEAT-058 observability)"
+    status: accepted
+    release: v3.2.1
+    description: >
+      Make FEAT-058's tracked memory content OBSERVABLE, not just precision-
+      affecting. Adds a library-only `memory: Vec<MemSegment>` field to each
+      `ProgramPoint` (the segmentation's [lo,hi)→interval cells at that pc,
+      snapshotted like `relational` / `operand_stack`), and a
+      "memory (offset → value)" column in the scry-viz program-points table
+      (a stored i32 renders as `@offset=value`; no tracked content shows ⊤).
+      Read-only surfacing — no new analysis, no soundness risk (a faithful
+      projection of what the fixpoint already computed). Same library-only
+      pattern as FEAT-041 relational output; feeds FEAT-054 (WIT surfacing for
+      non-Rust consumers). Before this, FEAT-058's effect was visible only
+      indirectly via tighter loaded-value intervals.
+    tags: [memory, segmentation, observability, viz, v3.2]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given an i32.store of a bounded value to a singleton in-bounds address, When scry analyzes it, Then the tracked cell is surfaced on a ProgramPoint's `memory` field. (Shipped: feat062_memory_content_surfaced_in_points.)"
+        - "Given that AnalysisResult, When scry-viz renders it, Then the program-points table shows the memory cell (e.g. @16=42) under a memory column. (Shipped: scry-viz renders_memory_content_cell.)"
+    links:
+      - type: traces-to
+        target: REQ-013
+      - type: traces-to
+        target: REQ-019

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -136,6 +136,27 @@ pub struct ProgramPoint {
     /// Library-only (the WIT mirror carries only `locals`); sound (each is a
     /// constraint the octagon maintains).
     pub relational: Vec<RelationalConstraint>,
+    /// FEAT-062 (FEAT-058 observability): the tracked linear-memory CONTENT at
+    /// this pc — the segmentation's `[lo, hi) → interval` cells, in ascending
+    /// offset order. Makes the content-sensitive memory (FEAT-058) OBSERVABLE
+    /// (scry-viz renders it; before this it only affected loaded-value
+    /// intervals). Empty = ⊤ (no content tracked). Library-only (WIT mirror
+    /// carries only `locals`); sound (each cell is a constraint the analysis
+    /// maintains — every concrete run's memory respects it).
+    pub memory: Vec<MemSegment>,
+}
+
+/// FEAT-062: a surfaced linear-memory content cell at a program point — every
+/// offset in `[lo, hi)` is constrained to `value`. Mirrors the internal
+/// `scry_segment::Seg`; offsets outside all cells are unconstrained (⊤).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MemSegment {
+    /// Inclusive low byte offset.
+    pub lo: i64,
+    /// Exclusive high byte offset (`lo < hi`).
+    pub hi: i64,
+    /// Interval every offset in `[lo, hi)` is constrained to.
+    pub value: Interval,
 }
 
 /// FEAT-041: a surfaced relational octagon constraint between two distinct
@@ -1203,6 +1224,19 @@ fn snapshot_relational(octagon: &Octagon) -> Vec<RelationalConstraint> {
                 scry_octagon::RelKind::Sum => RelKind::Sum,
             },
             bound: r.bound,
+        })
+        .collect()
+}
+
+/// FEAT-062: snapshot the tracked linear-memory content (the segmentation's
+/// cells) as a list of `MemSegment` records, in ascending offset order.
+fn snapshot_memory(mem: &Segmentation) -> Vec<MemSegment> {
+    mem.segments()
+        .iter()
+        .map(|s| MemSegment {
+            lo: s.lo,
+            hi: s.hi,
+            value: s.val,
         })
         .collect()
 }
@@ -3738,6 +3772,7 @@ impl Interp<'_, '_> {
                         locals: snapshot_locals(&reduce_locals(&ctx.locals, &ctx.octagon)),
                         operand_stack: snapshot_stack(&ctx.operand_stack),
                         relational: snapshot_relational(&ctx.octagon),
+                        memory: snapshot_memory(&ctx.mem),
                     });
                 }
                 pc = next;
@@ -3759,6 +3794,7 @@ impl Interp<'_, '_> {
                         locals: snapshot_locals(&reduce_locals(&ctx.locals, &ctx.octagon)),
                         operand_stack: snapshot_stack(&ctx.operand_stack),
                         relational: snapshot_relational(&ctx.octagon),
+                        memory: snapshot_memory(&ctx.mem),
                     });
                 }
                 pc = next;
@@ -3829,6 +3865,7 @@ impl Interp<'_, '_> {
                     locals: snapshot_locals(&reduce_locals(&ctx.locals, &ctx.octagon)),
                     operand_stack: snapshot_stack(&ctx.operand_stack),
                     relational: snapshot_relational(&ctx.octagon),
+                    memory: snapshot_memory(&ctx.mem),
                 });
             }
             if stop {
@@ -4259,6 +4296,8 @@ impl Interp<'_, '_> {
                 // were soundly widened to ⊤ above.
                 operand_stack: Vec::new(),
                 relational: snapshot_relational(&ctx.octagon),
+                // havoc reset ctx.mem to ⊤ above, so this is empty (accurate).
+                memory: snapshot_memory(&ctx.mem),
             });
         }
     }
@@ -6828,6 +6867,7 @@ mod tests {
                 }],
                 operand_stack: alloc::vec![av.clone()],
                 relational: alloc::vec![],
+                memory: alloc::vec![],
             }],
         };
         let res = AnalysisResult {
@@ -8666,6 +8706,28 @@ mod tests {
         assert!(
             !local0_is_const(&r, 42),
             "a call must forget memory content; stale [42,42] is UNSOUND; points={:?}",
+            r.invariants.points
+        );
+    }
+
+    /// FEAT-062 — the tracked memory content is SURFACED on the program points
+    /// (so scry-viz can render it). A `i32.store 42 @16` records the cell
+    /// [16,17) → [42,42]; it must appear in `point.memory`.
+    #[test]
+    fn feat062_memory_content_surfaced_in_points() {
+        let r = analyze_default(
+            "(module (memory 1) (func (result i32) (local i32) \
+               i32.const 16 i32.const 42 i32.store \
+               i32.const 16 i32.load local.set 0 local.get 0))",
+        );
+        let found = r.invariants.points.iter().any(|p| {
+            p.memory
+                .iter()
+                .any(|m| m.lo == 16 && m.hi == 17 && m.value.lo == 42 && m.value.hi == 42)
+        });
+        assert!(
+            found,
+            "the [16,17)→[42,42] memory cell must be surfaced on a point; points={:?}",
             r.invariants.points
         );
     }

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -1014,7 +1014,8 @@ fn render_points(s: &mut String, r: &AnalysisResult) {
         );
         s.push_str(
             "<table><thead><tr><th>pc</th><th>locals</th>\
-             <th>operand stack (bottom → top)</th></tr></thead><tbody>",
+             <th>operand stack (bottom → top)</th>\
+             <th>memory (offset → value)</th></tr></thead><tbody>",
         );
         for p in points.iter().filter(|p| p.func_index == idx) {
             let locals = if p.locals.is_empty() {
@@ -1038,12 +1039,34 @@ fn render_points(s: &mut String, r: &AnalysisResult) {
                     .collect::<Vec<_>>()
                     .join(" · ")
             };
+            // FEAT-062: the tracked linear-memory content (FEAT-058). Empty is
+            // shown as "(⊤)" — the analyzer's honest "no content tracked here",
+            // not a claim that memory is empty. A single-byte cell [o,o+1) (the
+            // strong-store case) renders as "@o"; a wider cell as "[lo, hi)".
+            let mem = if p.memory.is_empty() {
+                "<span class=\"empty\">(⊤)</span>".to_string()
+            } else {
+                p.memory
+                    .iter()
+                    .map(|m| {
+                        let loc = if m.hi == m.lo + 1 {
+                            format!("@{}", m.lo)
+                        } else {
+                            format!("[{}, {})", m.lo, m.hi)
+                        };
+                        format!("{loc}={}", interval(&m.value))
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" · ")
+            };
             let _ = write!(
                 s,
-                "<tr><td>{}</td><td><code>{}</code></td><td><code>{}</code></td></tr>",
+                "<tr><td>{}</td><td><code>{}</code></td><td><code>{}</code></td>\
+                 <td><code>{}</code></td></tr>",
                 p.pc,
                 esc(&locals),
                 stack,
+                mem,
             );
         }
         s.push_str("</tbody></table>");
@@ -1244,6 +1267,27 @@ mod tests {
     fn analyze_wat(src: &str) -> AnalysisResult {
         let bytes = wat::parse_str(src).expect("assemble wat");
         analyze(bytes, AnalysisConfig::default()).expect("analyze")
+    }
+
+    #[test]
+    fn renders_memory_content_cell() {
+        // FEAT-062: the tracked memory content (FEAT-058) must be visible in the
+        // rendered page — a store of 42 @16 then load surfaces the [16,17)→42
+        // cell, rendered "@16=42" under the "memory" column.
+        let r = analyze_wat(
+            "(module (memory 1) (func (export \"run\") (result i32) (local i32) \
+             i32.const 16 i32.const 42 i32.store \
+             i32.const 16 i32.load local.set 0 local.get 0))",
+        );
+        let html = render_html(&r, "mem");
+        assert!(
+            html.contains("memory (offset → value)"),
+            "the program-points table must carry a memory column"
+        );
+        assert!(
+            html.contains("@16=42"),
+            "the tracked cell [16,17)→42 must render as @16=42; html omitted it"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Makes FEAT-058's tracked memory content **visible in the dashboard** — answering "is the new stuff visible in our UI?". Before this, segmentation only showed up *indirectly* (tighter loaded-value intervals); the memory map itself was internal to the fixpoint.

## Changes
- **scry-analyze-core**: a library-only `memory: Vec<MemSegment>` field on each `ProgramPoint` — the segmentation's `[lo,hi)→interval` cells at that pc, snapshotted at every emission site (same pattern as `relational`/`operand_stack`). New public `MemSegment` type. WIT / frozen-JSON mirror unchanged.
- **scry-viz**: a new **"memory (offset → value)"** column in the program-points table. A stored i32 renders as `@offset=value`; no tracked content shows ⊤.

## Soundness
Read-only surfacing — a faithful projection of what the fixpoint already computed. No new analysis, no new claims, no soundness risk.

## Tests
- `feat062_memory_content_surfaced_in_points` (core — the `[16,17)→[42,42]` cell is surfaced).
- `renders_memory_content_cell` (viz — the page shows `@16=42` under a memory column).
- 96 core + 18 viz pass; clippy `-D warnings` + fmt clean; rivet validate PASS.

rivet **FEAT-062** `accepted` (release v3.2.1; traces REQ-013 visualization + REQ-019 memory). A v3.2.1 cut will follow (redeploys the Pages dashboard with the panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)