### PR TITLE
release: v3.2.1 — surface + visualize memory content (FEAT-062)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.2.1] — 2026-07-11
+
+Headline: **make the new memory tracking visible.** FEAT-062 surfaces FEAT-058's
+content-sensitive memory into the analysis output and the scry-viz dashboard —
+before this, segmentation was only visible *indirectly* via tighter loaded-value
+intervals. Additive / library-only observability; no analysis change.
+
+### Added — FEAT-062 (REQ-013, REQ-019) — surface + visualize memory content
+
+- `ProgramPoint.memory: Vec<MemSegment>` (new public `MemSegment` type): the
+  segmentation's `[lo,hi) → interval` cells at each pc, snapshotted like
+  `relational` / `operand_stack`. Library-only (WIT / frozen-JSON mirror
+  unchanged); feeds FEAT-054 (WIT surfacing for non-Rust consumers).
+- **scry-viz**: a new **"memory (offset → value)"** column in the program-points
+  table — a stored i32 renders as `@offset=value`; no tracked content shows ⊤.
+  The GitHub Pages dashboard now shows tracked linear-memory content.
+
+### Soundness
+
+- Read-only surfacing — a faithful projection of what the FEAT-058 fixpoint
+  already computes. No new analysis, no new claims, no soundness risk. Verified:
+  `feat062_memory_content_surfaced_in_points` (core), `renders_memory_content_cell`
+  (viz).
+
 ## [3.2.0] — 2026-07-11
 
 Headline: **"Content-sensitive memory"** — scry stops treating linear memory as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1851,18 +1851,18 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-bits"
-version = "3.2.0"
+version = "3.2.1"
 
 [[package]]
 name = "scry-sai-core"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-float",
@@ -1880,19 +1880,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-float"
-version = "3.2.0"
+version = "3.2.1"
 
 [[package]]
 name = "scry-sai-handle"
-version = "3.2.0"
+version = "3.2.1"
 
 [[package]]
 name = "scry-sai-interval"
-version = "3.2.0"
+version = "3.2.1"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1901,30 +1901,30 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "3.2.0"
+version = "3.2.1"
 
 [[package]]
 name = "scry-sai-pentagon"
-version = "3.2.0"
+version = "3.2.1"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "3.2.0"
+version = "3.2.1"
 
 [[package]]
 name = "scry-sai-segment"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "scry-sai-interval",
 ]
 
 [[package]]
 name = "scry-sai-taint"
-version = "3.2.0"
+version = "3.2.1"
 
 [[package]]
 name = "scry-sai-viz"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "cpp_demangle 0.5.1",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "3.2.0"
+version = "3.2.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "3.2.0" }
+scry-sai-interval = { path = "../scry-interval", version = "3.2.1" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,44 +43,44 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "3.2.0" }
-scry-sai-provenance = { path = "../scry-provenance", version = "3.2.0" }
+scry-sai-taint = { path = "../scry-taint", version = "3.2.1" }
+scry-sai-provenance = { path = "../scry-provenance", version = "3.2.1" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "3.2.0" }
+scry-sai-octagon = { path = "../scry-octagon", version = "3.2.1" }
 
 # Known-bits × interval-guarded congruence reduced product (FEAT-037 / DD-017):
 # an additive bit/alignment/stride companion computed in a straight-line-sound
 # pass, surfaced library-only on `AnalysisResult.bit_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-bits = { path = "../scry-bits", version = "3.2.0" }
+scry-sai-bits = { path = "../scry-bits", version = "3.2.1" }
 
 # Pentagons weakly-relational domain (FEAT-044 / AC-014): intervals + strict
 # `x < y` facts, the cheap relational layer behind sound out-of-bounds-trap
 # detection (FEAT-046). An additive guard-recording pass surfaces proven
 # strict relations library-only on `AnalysisResult.pentagon_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-pentagon = { path = "../scry-pentagon", version = "3.2.0" }
+scry-sai-pentagon = { path = "../scry-pentagon", version = "3.2.1" }
 
 # IEEE-754 float-interval domain (FEAT-047 / AC-022): sound f32/f64 abstraction
 # with NaN/±inf tracking + round-to-nearest-aware widening. An additive
 # straight-line pass surfaces sound float intervals library-only on
 # `AnalysisResult.float_facts`. Same pure `#![no_std]` dual-compile crate.
-scry-sai-float = { path = "../scry-float", version = "3.2.0" }
+scry-sai-float = { path = "../scry-float", version = "3.2.1" }
 
 # Affine Component-Model handle-state lattice (FEAT-049 / MF-007): tracks
 # own/borrow resource-handle state to flag use-after-drop / double-drop. A
 # straight-line pass over the canonical-ABI `[resource-drop]` call sites
 # surfaces findings library-only on `AnalysisResult.handle_findings`.
-scry-sai-handle = { path = "../scry-handle", version = "3.2.0" }
+scry-sai-handle = { path = "../scry-handle", version = "3.2.1" }
 
 # FEAT-058: the linear-memory segmentation domain (content-sensitive memory).
 # The interpreter tracks per-offset interval content for i32 loads/stores
 # instead of degrading every load to ⊤.
-scry-sai-segment = { path = "../scry-segment", version = "3.2.0" }
+scry-sai-segment = { path = "../scry-segment", version = "3.2.1" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -856,7 +856,7 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "3.2.0";
+const SCRY_VERSION: &str = "3.2.1";
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).

--- a/crates/scry-segment/Cargo.toml
+++ b/crates/scry-segment/Cargo.toml
@@ -20,4 +20,4 @@ path = "src/lib.rs"
 # The per-segment content domain. Path dep carries `version` so `cargo publish`
 # rewrites it to the crates.io coordinate; the version equals the workspace
 # version and is bumped in lockstep.
-scry-sai-interval = { path = "../scry-interval", version = "3.2.0" }
+scry-sai-interval = { path = "../scry-interval", version = "3.2.1" }

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "3.2.0" }
+scry-sai-core = { path = "../scry-analyze-core", version = "3.2.1" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }


### PR DESCRIPTION
Patch release: makes FEAT-058's content-sensitive memory **visible** — in the `AnalysisResult` and on the GitHub Pages dashboard.

- Version bump 3.2.0 → 3.2.1 (workspace + `SCRY_VERSION` + path-deps + `Cargo.lock`).
- FEAT-062 (merged in #102): `ProgramPoint.memory` field + scry-viz "memory (offset → value)" column.
- CHANGELOG 3.2.1.

Tagging v3.2.1 republishes the crates and **redeploys the Pages dashboard** so the memory panel is live. `rivet release status v3.2.1` = ✓ Cuttable; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)