### PR TITLE
v3.3 replan + FEAT-068/072/073: identity made visible, citable, and measured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,3 +347,38 @@ jobs:
           path: ${{ github.workspace }}/scry-self-analysis.html
           if-no-files-found: error
           retention-days: 14
+      # FEAT-073 self-adjudication harness — OBSERVATION MODE.
+      #
+      # FEAT-025 (above) dogfoods scry on its own module at ONE commit. This
+      # extends the same instrument across TIME: build scry_mcdc.wasm at the
+      # last few commits and compare consecutive pairs BY STABLE OBLIGATION
+      # IDENTITY (FEAT-064/072).
+      #
+      # It DOES NOT GATE, and that is deliberate, not an oversight (DD-022).
+      # The adjudicator this would drive was refuted in review (scry#122): an
+      # adjudicator that can wrongly report a fix is worse than none, because
+      # the cheapest way for an agent to satisfy it is to delete the code. So
+      # the harness reports and never judges — `continue-on-error` is belt to
+      # the script's braces, which exits 0 unconditionally by construction.
+      #
+      # This already paid for itself: its first run surfaced scry#123 (43-45%
+      # of function identities churn per build via the Rust symbol
+      # disambiguator), a defect no fixture suite could have found because it
+      # lives in the toolchain's output rather than in scry's logic.
+      #
+      # It graduates to a gate only when REQ-021 closes.
+      - name: Self-adjudication harness (FEAT-073, observation only — never gates)
+        continue-on-error: true
+        run: |
+          git fetch --deepen=5 origin "$GITHUB_SHA" 2>/dev/null || true
+          bash scripts/self-history.sh 3 "${{ github.workspace }}/self-history"
+      - name: Upload self-history observation
+        uses: actions/upload-artifact@v4
+        with:
+          name: scry-self-history
+          # if-no-files-found: warn — an observation that produced nothing is a
+          # fact to report, not a build failure. `error` here would turn the
+          # non-gating harness into a gate through the back door.
+          if-no-files-found: warn
+          path: ${{ github.workspace }}/self-history
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -411,6 +411,35 @@ jobs:
             -o "$GITHUB_WORKSPACE/dist/self-analysis.html" \
             --title "scry ${VERSION} — self-analysis (scry_mcdc.wasm)"
 
+      # FEAT-072: a release-over-release delta, keyed on stable obligation
+      # identity. Answers "what actually moved since the last release?" — the
+      # question the single-snapshot dashboard has never been able to answer,
+      # because (func_index, pc) shifts on every edit.
+      #
+      # It reports what CHANGED and asserts no verdict (scry#122 / DD-022); the
+      # page carries that constraint in its own copy and a unit test greps for
+      # it. `continue-on-error` because a missing or unbuildable previous tag
+      # is a fact about the history, not a reason to block a release — the
+      # landing page links this view only when it exists.
+      - name: Render release delta vs the previous tag (FEAT-072)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          PREV="$(git tag --list 'v*' --sort=-v:refname | grep -v "^${VERSION}$" | head -1)"
+          if [[ -z "$PREV" ]]; then
+            echo "no previous tag — skipping the delta view (first release)"; exit 0
+          fi
+          echo "delta: $PREV -> $VERSION"
+          WT="$(mktemp -d)/prev"
+          git worktree add --detach -q "$WT" "$PREV" || exit 0
+          ( cd "$WT/crates/scry-mcdc" && cargo build --release --target wasm32-wasip1 -q ) || exit 0
+          cargo run --release -p scry-sai-viz -- delta \
+            "$WT/crates/scry-mcdc/target/wasm32-wasip1/release/scry_mcdc.wasm" \
+            crates/scry-mcdc/target/wasm32-wasip1/release/scry_mcdc.wasm \
+            -o "$GITHUB_WORKSPACE/dist/delta.html" \
+            --title "${PREV} → ${VERSION} (by stable obligation identity)"
+          git worktree remove --force "$WT" 2>/dev/null || true
+
       - name: Build landing page (scry-viz index)
         run: |
           set -euo pipefail

--- a/artifacts/design.yaml
+++ b/artifacts/design.yaml
@@ -843,9 +843,19 @@ artifacts:
         before implementing any of them.
         (2) Enforce observation mode STRUCTURALLY — the harness cannot return
         non-zero — rather than by a comment asking readers not to gate on it.
-        (3) Publish the ADJUDICABLE FRACTION ("of M obligations, K adjudicable,
-        N uncertain") and suppress the discharge count entirely while scry#122
-        is open, enforced by a test that greps the rendered page.
+        (3) Publish the ALIAS-FREE FRACTION ("of M shared sites, K provably
+        alias-free, the rest not excluded") and suppress the discharge count
+        entirely while scry#122 is open, enforced by a test that greps the
+        rendered page.
+        CORRECTED IN DRAFTING: this decision first said "K adjudicable", which
+        over-claims — nothing here certifies that a site can be adjudicated.
+        What IS certifiable is narrower and provable: aliasing requires a
+        deleted same-kind sibling to inherit an ordinal from
+        (`ObligationId.v: survivor_inherits_deleted_identity`), so an ordinal
+        domain holding exactly ONE member in BOTH runs has nothing to inherit
+        from. Note this is strictly STRONGER than DD-021's refuted rule — a
+        singleton domain rules aliasing out, whereas an unchanged domain does
+        not — and it is the wording the code implements.
       rationale: >
         ALTERNATIVE REJECTED for (1) — fix all nine items, then dogfood.
         Nine fixes guessed at in the dark is exactly how the first

--- a/artifacts/design.yaml
+++ b/artifacts/design.yaml
@@ -664,3 +664,229 @@ artifacts:
         target: FEAT-064
       - type: traces-to
         target: FEAT-065
+
+  - id: DD-021
+    type: design-decision
+    title: "v3.3 — Adjudicating a NON-INJECTIVE identity: three keys, and `discharged` as a certainty claim"
+    status: proposed
+    tags: [ai-agent, fix-verify-loop, oracle, conservatism, v3.3]
+    description: >
+      How FEAT-065 compares two runs given that FEAT-064's identity is provably
+      NOT injective across arbitrary edits. Two findings forced this to be a
+      decision rather than an implementation detail.
+      (1) `proofs/rocq/ObligationId.v` PROVES the aliasing hazard
+      (`survivor_inherits_deleted_identity`): delete the first of two same-kind
+      operators in a region and the survivor's ordinal — hence its identity —
+      becomes exactly the deleted site's. A naive diff-by-identity can therefore
+      report a FALSE `discharged`: site A is an open obligation, site B at the
+      same kind is PROVEN-SAFE, A is deleted, B inherits A's identity, and A's
+      identity now resolves to a proven-safe advisory although A was never fixed.
+      (2) The advisory CODE is a required component of the identity (clean-room:
+      one `i32.div_s` raises both div-by-zero and signed-overflow at one pc, so
+      the site alone does not discriminate). But fixing an obligation CHANGES its
+      code — `div-by-zero` becomes `proven-safe` — so the full identity is
+      unstable across exactly the transition the adjudicator exists to detect.
+      Matching on it alone would render every genuine discharge as
+      "one identity vanished, an unrelated one appeared".
+    fields:
+      decision: >
+        Emit THREE keys per advisory, each with one job:
+          * `obligation_id`  = hash(func_ident, path, kind, ordinal, CODE) —
+            globally unique per obligation. What a consumer stores and cites.
+          * `site_key`       = hash(func_ident, path, kind, ordinal) — identifies
+            the SITE, stable across a code/class change. This is what FEAT-065
+            MATCHES ON, so a div-by-zero becoming proven-safe is recognised as
+            the same site changing state rather than two unrelated events.
+          * `group_key`      = hash(func_ident, path, kind) — the ORDINAL DOMAIN.
+            Its membership is what aliasing perturbs, so it is the conservatism
+            signal.
+        Adjudication outcomes: `discharged`, `still-open`, `regressed`, `moved`,
+        `removed-with-code`, `uncertain`.
+        `discharged` is a CERTAINTY CLAIM and requires all of: the site_key was an
+        open obligation before; it is proven-safe (or raises no obligation) after;
+        AND its `group_key`'s site_key SET is unchanged between the two runs.
+        If that set changed, the verdict is `uncertain` — never `discharged`.
+        `removed-with-code` (the site no longer exists) is a distinct outcome and
+        must never be reported as `discharged`.
+      rationale: >
+        The adjudicator inherits the analyzer's discipline one layer up: scry
+        claims PROVEN-SAFE only when the abstract state rules the trap out, and
+        FEAT-065 claims `discharged` only when identity cannot have aliased.
+        Over-claiming a discharge is the same class of error as an unsound
+        analysis, and it is the error an agent optimising against the verdict
+        would exploit fastest — an agent rewarded for `discharged` learns to
+        DELETE code, which is why `removed-with-code` is kept strictly separate.
+        RETRACTED 2026-08-11 by adversarial review — this decision originally
+        justified the group-set check by asserting that "aliasing by deletion or
+        insertion NECESSARILY changes the ordinal domain's membership". THAT IS
+        FALSE, and it was the sentence the whole conservatism rule rested on. A
+        deletion PAIRED WITH a same-kind insertion in the same region leaves the
+        group's site_key set byte-identical, so the check passes and a FALSE
+        `discharged` is produced — the delete-instead-of-fix reward hack this
+        rule exists to prevent. The group-set check is therefore a NECESSARY but
+        NOT SUFFICIENT condition, and on its own it does not make `discharged`
+        a certainty claim. Sound matching needs CONTENT corroboration (hashing
+        the operator's local context so a replaced operator cannot inherit a
+        predecessor's identity) rather than a positional ordinal plus a
+        population check. See the limitations field; the implementation is held
+        in draft until this is resolved.
+      limitations: >
+        FOUND BY ADVERSARIAL REVIEW 2026-08-11 (all reproduced; the
+        implementation is in draft, nothing shipped):
+        (1) CARDINALITY-PRESERVING DELETION defeats the group-set check — delete
+            the open operator and append a same-kind safe one, and the site set
+            is unchanged, yielding a false `discharged`. This falsifies the
+            rationale's central claim (see above).
+        (2) `body_shape_hash` is the WHOLE function identity in the no-name /
+            no-export case, so two structurally identical functions share
+            site/group keys — deleting a whole function carrying an obligation
+            reports `discharged`. Conversely ANY opcode edit in such a function
+            moves every key in it, so for stripped modules `discharged` is
+            unreachable for the canonical fix shape (insert a guard / replace a
+            `local.get` with a constant). Mitigation direction: never claim
+            `discharged` when the function identity came from the shape-hash
+            fallback — degrade to `uncertain`.
+        (3) OBLIGATION LAUNDERING: wrapping the site in a typed `block`/`if`
+            routes it through `havoc_region`, which emits no trap check, no gap
+            and no advisory when the write set is empty and the region contains
+            no call — so a LIVE obligation disappears and reads as
+            `removed-with-code`. Root cause is a pre-existing FEAT-040/046
+            reporting hole, tracked separately; the adjudicator must treat
+            "absent from a function that degraded or gained a havoc region" as
+            `uncertain`.
+        (4) `regressed` is FABRICATED on a byte-identical module: `site_key`
+            excludes the code, so an open div-by-zero and a proven
+            signed-overflow at one `i32.div_s` share a site key, putting it in
+            the proven set. Self-comparison returns contradictory `still-open`
+            and `regressed` verdicts under one id with an invented before-code.
+            The proven-safe advisory does not record WHICH trap kind it proves,
+            which is the underlying data gap.
+        (5) NEW obligations produce NO verdict at all (only sites that
+            previously carried a proven fact are checked), so a fault introduced
+            where nothing was flagged before passes the gate clean. This is the
+            blindest direction for an autonomous agent.
+        (6) `obligation_id` is not unique, against this decision's own claim: two
+            ProvenSafe trap kinds at one pc both use code `proven-safe`, and the
+            shape-hash collision duplicates ids across functions.
+        PRE-EXISTING RESIDUAL, disclosed from the start: a pure REORDERING of two
+        same-kind operators within one region preserves the group's site_key set
+        while swapping which site each key denotes (each op takes the other's
+        ordinal). The group-set check cannot see it, so that edit shape can still
+        mis-attribute a verdict. It is an unusual edit, its consequence is a
+        wrong verdict rather than an unsound analysis, and closing it would need
+        content corroboration beyond the key (e.g. hashing the operator's local
+        context) — deferred, and named here so a consumer is not surprised.
+        Consequence for consumers: a `discharged` verdict is evidence, not proof,
+        under a same-kind reordering; `uncertain` is the honest default whenever
+        the domain moved.
+    links:
+      - type: satisfies
+        target: REQ-021
+      - type: traces-to
+        target: FEAT-065
+      - type: traces-to
+        target: DD-020
+
+  - id: DD-022
+    type: design-decision
+    title: "Dogfood the adjudicator in OBSERVATION MODE, and publish the uncertain fraction rather than the discharge count"
+    status: proposed
+    description: >
+      Two coupled decisions taken on 2026-08-20, after adversarial review found
+      six wrong-verdict paths in the FEAT-065 adjudicator (scry#122) and DD-021's
+      central rationale was retracted in place.
+
+      DECISION 1 — MEASURE BEFORE REWORKING. Run the REFUTED adjudicator over
+      scry's own commit history (FEAT-073) before implementing any of scry#122's
+      nine work items, and let the observed distribution order them.
+      Alternative rejected: fix all nine, then dogfood. Rejected because nine
+      fixes guessed at in the dark is how the first implementation was built, and
+      because scry's own history is a better adversary than any fixture we would
+      write — it contains real deletions, real same-kind insertions and real
+      renames at 6,191-obligation scale. Four vacuous oracles were written in
+      this project during August 2026; every one passed a fixture chosen by the
+      same person who wrote the code. Real history is not chosen.
+
+      DECISION 2 — OBSERVATION MODE IS STRUCTURAL, NOT PROCEDURAL. The harness
+      exits 0 unconditionally and stamps scry#122 into every artifact it writes.
+      Alternative rejected: run it as a gate with a generous threshold. Rejected
+      because an adjudicator that can wrongly report `discharged` is worse than
+      none — an agent optimising against the verdict finds the cheapest exploit
+      (delete the code) before it finds a fix — and a threshold makes that
+      exploit merely quieter. A comment saying "do not gate on this" is a
+      convention; a function that cannot return non-zero is a property.
+
+      DECISION 3 — THE PUBLISHED HEADLINE IS THE ADJUDICABLE FRACTION. While
+      scry#122 is open, the delta view (FEAT-072) renders "of M obligations, K
+      adjudicable, N uncertain" and NO discharge count, enforced by a test that
+      greps the rendered page.
+      Alternative rejected: publish discharges with a caveat paragraph. Rejected
+      because the dashboard is public, the standing bar is that every public
+      claim survives Conrad Watt, and a caveat does not travel — the number gets
+      quoted, the paragraph does not. The uncertain fraction is the one figure
+      the refutation did not undermine, and it is also the more useful one: it
+      states how far the matcher can be trusted. When REQ-021 closes, the
+      discharge count is UN-SUPPRESSED rather than re-implemented, so the
+      constraint carries no rework cost.
+
+      SEPARATION OF CONCERNS (recorded because it was nearly conflated): scale
+      does not substitute for adversarial reading. The six findings came from
+      reading, not from volume, and a 6,191-obligation run producing plausible
+      numbers has exactly the shape of the vacuous oracles. FEAT-073 measures
+      WHICH failures occur; REQ-021's adversarial acceptance bar establishes
+      THAT each is fixed. Both are required; neither is evidence for the other.
+    tags: [ai-agent, dogfood, honesty, observability, v3.3]
+    fields:
+      decision: >
+        (1) Run the REFUTED adjudicator over scry's own commit history and let
+        the observed verdict distribution ORDER scry#122's nine work items,
+        before implementing any of them.
+        (2) Enforce observation mode STRUCTURALLY — the harness cannot return
+        non-zero — rather than by a comment asking readers not to gate on it.
+        (3) Publish the ADJUDICABLE FRACTION ("of M obligations, K adjudicable,
+        N uncertain") and suppress the discharge count entirely while scry#122
+        is open, enforced by a test that greps the rendered page.
+      rationale: >
+        ALTERNATIVE REJECTED for (1) — fix all nine items, then dogfood.
+        Nine fixes guessed at in the dark is exactly how the first
+        implementation was built. scry's own history is a better adversary than
+        any fixture we would write: it holds real deletions, real same-kind
+        insertions and real renames at 6,191-obligation scale. Four vacuous
+        oracles were written in this project during August 2026 and every one
+        passed a fixture chosen by whoever wrote the code. Real history is not
+        chosen.
+        ALTERNATIVE REJECTED for (2) — run it as a gate with a generous
+        threshold. An adjudicator that can wrongly report `discharged` is worse
+        than no adjudicator: an agent optimising against the verdict finds the
+        cheapest exploit (delete the code) before it finds a fix, and a
+        threshold only makes that exploit quieter. A comment is a convention; a
+        function that cannot fail is a property.
+        ALTERNATIVE REJECTED for (3) — publish discharges with a caveat
+        paragraph. The dashboard is public and the standing bar is that every
+        claim survives Conrad Watt. A caveat does not travel: the number gets
+        quoted, the paragraph does not. The uncertain fraction is both the one
+        figure the refutation did not undermine and the more useful one, since
+        it states how far the matcher can be trusted. When REQ-021 closes the
+        discharge count is UN-SUPPRESSED rather than re-implemented, so the
+        constraint carries no rework cost.
+      limitations: >
+        Scale does not substitute for adversarial reading, and this decision
+        must not be read as claiming it does. The six findings came from
+        reading, not from volume, and a 6,191-obligation run producing
+        plausible numbers has precisely the shape of the four vacuous oracles.
+        FEAT-073 measures WHICH failures occur; REQ-021's adversarial
+        acceptance bar establishes THAT each is fixed. Both are required and
+        neither is evidence for the other.
+        The harness also samples only scry's own coding style — a Rust/LLVM
+        Wasm producer. Edit shapes common in hand-written or other-toolchain
+        Wasm may be absent from the sample, so an UNOBSERVED failure path is
+        not a refuted one, only an unmeasured one.
+    links:
+      - type: satisfies
+        target: REQ-020
+      - type: traces-to
+        target: FEAT-072
+      - type: traces-to
+        target: FEAT-073
+      - type: traces-to
+        target: DD-021

--- a/artifacts/design.yaml
+++ b/artifacts/design.yaml
@@ -843,19 +843,36 @@ artifacts:
         before implementing any of them.
         (2) Enforce observation mode STRUCTURALLY — the harness cannot return
         non-zero — rather than by a comment asking readers not to gate on it.
-        (3) Publish the ALIAS-FREE FRACTION ("of M shared sites, K provably
-        alias-free, the rest not excluded") and suppress the discharge count
-        entirely while scry#122 is open, enforced by a test that greps the
-        rendered page.
-        CORRECTED IN DRAFTING: this decision first said "K adjudicable", which
-        over-claims — nothing here certifies that a site can be adjudicated.
-        What IS certifiable is narrower and provable: aliasing requires a
-        deleted same-kind sibling to inherit an ordinal from
-        (`ObligationId.v: survivor_inherits_deleted_identity`), so an ordinal
-        domain holding exactly ONE member in BOTH runs has nothing to inherit
-        from. Note this is strictly STRONGER than DD-021's refuted rule — a
-        singleton domain rules aliasing out, whereas an unchanged domain does
-        not — and it is the wording the code implements.
+        (3) Publish the ORDINAL-STABLE FRACTION and suppress the discharge
+        count entirely while scry#122 is open, enforced by a test that greps the
+        rendered page — which must also assert the LIMITATION is disclosed, not
+        merely that the over-claim is absent.
+        CORRECTED TWICE IN DRAFTING, and the second correction matters more than
+        the first.
+        (a) It first said "K adjudicable", which over-claims: nothing here
+        certifies that a site can be adjudicated.
+        (b) It was then changed to "K provably ALIAS-FREE", justified by
+        `ObligationId.v: survivor_inherits_deleted_identity` needing a same-kind
+        sibling that a singleton ordinal domain does not have. THAT IS ALSO
+        WRONG, and it is wrong in the same way DD-021 was. It reasons from the
+        one theorem that happens to be proven rather than from what aliasing is;
+        a proof of ONE sufficient condition does not enumerate them.
+        The counterexample, found before publication and now pinned as
+        `feat072_region_shift_is_not_certified_as_identity_held`: `group_key`
+        hashes the region PATH, and a path is a sibling index at its depth.
+        Delete a whole region and its later siblings renumber, so a surviving
+        region moves into the deleted region's path and its sole operator
+        inherits the entire key — while BOTH domains remain singletons, so the
+        ordinal check sees nothing. An obligation removed by deleting its region
+        is then indistinguishable from one that changed state.
+        The claim is therefore named for its SCOPE: `OrdinalStable` excludes
+        sibling-ORDINAL donation and nothing else. It is a filter that says which
+        rows to look at first, never a warrant that a change belongs to a site.
+        RECORDED AS A PATTERN, because this is now the third instance: every
+        attempt to certify identity from the KEYS ALONE has failed, at three
+        different levels — the ordinal (DD-021), the region path (here), and the
+        function ident (scry#123). The keys are a good address and a bad proof.
+        Corroboration has to come from CONTENT.
       rationale: >
         ALTERNATIVE REJECTED for (1) — fix all nine items, then dogfood.
         Nine fixes guessed at in the dark is exactly how the first

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1371,3 +1371,5 @@ artifacts:
         target: FEAT-025
       - type: traces-to
         target: FEAT-064
+      - type: traces-to
+        target: DD-022

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1037,7 +1037,9 @@ artifacts:
     fields:
       phase: phase-3
       acceptance-criteria:
-        - "Given a module and an edit that changes code in an unrelated function, When scry re-analyzes, Then every obligation ID outside the edited function is unchanged."
+        - "Given a module and an edit that changes code in an unrelated function, When scry re-analyzes, Then every obligation ID outside the edited function is unchanged. FALSIFIED IN PRACTICE on Rust-produced modules (measured 2026-08-20 by FEAT-073, scry#123) — holds only for functions whose name-section name is itself stable. It is met by the unit fixture and NOT met by real toolchain output; see the AC below, which states what was measured."
+        - "MEASURED, not assumed (FEAT-073 over scry's own history, commits 582cfb06→524b3e0b). Given two builds of the same Rust source differing by an unrelated edit, When identities are compared, Then 334 of 744 functions carrying advisories (45%) lose EVERY obligation identity and 410 keep every one — an all-or-nothing split with ZERO partial cases. Cause: Rust legacy mangling ends in `17h<16 hex>E`, a symbol disambiguator derived from crate metadata and instantiation rather than from the function body, so an unrelated edit renames the function. `func_ident` is the first component of every key, so the churn takes the whole function's obligations with it."
+        - "OPEN, deliberately not claimed: whether a genuine FIX presents as a changed obligation at a surviving site. Across 7 consecutive commit pairs of scry's own history, ZERO shared sites changed their obligation set. That is a fact about the SAMPLE — scry's commits alter analyzer logic, which recompiles into different monomorphizations — and must not be restated as a structural claim without a fixture that isolates it."
         - "Given an edit that inserts instructions EARLIER in the same function AND the inserted code contains no operator of the same kind in the same region and opens no new block/loop/if at the same-or-shallower depth, When scry re-analyzes, Then obligation IDs for later sites in that function are unchanged (pc-shift immunity). QUALIFIED after clean-room review: the unrestricted form of this AC is FALSE — see DD-020's limitation section. The original wording was met only by a fixture selected around the failing case."
         - "Given one operator that raises SEVERAL obligations (an `i32.div_s` raises both div-by-zero and signed-overflow at one pc), When scry stamps identities, Then the obligations receive DISTINCT ids — the site alone is not a discriminator."
         - "Given a module-scoped advisory (unbounded-stack, which uses a `(func 0, pc 0)` sentinel rather than a real site), When scry stamps identities, Then it receives a module-scoped identity that neither collides with a genuine advisory at func 0 pc 0 nor drifts when func 0's first instruction changes."
@@ -1288,10 +1290,12 @@ artifacts:
       is untriageable; a delta is naturally small, which is the point.
 
       HONESTY CONSTRAINT (non-negotiable while scry#122 is open): the delta view
-      MUST NOT publish a `discharged` count. Its headline is the ADJUDICABLE
-      FRACTION — "of M obligations, K adjudicable, N uncertain" — because the
-      uncertain fraction is the number that states how far the matcher can be
-      trusted, and it is the one number the refutation did not undermine. The
+      MUST NOT publish a `discharged` count. Its headline is the ALIAS-FREE
+      FRACTION — "of M shared sites, K provably alias-free" — because that is
+      the one claim the refutation did not undermine AND it is provable rather
+      than merely conservative: aliasing needs a deleted same-kind sibling
+      (`survivor_inherits_deleted_identity`), so a singleton ordinal domain has
+      nothing to inherit from. The
       dashboard is public and every public claim must survive Conrad Watt; a
       discharge count from a matcher with six known wrong-verdict paths does not.
       When REQ-021 lands, the discharge count is UNSUPPRESSED — it is not
@@ -1301,7 +1305,7 @@ artifacts:
       phase: phase-3
       acceptance-criteria:
         - "Given the published self-analysis page, When a consumer deep-links to one obligation, Then the URL fragment is that obligation's stable ID — not its pc — and the same fragment still resolves after an UNRELATED function is edited and the page re-rendered."
-        - "Given two guidance feeds from different commits, When `scry-viz diff` renders them, Then every row is keyed on obligation ID and the summary reports the adjudicable/uncertain split."
+        - "Given two modules from different commits, When `scry-viz delta` renders them, Then every row is keyed on stable identity (not pc) and the summary reports the ALIAS-FREE / NOT-EXCLUDED split. Corrected from 'adjudicable/uncertain' during implementation: nothing certifies adjudicability, but a singleton ordinal domain provably cannot alias, since aliasing needs a deleted same-kind sibling to inherit from."
         - "Given `scry-viz diff` while scry#122 is open, When it renders any pair, Then NO discharge count appears anywhere in the output — enforced by a test that greps the rendered page, not by reviewer discipline."
         - "Given a feed compared with ITSELF, When `scry-viz diff` renders it, Then it reports zero changes and every obligation unchanged — the page's own vacuity check, so a plausible-looking delta cannot come from an empty comparison."
         - "Given a pair known to differ, When `scry-viz diff` renders it, Then the change set is NON-EMPTY — the dual check, so 'no changes' can never be the silent result of a broken match."
@@ -1351,6 +1355,8 @@ artifacts:
         - "Given a commit compared with ITSELF, When the harness runs, Then it reports only `still-open` — the same self-comparison invariant REQ-021 is held to, measured on the real module rather than a fixture."
         - "Given the harness in CI, When any pair yields `regressed` or `discharged`, Then the job still exits 0 — observation mode is a property of the code, not a convention a future edit can quietly drop."
         - "Given the measured distribution, When scry#122 is prioritized, Then each of its nine work items is annotated with whether the path was OBSERVED on real history or remains theoretical — the ordering is evidence-led."
+        - "FIRST RUN, 2026-08-20 (8 commits, 7 pairs). The harness paid for itself before scry#122 was touched: it surfaced a defect that is on NEITHER the issue's nine items nor DD-020's limitations — 43-45% of function identities churn per build via the Rust symbol disambiguator (scry#123). Recorded as the harness's own acceptance evidence: a fixture-only test suite could not have found this, because the defect lives in the toolchain's output rather than in scry's logic."
+        - "The same run REFUTED a hypothesis of the author's before it was published — that ordinal shifts inside surviving functions would masquerade as gone+new. The discriminating probe found ZERO partial-overlap functions, so ordinal shift contributed nothing to the observed churn. Recorded because the harness's value is symmetric: it must be able to kill our explanations, not only confirm them."
     links:
       - type: traces-to
         target: REQ-020

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1290,12 +1290,16 @@ artifacts:
       is untriageable; a delta is naturally small, which is the point.
 
       HONESTY CONSTRAINT (non-negotiable while scry#122 is open): the delta view
-      MUST NOT publish a `discharged` count. Its headline is the ALIAS-FREE
-      FRACTION — "of M shared sites, K provably alias-free" — because that is
-      the one claim the refutation did not undermine AND it is provable rather
-      than merely conservative: aliasing needs a deleted same-kind sibling
-      (`survivor_inherits_deleted_identity`), so a singleton ordinal domain has
-      nothing to inherit from. The
+      MUST NOT publish a `discharged` count. Its headline is the
+      ORDINAL-STABLE fraction: sites whose ordinal domain is a singleton in both
+      runs, so no same-kind SIBLING could have donated an ordinal
+      (`survivor_inherits_deleted_identity` needs one).
+      NAMED FOR ITS SCOPE after a pre-publication counterexample: this excludes
+      sibling-ordinal donation and NOTHING ELSE. A whole-region deletion
+      renumbers later sibling regions, so a survivor can occupy the deleted
+      region's path and inherit its key with both domains still singletons. The
+      page must disclose that, and the grep test asserts the disclosure is
+      present as well as asserting the over-claim is absent. The
       dashboard is public and every public claim must survive Conrad Watt; a
       discharge count from a matcher with six known wrong-verdict paths does not.
       When REQ-021 lands, the discharge count is UNSUPPRESSED — it is not
@@ -1305,7 +1309,8 @@ artifacts:
       phase: phase-3
       acceptance-criteria:
         - "Given the published self-analysis page, When a consumer deep-links to one obligation, Then the URL fragment is that obligation's stable ID — not its pc — and the same fragment still resolves after an UNRELATED function is edited and the page re-rendered."
-        - "Given two modules from different commits, When `scry-viz delta` renders them, Then every row is keyed on stable identity (not pc) and the summary reports the ALIAS-FREE / NOT-EXCLUDED split. Corrected from 'adjudicable/uncertain' during implementation: nothing certifies adjudicability, but a singleton ordinal domain provably cannot alias, since aliasing needs a deleted same-kind sibling to inherit from."
+        - "Given two modules from different commits, When `scry-viz delta` renders them, Then every row is keyed on stable identity (not pc) and the summary reports the ORDINAL-STABLE / NOT-EXCLUDED split. Renamed twice during implementation, and the history is the point: 'adjudicable' over-claimed, then 'alias-free' over-claimed in exactly DD-021's way — reasoning from the one proven theorem rather than from what aliasing is."
+        - "Given a module where a whole region carrying an unproven obligation is DELETED and a later sibling region moves into its path, When `scry-viz delta` renders it, Then the page DISCLOSES that ordinal-stability does not cover a region-path shift. The survivor is still counted ordinal-stable — the check cannot see it — so the acceptance is on the disclosure, and the limitation is pinned by feat072_region_shift_is_not_certified_as_identity_held so a later fix must update the disclosure in the same commit."
         - "Given `scry-viz diff` while scry#122 is open, When it renders any pair, Then NO discharge count appears anywhere in the output — enforced by a test that greps the rendered page, not by reviewer discipline."
         - "Given a feed compared with ITSELF, When `scry-viz diff` renders it, Then it reports zero changes and every obligation unchanged — the page's own vacuity check, so a plausible-looking delta cannot come from an empty comparison."
         - "Given a pair known to differ, When `scry-viz diff` renders it, Then the change set is NON-EMPTY — the dual check, so 'no changes' can never be the silent result of a broken match."

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -22,7 +22,8 @@ artifacts:
   #         AI agent is GATED on a sound checker: stable obligation identity
   #         + `scry verify` adjudication (depth), plus the MCP/query/schema
   #         surfaces and the precision work that make 6,191 unproven
-  #         obligations actionable at all (breadth). REQ-020, FEAT-064..071.
+  #         obligations actionable at all (breadth). REQ-020, FEAT-064,
+  #         066..073. The GATE half split to v3.4.0 as REQ-021/FEAT-065.
   #   v3.4  "Precision ceiling"             — convex polyhedra, ELINA-
   #         decomposed, for exact linear inequalities above the octagon.
   #         FEAT-057. Displaced from v3.3 on 2026-08-06 (see its section).
@@ -207,14 +208,20 @@ artifacts:
 
   - id: REQ-020
     type: requirement
-    title: "An AI agent can be GATED on scry: stable obligation identity + a machine-checkable oracle"
+    title: "An AI agent can CITE a scry obligation: stable identity that survives the edit"
     status: proposed
     release: v3.3.0
     description: >
       REQ-018 shipped ranked, honesty-classed advisories each carrying a
       VERIFICATION ORACLE — but as PROSE ("re-run scry: this trap_check becomes
       ProvenSafe"). A human can follow that; an agent loop cannot be gated on it.
-      Two things block the loop, and this requirement closes both.
+      Two things block the loop. This requirement closes the FIRST; REQ-021
+      closes the second. They were ONE requirement until 2026-08-20, when
+      adversarial review falsified the adjudicator's matching rule before it
+      shipped (scry#122) — at which point holding a verifiable identity half
+      hostage to a refuted adjudication half became the wrong trade. Splitting
+      is the honest move: a conjunctive requirement cannot be half-discharged,
+      and rewording it to hide the second half would be a vacuous gate.
 
       (1) IDENTITY. scry keys every finding on `(func_index, pc)`. The moment an
       agent edits the module and recompiles, every pc shifts, so "did my fix
@@ -224,11 +231,12 @@ artifacts:
       STABLE, content-addressed obligation identity that is invariant under
       edits elsewhere in the module and elsewhere in the same function.
 
-      (2) ADJUDICATION. scry shall be able to compare a new run against a prior
-      one and classify each obligation: discharged / still-open / regressed /
-      moved / removed-with-code. That converts the v3.1 prose oracle into a
-      machine verdict, so an agent's edit is gated by a SOUND CHECKER rather
-      than by tests — the actual value of REQ-018, finally executable.
+      (2) ADJUDICATION — SPLIT OUT to REQ-021 (v3.4.0) on 2026-08-20. Comparing
+      a new run against a prior one and classifying each obligation is the other
+      half of the loop, and it remains the point of the arc; but its matching
+      rule was refuted in review (DD-021's rationale retracted in place; six
+      wrong-verdict paths in scry#122) and it must not ship on a positional
+      ordinal. Identity is verifiable on its own and ships in v3.3.0.
 
       MOTIVATION (measured, not assumed): scry's own self-analysis reports 0
       proven faults against 6,191 unproven obligations and 1,962 precision gaps.
@@ -239,8 +247,9 @@ artifacts:
 
       HONESTY: a rewritten function SHOULD lose its obligation IDs. That is
       correct behaviour (the site genuinely no longer exists), not a defect, and
-      the adjudicator must report it as `removed-with-code`, never as
-      `discharged`.
+      the adjudicator (REQ-021) must report it as `removed-with-code`, never as
+      `discharged`. This statement is the shared honesty constraint across both
+      halves and is why the split does not weaken either.
     tags: [ai-agent, fix-verify-loop, identity, oracle, precision, v3.3]
     fields:
       priority: must
@@ -254,6 +263,56 @@ artifacts:
         target: G-005
       - type: evaluates-tech
         target: TE-011
+
+  - id: REQ-021
+    type: requirement
+    title: "An AI agent can be GATED on scry: a machine-checkable verdict on its own edit"
+    status: proposed
+    release: v3.4.0
+    description: >
+      The ADJUDICATION half of the original REQ-020, split out on 2026-08-20
+      after adversarial review refuted the first implementation's matching rule.
+
+      scry shall compare a fresh analysis against a prior one and classify every
+      obligation by its stable identity (REQ-020 / FEAT-064): discharged /
+      still-open / regressed / moved / removed-with-code / uncertain. That turns
+      the v3.1 PROSE oracle ("re-run scry; this trap_check becomes ProvenSafe")
+      into a machine verdict, so an agent's edit is judged by a SOUND
+      over-approximation rather than by whether the tests still pass.
+
+      WHY IT IS ITS OWN REQUIREMENT, AND WHY IT IS NOT IN v3.3.0. The first
+      implementation (FEAT-065, PR #120, never merged) matched obligations on a
+      positional intra-region ordinal plus a population check, justified by the
+      claim that aliasing "necessarily" changes the ordinal domain's membership.
+      That claim is FALSE: a deletion paired with a same-kind insertion leaves
+      the group byte-identical, producing a false `discharged`. Five further
+      wrong-verdict paths were found in the same pass (scry#122).
+
+      THE BAR THIS REQUIREMENT MUST CLEAR. An adjudicator that can wrongly
+      report `discharged` is strictly WORSE than no adjudicator, because an
+      agent optimising against the verdict finds the cheapest exploit — deleting
+      the code — before it finds a fix. Verification of this requirement is
+      therefore adversarial by construction: a self-comparison yields only
+      `still-open`; a deletion never yields `discharged`; a cardinality-
+      preserving delete+insert yields `uncertain`; a newly introduced fault
+      always yields a verdict. Matching must be CONTENT-CORROBORATED, not
+      positional — DD-020 named this as a deferred option; the review made it
+      mandatory.
+
+      EVIDENCE BEFORE REWORK: FEAT-073 runs the refuted adjudicator over scry's
+      OWN commit history in observation mode, so which of the nine scry#122 work
+      items actually fire on real code is a measurement rather than a guess.
+    tags: [ai-agent, oracle, fix-verify-loop, gate, adversarial, v3.4]
+    fields:
+      priority: must
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-020
+      - type: traces-to
+        target: REQ-018
+      - type: traces-to
+        target: G-005
 
   # ══════════════════════════════════════════════════════════════════════
   # RELEASE v2.6.0 — "Make the analysis observable"
@@ -934,11 +993,17 @@ artifacts:
         target: TE-011
 
   # ══════════════════════════════════════════════════════════════════════
-  # RELEASE v3.3.0 — "Agent-verifiable"  (REQ-020)
+  # RELEASE v3.3.0 — "Agent-citable"  (REQ-020)
+  # RE-SCOPED 2026-08-20. Was "Agent-verifiable" and carried BOTH halves of the
+  # fix-verify loop. The adjudication half was refuted in review before it
+  # shipped (scry#122) and moved to v3.4.0 with the new REQ-021. What remains
+  # here is verifiable on its own: an obligation an agent can CITE, surfaces it
+  # can reach, and the precision that makes the citations worth having.
   # Read-out from Wasm Research Day (6 Aug 2026): the AI-consumer axis is the
   # decisive one. Two halves, deliberately paired:
-  #   DEPTH   — close the fix-verify loop (identity + adjudication), so an
-  #             agent's edit is gated by a sound checker instead of by tests.
+  #   DEPTH   — identity that survives the edit, MADE VISIBLE (anchors, delta
+  #             view) and EXERCISED ON OURSELVES (self-adjudication harness,
+  #             observation mode). The gate itself follows in v3.4.0.
   #   BREADTH — make the analysis reachable and askable by an agent at all
   #             (MCP surface, queries, versioned schema, manifest), plus the
   #             precision work that makes 6,191 obligations actionable.
@@ -986,9 +1051,9 @@ artifacts:
 
   - id: FEAT-065
     type: feature
-    title: "v3.3 — `scry verify --against`: scry adjudicates its own oracle"
+    title: "v3.4 — `scry verify --against`: scry adjudicates its own oracle"
     status: proposed
-    release: v3.3.0
+    release: v3.4.0
     description: >
       Turn the v3.1 prose verification oracle into a machine verdict. `scry verify
       --against <previous.json>` compares a fresh analysis with a prior one and
@@ -1024,9 +1089,14 @@ artifacts:
         - "Given a POTENTIAL-TRAP obligation and an edit that adds a correct guard, When `scry verify --against` runs, Then that obligation is reported `discharged` and the exit code signals success."
         - "Given an edit that DELETES the function containing an open obligation, When verify runs, Then it is reported `removed-with-code`, never `discharged`."
         - "Given an edit that invalidates a previously PROVEN-SAFE site, When verify runs, Then it is reported `regressed` and the exit code signals failure."
+        - "ADVERSARIAL BAR (added 2026-08-20 after review refuted the first implementation; each case must be shown RED against the pre-rework adjudicator before it is fixed). Given a module compared with ITSELF, When verify runs, Then EVERY verdict is `still-open` — no `regressed`, no `moved`, no `discharged`. The original test for this passed vacuously."
+        - "Given a cardinality-preserving edit — one same-kind operator deleted and another inserted in the same region, leaving the group multiset byte-identical — When verify runs, Then the affected obligations are `uncertain`, never `discharged`. This is the case that falsified DD-021's rationale."
+        - "Given a function whose identity was derived from `body_shape_hash` (no name-section name, no export name), When verify runs, Then no obligation in it is ever reported `discharged` — the fallback identity cannot corroborate a discharge."
+        - "Given an edit that INTRODUCES a new obligation at a site that had no prior advisory, When verify runs, Then a verdict is emitted for it. Pre-rework this produced ZERO verdicts, so an agent that fixed A while breaking B passed clean."
+        - "Given the harness of FEAT-073 over scry's own history, When the reworked adjudicator replaces the refuted one, Then the verdict distribution is re-measured and any newly-silent verdict class is explained rather than assumed to be an improvement."
     links:
       - type: traces-to
-        target: REQ-020
+        target: REQ-021
       - type: traces-to
         target: REQ-018
       - type: traces-to
@@ -1046,11 +1116,16 @@ artifacts:
       `verify` (FEAT-065 adjudication). Returns structured results, never HTML.
       Single biggest adoption lever for the AI-consumer axis (TE-011:
       structured-primary — agents under-read rendered output).
+      SCOPE SPLIT (2026-08-20): the v3.3.0 slice is `analyze` + `query` only.
+      The `verify` tool follows FEAT-065 into v3.4.0 with REQ-021 — exposing a
+      refuted adjudicator over MCP would put a wrong verdict directly into an
+      agent's tool loop, which is the single worst place for it to land.
     tags: [ai-agent, mcp, interop, v3.3]
     fields:
       phase: phase-3
       acceptance-criteria:
         - "Given an MCP client, When it calls `analyze` on a Wasm module, Then it receives a structured summary (counts by advisory class, trap verdicts, gaps) without parsing HTML or reading a multi-MB dump."
+        - "Given the v3.3.0 server, When a client enumerates its tools, Then `verify` is ABSENT rather than present-and-unreliable — the deferral is enforced by the tool list, not by documentation."
     links:
       - type: traces-to
         target: REQ-020
@@ -1182,3 +1257,106 @@ artifacts:
         target: REQ-017
       - type: traces-to
         target: G-005
+
+  # ── DOGFOOD + VISUALIZATION: the two surfaces that make identity real ──
+  # Added 2026-08-20. Identity (FEAT-064) is landed and correct within its
+  # qualified scope, but it is INVISIBLE: nothing publishes it, nothing cites
+  # it, and nothing exercises it at scale. These two features fix that without
+  # depending on the refuted adjudicator.
+
+  - id: FEAT-072
+    type: feature
+    title: "v3.3 — Obligation anchors + the delta view (identity, made visible)"
+    status: proposed
+    release: v3.3.0
+    description: >
+      The dashboard renders ONE snapshot. The entire value of a stable obligation
+      identity is across TIME, so today FEAT-064 ships a key that nothing
+      displays, nothing links to, and no consumer can cite. Two pieces:
+
+      (a) ANCHORS. Every obligation in the rendered page carries
+      `id="ob-<obligation_id>"` plus a copyable deep link, so a verdict, a
+      GitHub issue, a commit message, or an agent's citation resolves to a URL
+      that SURVIVES the next release. Today a consumer can only cite
+      `(func_index, pc)`, which is exactly the key that shifts on every edit —
+      the dashboard has been handing out references it knows will break. This
+      piece is independent of adjudication and ships in v3.3.0 unconditionally.
+
+      (b) DELTA VIEW. `scry-viz diff <before.guidance.json> <after.guidance.json>`
+      renders a page keyed on obligation ID rather than pc: what is new, what is
+      gone, what is unchanged, what cannot be matched. The 6,191-obligation dump
+      is untriageable; a delta is naturally small, which is the point.
+
+      HONESTY CONSTRAINT (non-negotiable while scry#122 is open): the delta view
+      MUST NOT publish a `discharged` count. Its headline is the ADJUDICABLE
+      FRACTION — "of M obligations, K adjudicable, N uncertain" — because the
+      uncertain fraction is the number that states how far the matcher can be
+      trusted, and it is the one number the refutation did not undermine. The
+      dashboard is public and every public claim must survive Conrad Watt; a
+      discharge count from a matcher with six known wrong-verdict paths does not.
+      When REQ-021 lands, the discharge count is UNSUPPRESSED — it is not
+      re-implemented, only un-hidden, so the constraint costs nothing later.
+    tags: [ai-agent, visualization, identity, honesty, v3.3]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given the published self-analysis page, When a consumer deep-links to one obligation, Then the URL fragment is that obligation's stable ID — not its pc — and the same fragment still resolves after an UNRELATED function is edited and the page re-rendered."
+        - "Given two guidance feeds from different commits, When `scry-viz diff` renders them, Then every row is keyed on obligation ID and the summary reports the adjudicable/uncertain split."
+        - "Given `scry-viz diff` while scry#122 is open, When it renders any pair, Then NO discharge count appears anywhere in the output — enforced by a test that greps the rendered page, not by reviewer discipline."
+        - "Given a feed compared with ITSELF, When `scry-viz diff` renders it, Then it reports zero changes and every obligation unchanged — the page's own vacuity check, so a plausible-looking delta cannot come from an empty comparison."
+        - "Given a pair known to differ, When `scry-viz diff` renders it, Then the change set is NON-EMPTY — the dual check, so 'no changes' can never be the silent result of a broken match."
+    links:
+      - type: traces-to
+        target: REQ-020
+      - type: traces-to
+        target: REQ-017
+      - type: traces-to
+        target: FEAT-064
+      - type: traces-to
+        target: FEAT-063
+
+  - id: FEAT-073
+    type: feature
+    title: "v3.3 — Self-adjudication harness: scry adjudicates scry, in observation mode"
+    status: proposed
+    release: v3.3.0
+    description: >
+      Roll the fix-verify loop out ON OURSELVES. FEAT-025 already dogfoods scry
+      on its own compiled module (`scry_mcdc.wasm`) at a single commit; this
+      extends the same instrument across TIME — run the adjudicator over N
+      consecutive commits of scry's own history and publish the verdict
+      distribution.
+
+      PURPOSE IS EVIDENCE, NOT GATING. scry#122 lists nine work items and there
+      is no data on which of them fire on real code. scry's own history contains
+      real deletions, real same-kind insertions, and real function renames at
+      6,191-obligation scale — a far stronger sample than a hand-built fixture,
+      and the four vacuous oracles written in this project during August 2026
+      are the standing argument for preferring measured behaviour to designed
+      behaviour. The measurement ORDERS the rework instead of guessing at it.
+
+      OBSERVATION MODE IS ENFORCED BY CONSTRUCTION (DD-022): the harness exits 0
+      unconditionally, gates nothing, and every artifact it writes carries a
+      header naming scry#122 so that no reader — human or agent — mistakes a
+      `discharged` count for truth. It graduates to a gate only when REQ-021 has
+      closed and the distribution is understood. A gate on an unvalidated
+      adjudicator is precisely the failure mode the adjudicator exists to
+      prevent, one layer up.
+    tags: [ai-agent, dogfood, ci, evidence, honesty, v3.3]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given N consecutive commits of scry, When the harness runs, Then it emits a per-pair verdict distribution, and every artifact it writes names scry#122 as the reason no verdict in it is authoritative."
+        - "Given a pair of commits KNOWN to differ, When the harness runs, Then its verdict set is NON-EMPTY — the harness's own vacuity check, so a clean run can never be an empty run silently reported as agreement."
+        - "Given a commit compared with ITSELF, When the harness runs, Then it reports only `still-open` — the same self-comparison invariant REQ-021 is held to, measured on the real module rather than a fixture."
+        - "Given the harness in CI, When any pair yields `regressed` or `discharged`, Then the job still exits 0 — observation mode is a property of the code, not a convention a future edit can quietly drop."
+        - "Given the measured distribution, When scry#122 is prioritized, Then each of its nine work items is annotated with whether the path was OBSERVED on real history or remains theoretical — the ordering is evidence-led."
+    links:
+      - type: traces-to
+        target: REQ-020
+      - type: traces-to
+        target: REQ-021
+      - type: traces-to
+        target: FEAT-025
+      - type: traces-to
+        target: FEAT-064

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -675,6 +675,29 @@ pub struct Advisory {
     /// Empty when no identity could be derived. Opaque by construction — the
     /// layout is not a contract; do not parse it.
     pub obligation_id: String,
+    /// FEAT-072 (DD-021): identity of the SITE, excluding the advisory code —
+    /// so it is STABLE when an obligation changes state. A `div-by-zero`
+    /// becoming `proven-safe` changes `obligation_id` but NOT this, which is
+    /// what lets a delta view report "this site changed state" instead of
+    /// "one identity vanished and an unrelated one appeared".
+    ///
+    /// Derived here as DATA. It is deliberately NOT paired with an adjudicator
+    /// in this release: matching on this key alone was refuted in review
+    /// (scry#122), because a positional ordinal can be inherited by a
+    /// surviving sibling. Consumers may group and diff by it; nothing in this
+    /// release may conclude "discharged" from it.
+    pub site_key: String,
+    /// FEAT-072 (DD-021): the ORDINAL DOMAIN this site's ordinal is counted
+    /// within (function + region path + operator kind), WITHOUT the ordinal.
+    ///
+    /// This is the aliasing signal made observable: `ObligationId.v` proves a
+    /// surviving site can inherit a deleted sibling's ordinal
+    /// (survivor_inherits_deleted_identity), and that can only happen inside
+    /// one group. Comparing a group's membership across two runs therefore
+    /// bounds where identity may have shifted. Necessary but NOT sufficient to
+    /// rule aliasing out — the pairing of a deletion with a same-kind insertion
+    /// leaves the group unchanged, which is precisely what falsified DD-021.
+    pub group_key: String,
 }
 
 /// FEAT-055 (REQ-018): a candidate counterexample for an `UnprovenObligation`
@@ -3107,6 +3130,45 @@ fn obligation_id_of(func_ident: &str, path: &str, kind: &str, ordinal: u32, code
     out
 }
 
+/// FEAT-072 (DD-021): the SITE key — everything the obligation id has EXCEPT
+/// the advisory code, so it survives an obligation changing state.
+fn site_key_of(func_ident: &str, path: &str, kind: &str, ordinal: u32) -> String {
+    let mut h = Sha256::new();
+    h.update(b"site|");
+    h.update(func_ident.as_bytes());
+    h.update(b"|");
+    h.update(path.as_bytes());
+    h.update(b"|");
+    h.update(kind.as_bytes());
+    h.update(b"|");
+    h.update(ordinal.to_le_bytes());
+    let d = h.finalize();
+    let mut out = String::with_capacity(16);
+    for b in d.iter().take(8) {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// FEAT-072 (DD-021): the ORDINAL DOMAIN key — function + region path + kind,
+/// WITHOUT the ordinal. Aliasing can only occur WITHIN one such domain, so a
+/// change in a group's membership bounds where identity may have shifted.
+fn group_key_of(func_ident: &str, path: &str, kind: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(b"group|");
+    h.update(func_ident.as_bytes());
+    h.update(b"|");
+    h.update(path.as_bytes());
+    h.update(b"|");
+    h.update(kind.as_bytes());
+    let d = h.finalize();
+    let mut out = String::with_capacity(16);
+    for b in d.iter().take(8) {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
 /// FEAT-064: does this advisory describe the MODULE rather than a code site?
 /// Such advisories carry `(func 0, pc 0)` as a SENTINEL, so giving them a site
 /// identity would collide with a genuine advisory there, drift whenever func 0's
@@ -3126,6 +3188,8 @@ fn stamp_obligation_ids(
 ) {
     for a in advisories.iter_mut().filter(|a| is_module_scoped(&a.code)) {
         a.obligation_id = obligation_id_of("<module>", "", "<module>", 0, &a.code);
+        a.site_key = site_key_of("<module>", "", "<module>", 0);
+        a.group_key = group_key_of("<module>", "", "<module>");
     }
     for f in defined_funcs {
         let ident = function_meta
@@ -3145,6 +3209,8 @@ fn stamp_obligation_ids(
                     .map(op_report_name)
                     .unwrap_or_else(|| a.code.clone());
                 a.obligation_id = obligation_id_of(&ident, path, &kind, *ordinal, &a.code);
+                a.site_key = site_key_of(&ident, path, &kind, *ordinal);
+                a.group_key = group_key_of(&ident, path, &kind);
             }
         }
     }
@@ -3188,6 +3254,8 @@ fn compute_advisories(
             verification: "re-run scry: this handle_findings entry disappears".into(),
             counterexample: None,
             obligation_id: String::new(),
+            site_key: String::new(),
+            group_key: String::new(),
         });
     }
 
@@ -3228,6 +3296,8 @@ fn compute_advisories(
                     ),
                     counterexample: Some(trap_counterexample(t.kind, &t.op, memory_size_bytes)),
                 obligation_id: String::new(),
+                site_key: String::new(),
+                group_key: String::new(),
                 });
             }
             TrapVerdict::ProvenSafe => {
@@ -3255,6 +3325,8 @@ fn compute_advisories(
                     ),
                     counterexample: None,
                 obligation_id: String::new(),
+                site_key: String::new(),
+                group_key: String::new(),
                 });
             }
         }
@@ -3296,6 +3368,8 @@ fn compute_advisories(
             ),
             counterexample: None,
                 obligation_id: String::new(),
+                site_key: String::new(),
+                group_key: String::new(),
         });
     }
 
@@ -3315,6 +3389,8 @@ fn compute_advisories(
             verification: "re-run scry: stack_usage.max_stack_bytes becomes Bytes(n)".into(),
             counterexample: None,
                 obligation_id: String::new(),
+                site_key: String::new(),
+                group_key: String::new(),
         });
     }
 

--- a/crates/scry-mcdc/Cargo.lock
+++ b/crates/scry-mcdc/Cargo.lock
@@ -76,32 +76,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "scry-sai-bits"
+version = "3.2.4"
+
+[[package]]
 name = "scry-sai-core"
-version = "1.13.0"
+version = "3.2.4"
 dependencies = [
+ "scry-sai-bits",
+ "scry-sai-float",
+ "scry-sai-handle",
  "scry-sai-interval",
  "scry-sai-octagon",
+ "scry-sai-pentagon",
  "scry-sai-provenance",
+ "scry-sai-segment",
  "scry-sai-taint",
  "sha2",
  "wasmparser",
 ]
 
 [[package]]
+name = "scry-sai-float"
+version = "3.2.4"
+
+[[package]]
+name = "scry-sai-handle"
+version = "3.2.4"
+
+[[package]]
 name = "scry-sai-interval"
-version = "1.13.0"
+version = "3.2.4"
 
 [[package]]
 name = "scry-sai-octagon"
-version = "1.13.0"
+version = "3.2.4"
+
+[[package]]
+name = "scry-sai-pentagon"
+version = "3.2.4"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "1.13.0"
+version = "3.2.4"
+
+[[package]]
+name = "scry-sai-segment"
+version = "3.2.4"
+dependencies = [
+ "scry-sai-interval",
+]
 
 [[package]]
 name = "scry-sai-taint"
-version = "1.13.0"
+version = "3.2.4"
 
 [[package]]
 name = "sha2"
@@ -128,9 +156,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasmparser"
-version = "0.247.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags",
 ]

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -898,7 +898,8 @@ fn render_advisory_row(s: &mut String, a: &scry_analyze_core::Advisory) {
         let _ = write!(
             s,
             "<li id=\"ob-{0}\" class=\"{cls}\"><a class=\"anchor\" href=\"#ob-{0}\" \
-             title=\"stable obligation id — survives edits elsewhere in the module\">¶</a>",
+             title=\"content-addressed obligation id — stable while this function\'s \
+             name and structure are (see scry#123)\">¶</a>",
             esc(&a.obligation_id),
         );
     }
@@ -2372,7 +2373,7 @@ mod tests {
         assert_eq!(d.only_before(), 0, "self-comparison loses no site");
         assert_eq!(d.only_after(), 0, "self-comparison gains no site");
         assert_eq!(d.unchanged(), d.sites_before(), "every site unchanged");
-        assert_eq!(d.attributable_changes(), 0);
+        assert_eq!(d.ordinal_stable_changes(), 0);
     }
 
     /// The DUAL check — without it, "no changes" could silently be the result
@@ -2401,12 +2402,12 @@ mod tests {
     /// ordinal domain (`ObligationId.v: survivor_inherits_deleted_identity`),
     /// so a singleton domain is provably alias-free and a populated one is not.
     #[test]
-    fn feat072_alias_free_requires_a_singleton_ordinal_domain() {
+    fn feat072_ordinal_stable_requires_a_singleton_domain() {
         let one = analyze_wat(DIV_A);
         let d1 = compute_delta(&one, &one);
         assert!(
-            d1.alias_free() > 0,
-            "a lone div_s must be provably alias-free"
+            d1.ordinal_stable() > 0,
+            "a lone div_s has no same-kind sibling, so it is ordinal-stable"
         );
         assert_eq!(
             d1.not_excluded(),
@@ -2423,12 +2424,12 @@ mod tests {
         let d2 = compute_delta(&two, &two);
         assert!(
             d2.not_excluded() > 0,
-            "two same-kind sites must NOT be certified alias-free"
+            "two same-kind sites must NOT be reported ordinal-stable"
         );
         assert_eq!(
-            d2.alias_free(),
+            d2.ordinal_stable(),
             0,
-            "no site in a populated domain may be certified"
+            "no site in a populated domain may be reported ordinal-stable"
         );
     }
 
@@ -2471,6 +2472,60 @@ mod tests {
                 "a moved row must fall in exactly one bucket: {r:?}"
             );
         }
+    }
+
+    /// The limitation `OrdinalStable` does NOT cover, pinned so it cannot be
+    /// forgotten or silently "fixed" without updating the page's disclosure.
+    ///
+    /// `group_key` hashes the region PATH, and a path is a sibling index at its
+    /// depth. Delete a whole region and its later siblings renumber, so a
+    /// surviving region moves into the deleted one's path and its sole operator
+    /// inherits the entire key — while BOTH domains stay singletons and the
+    /// ordinal check therefore sees nothing.
+    ///
+    /// Here the unsafe `div_s` is deleted along with its block, and the
+    /// proven-safe `div_s` from the next block takes its identity. From the
+    /// keys alone that is indistinguishable from the obligation being fixed.
+    /// This is `survivor_inherits_deleted_identity` one level up the key.
+    #[test]
+    fn feat072_region_shift_is_not_certified_as_identity_held() {
+        let before = analyze_wat(
+            "(module (func (export \"a\") (param i32) (result i32) (local i32) \
+             (block i32.const 10 local.get 0 i32.div_s local.set 1) \
+             (block i32.const 10 i32.const 2 i32.div_s local.set 1) \
+             local.get 1))",
+        );
+        // The FIRST block — the one carrying the unproven obligation — is gone.
+        let after = analyze_wat(
+            "(module (func (export \"a\") (param i32) (result i32) (local i32) \
+             (block i32.const 10 i32.const 2 i32.div_s local.set 1) \
+             local.get 1))",
+        );
+        let d = compute_delta(&before, &after);
+
+        // CHARACTERIZATION, not an endorsement: the ordinal check cannot see a
+        // region-path shift, so the survivor IS reported ordinal-stable and the
+        // change IS counted. Pinned deliberately. If a future change makes this
+        // 0, that is an improvement — and this test must fail so that the
+        // page's disclosure is updated in the same commit rather than left
+        // warning about a hazard that no longer exists.
+        assert_eq!(
+            d.ordinal_stable_changes(),
+            1,
+            "known limitation: a region-path shift is invisible to the ordinal check"
+        );
+
+        // What MUST hold: the page has to disclose it. A number the reader
+        // cannot calibrate is worse than no number.
+        let html = render_delta_html(&d, "region shift").to_lowercase();
+        assert!(
+            html.contains("region"),
+            "the page must disclose the region-path hazard"
+        );
+        assert!(
+            html.contains("not a certificate") || html.contains("not certif"),
+            "the page must say plainly that ordinal-stable is not a certificate"
+        );
     }
 
     /// DD-022, enforced mechanically: the published page must not make a
@@ -2532,10 +2587,22 @@ mod tests {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AliasStatus {
     /// The site's ordinal domain (`group_key`) holds exactly ONE site in both
-    /// runs. Aliasing needs a deleted same-kind sibling to inherit an ordinal
-    /// from (`ObligationId.v: survivor_inherits_deleted_identity`); a singleton
-    /// domain has none, so identity here provably did not alias.
-    AliasFree,
+    /// runs, so no same-kind SIBLING could have donated its ordinal
+    /// (`ObligationId.v: survivor_inherits_deleted_identity` needs one).
+    ///
+    /// SCOPE — this rules out ORDINAL donation only. It does NOT certify that
+    /// identity held. `group_key` hashes the region PATH, and a path is a
+    /// sibling ordinal at its depth: deleting a whole region renumbers its
+    /// later siblings, so a surviving region can occupy the deleted region's
+    /// path and its sole operator inherits the whole key while both domains
+    /// stay singletons. Demonstrated by
+    /// `feat072_region_shift_is_not_certified_as_identity_held`.
+    ///
+    /// This variant was called `AliasFree` in drafting. The name was wrong:
+    /// it reasoned from the one theorem that was proven rather than from what
+    /// aliasing is, and a proof of one sufficient condition does not enumerate
+    /// them. Renamed before publication.
+    OrdinalStable,
     /// The domain holds two or more sites in one or both runs, so a deletion
     /// could have shifted ordinals within it. NOT a claim that aliasing
     /// happened — a claim that it is not excluded, which is the honest default.
@@ -2619,10 +2686,10 @@ impl Delta {
             .count()
     }
     /// Sites present in both runs whose identity provably did not alias.
-    pub fn alias_free(&self) -> usize {
+    pub fn ordinal_stable(&self) -> usize {
         self.rows
             .iter()
-            .filter(|r| r.in_both() && r.alias == AliasStatus::AliasFree)
+            .filter(|r| r.in_both() && r.alias == AliasStatus::OrdinalStable)
             .count()
     }
     /// Sites present in both runs where aliasing is not excluded.
@@ -2635,10 +2702,10 @@ impl Delta {
     /// The rows a future adjudicator (REQ-021) could act on soundly TODAY:
     /// present in both runs, obligation set changed, and provably alias-free.
     /// Reported as a COUNT OF CANDIDATES, never as discharges.
-    pub fn attributable_changes(&self) -> usize {
+    pub fn ordinal_stable_changes(&self) -> usize {
         self.rows
             .iter()
-            .filter(|r| r.in_both() && r.changed() && r.alias == AliasStatus::AliasFree)
+            .filter(|r| r.in_both() && r.changed() && r.alias == AliasStatus::OrdinalStable)
             .count()
     }
 }
@@ -2695,7 +2762,7 @@ pub fn compute_delta(before: &AnalysisResult, after: &AnalysisResult) -> Delta {
         let alias = if gb.get(group).is_some_and(|s| s.len() == 1)
             && ga.get(group).is_some_and(|s| s.len() == 1)
         {
-            AliasStatus::AliasFree
+            AliasStatus::OrdinalStable
         } else {
             AliasStatus::NotExcluded
         };
@@ -2753,20 +2820,31 @@ pub fn render_delta_html(d: &Delta, title: &str) -> String {
          so an unchanged domain does <em>not</em> imply identity held. An \
          adjudicator that can wrongly report success is worse than none, \
          because the cheapest way to satisfy it is to delete the code.</p>\
-         <p>The one claim made here is <strong>alias-free</strong>: a site whose \
-         ordinal domain holds exactly one member in <em>both</em> runs. Aliasing \
-         requires a deleted same-kind sibling to inherit an ordinal from \
-         (<code>ObligationId.v: survivor_inherits_deleted_identity</code>); a \
-         singleton domain has none. Everything else is <strong>not \
-         excluded</strong> — which is a statement about our knowledge, not about \
-         the code.</p></section>",
+         <p>The one claim made here is narrow and its name says so: \
+         <strong>ordinal-stable</strong>. A site whose ordinal domain holds \
+         exactly one member in <em>both</em> runs cannot have had its ordinal \
+         donated by a same-kind sibling, because \
+         <code>ObligationId.v: survivor_inherits_deleted_identity</code> needs \
+         one and a singleton domain has none.</p>\
+         <p><strong>That is not a certificate that identity held.</strong> The \
+         key hashes a region <em>path</em>, and a path is a sibling index at \
+         its depth — so deleting a whole region renumbers its later siblings, \
+         and a surviving region can move into the deleted one's path. Its sole \
+         operator then inherits the entire key while both domains remain \
+         singletons. An obligation removed by deleting its region can therefore \
+         look, from the keys alone, exactly like one that changed state. This \
+         page reports what moved; establishing that a change belongs to a \
+         particular site needs corroboration these keys do not carry \
+         (<code>scry#122</code>, <code>scry#123</code>).</p>\
+         <p>Everything not ordinal-stable is <strong>not excluded</strong> — a \
+         statement about our knowledge, not about the code.</p></section>",
     );
 
-    let both = d.alias_free() + d.not_excluded();
+    let both = d.ordinal_stable() + d.not_excluded();
     let pct = if both == 0 {
         0.0
     } else {
-        100.0 * d.alias_free() as f64 / both as f64
+        100.0 * d.ordinal_stable() as f64 / both as f64
     };
     s.push_str("<section><h2>Summary</h2><dl>");
     let _ = write!(
@@ -2775,32 +2853,32 @@ pub fn render_delta_html(d: &Delta, title: &str) -> String {
          <dt>module after</dt><dd><code>{}</code></dd>\
          <dt>sites before / after</dt><dd>{} / {}</dd>\
          <dt>present in both</dt><dd>{}</dd>\
-         <dt class=\"ok\">…provably alias-free</dt><dd class=\"ok\">{} ({:.1}%)</dd>\
-         <dt class=\"warn\">…aliasing not excluded</dt><dd class=\"warn\">{}</dd>\
+         <dt class=\"ok\">…ordinal-stable</dt><dd class=\"ok\">{} ({:.1}%)</dd>\
+         <dt class=\"warn\">…ordinal donation not excluded</dt><dd class=\"warn\">{}</dd>\
          <dt>only in before (site gone)</dt><dd>{}</dd>\
          <dt>only in after (site new)</dt><dd>{}</dd>\
          <dt>obligation set changed</dt><dd>{}</dd>\
-         <dt>…of those, attributable</dt><dd>{}</dd>",
+         <dt>…of those, ordinal-stable</dt><dd>{}</dd>",
         esc(&d.sha_before),
         esc(&d.sha_after),
         d.sites_before(),
         d.sites_after(),
         both,
-        d.alias_free(),
+        d.ordinal_stable(),
         pct,
         d.not_excluded(),
         d.only_before(),
         d.only_after(),
         d.changed(),
-        d.attributable_changes(),
+        d.ordinal_stable_changes(),
     );
     s.push_str("</dl>");
     s.push_str(
-        "<p class=\"muted\"><em>Attributable</em> = present in both runs, the \
-         obligation set changed, and the site is provably alias-free — so the \
-         change can be pinned to <em>this</em> site rather than to a neighbour \
-         that inherited its ordinal. These are the rows a sound adjudicator \
-         could act on today. They are candidates, not verdicts.</p>",
+        "<p class=\"muted\">The <em>ordinal-stable</em> subtotal is the rows on \
+         which one specific hazard — a same-kind sibling donating its ordinal — \
+         is excluded. It is a filter, not a warrant: a region-path shift can \
+         still move a key between operators, so these are the rows worth \
+         looking at FIRST, not the rows that are settled.</p>",
     );
     s.push_str(
         "<p class=\"muted\">A site \"only in before\" is <strong>not</strong> a \
@@ -2848,7 +2926,7 @@ pub fn render_delta_html(d: &Delta, title: &str) -> String {
                 _ => ("warn", "changed"),
             };
             let (acls, atxt) = match r.alias {
-                AliasStatus::AliasFree => ("ok", "alias-free"),
+                AliasStatus::OrdinalStable => ("ok", "alias-free"),
                 AliasStatus::NotExcluded => ("warn", "not excluded"),
             };
             let pcs = match (r.pc_before, r.pc_after) {
@@ -2905,21 +2983,21 @@ pub fn render_delta_json(d: &Delta) -> String {
          \"adjudicated\":false,\"adjudication_issue\":\"scry#122\",\
          \"module_sha256_before\":\"{}\",\"module_sha256_after\":\"{}\",\
          \"sites_before\":{},\"sites_after\":{},\
-         \"alias_free\":{},\"not_excluded\":{},\
+         \"ordinal_stable\":{},\"not_excluded\":{},\
          \"only_before\":{},\"only_after\":{},\
-         \"changed\":{},\"unchanged\":{},\"attributable_changes\":{}}}",
+         \"changed\":{},\"unchanged\":{},\"ordinal_stable_changes\":{}}}",
         GUIDANCE_SCHEMA_VERSION,
         json_esc(&d.sha_before),
         json_esc(&d.sha_after),
         d.sites_before(),
         d.sites_after(),
-        d.alias_free(),
+        d.ordinal_stable(),
         d.not_excluded(),
         d.only_before(),
         d.only_after(),
         d.changed(),
         d.unchanged(),
-        d.attributable_changes(),
+        d.ordinal_stable_changes(),
     );
     s
 }

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -877,6 +877,12 @@ fn advisory_class_name(c: AdvisoryClass) -> &'static str {
 
 /// Render one advisory as a `<li>` — the shared body of the (capped) HTML
 /// Guidance list.
+///
+/// FEAT-072: the row carries `id="ob-<obligation_id>"` and a `¶` permalink, so
+/// an obligation is CITABLE by URL. Until now the only handle a consumer could
+/// quote was `fn{index}:{pc}` — which is precisely the key that shifts on the
+/// next edit, so the dashboard was handing out references it knew would break.
+/// The `(func_index, pc)` pair stays visible as a positional convenience.
 fn render_advisory_row(s: &mut String, a: &scry_analyze_core::Advisory) {
     let (cls, label) = match a.class {
         AdvisoryClass::DefiniteFault => ("err", "FIX"),
@@ -884,9 +890,21 @@ fn render_advisory_row(s: &mut String, a: &scry_analyze_core::Advisory) {
         AdvisoryClass::PrecisionGap => ("info", "PRECISION"),
         AdvisoryClass::LeverageableFact => ("info", "LEVERAGE"),
     };
+    // An empty id means no identity could be derived (FEAT-064). Emit no anchor
+    // rather than a dead `#ob-` fragment that would resolve to the wrong row.
+    if a.obligation_id.is_empty() {
+        let _ = write!(s, "<li class=\"{cls}\">");
+    } else {
+        let _ = write!(
+            s,
+            "<li id=\"ob-{0}\" class=\"{cls}\"><a class=\"anchor\" href=\"#ob-{0}\" \
+             title=\"stable obligation id — survives edits elsewhere in the module\">¶</a>",
+            esc(&a.obligation_id),
+        );
+    }
     let _ = write!(
         s,
-        "<li class=\"{cls}\"><span class=\"sev\">{label}</span> \
+        "<span class=\"sev\">{label}</span> \
          <code>fn{}:{} {}</code> — {}<br><em>Action:</em> {}<br><em>Verify:</em> {}",
         a.func_index,
         a.pc,
@@ -1413,14 +1431,32 @@ fn esc(raw: &str) -> String {
 
 // ── structured guidance feed ────────────────────────────────────────────────
 
+/// FEAT-068: the guidance-feed schema version. Bumped when a field is added or
+/// its meaning changes, so a consumer can tell "this producer is old" from
+/// "this module has no such finding" — the distinction the un-versioned v1 feed
+/// could not express.
+///
+/// v2 (this release) adds `guidance_schema` itself plus `obligation_id`,
+/// `site_key` and `group_key` on every advisory.
+pub const GUIDANCE_SCHEMA_VERSION: u32 = 2;
+
 /// Serialize the actionable findings as a machine-consumable JSON document — the
 /// feed an AI-agent consumer reads instead of scraping the (now capped) HTML.
 ///
-/// Shape (stable): a top-level object
-/// `{ "module_sha256": "…", "schema": "…", "advisories": [ … ], "trap_checks": [ … ] }`.
+/// Shape: a top-level object
+/// `{ "guidance_schema": 2, "module_sha256": "…", "schema": "…",
+///    "advisories": [ … ], "trap_checks": [ … ] }`.
+///
+/// FEAT-068: `guidance_schema` is an explicit integer version. v1 (the v3.2.2
+/// feed) had none, so a consumer could not tell a field's ABSENCE from an old
+/// producer. v2 adds the version and the three FEAT-064/DD-021 identity keys.
+/// Absence of `guidance_schema` means v1; a consumer requiring identity must
+/// check for it rather than assume.
+///
 /// Each advisory is
 /// `{ "func_index", "pc", "class", "code", "detail", "suggested_action",
-///    "verification", "counterexample"? }`, mirroring the [`Advisory`] fields
+///    "verification", "obligation_id", "site_key", "group_key",
+///    "counterexample"? }`, mirroring the [`Advisory`] fields
 /// (`class` uses the machine-stable name, e.g. `"unproven-obligation"`). Each
 /// trap check is `{ "func_index", "pc", "op", "kind", "verdict" }`.
 ///
@@ -1432,7 +1468,8 @@ pub fn render_guidance_json(result: &AnalysisResult) -> String {
     s.push('{');
     let _ = write!(
         s,
-        "\"module_sha256\":\"{}\",\"schema\":\"{}\",",
+        "\"guidance_schema\":{},\"module_sha256\":\"{}\",\"schema\":\"{}\",",
+        GUIDANCE_SCHEMA_VERSION,
         json_esc(&result.invariants.module_sha256),
         json_esc(&result.invariants.schema),
     );
@@ -1445,7 +1482,8 @@ pub fn render_guidance_json(result: &AnalysisResult) -> String {
         let _ = write!(
             s,
             "{{\"func_index\":{},\"pc\":{},\"class\":\"{}\",\"code\":\"{}\",\
-             \"detail\":\"{}\",\"suggested_action\":\"{}\",\"verification\":\"{}\"",
+             \"detail\":\"{}\",\"suggested_action\":\"{}\",\"verification\":\"{}\",\
+             \"obligation_id\":\"{}\",\"site_key\":\"{}\",\"group_key\":\"{}\"",
             a.func_index,
             a.pc,
             advisory_class_name(a.class),
@@ -1453,6 +1491,9 @@ pub fn render_guidance_json(result: &AnalysisResult) -> String {
             json_esc(&a.detail),
             json_esc(&a.suggested_action),
             json_esc(&a.verification),
+            json_esc(&a.obligation_id),
+            json_esc(&a.site_key),
+            json_esc(&a.group_key),
         );
         if let Some(cx) = &a.counterexample {
             let _ = write!(
@@ -1548,6 +1589,12 @@ const STYLE: &str = "<style>\
     .ok{color:var(--ok);font-weight:600}.warn{color:var(--warn);font-weight:600}\
     .err{color:var(--err);font-weight:600}.muted,.empty{color:var(--muted)}\
     .diags{list-style:none;padding:0}.diags li{padding:4px 0;border-bottom:1px solid var(--line)}\
+    .anchor{float:right;color:var(--line);text-decoration:none;font-weight:400;\
+    padding:0 2px;margin-left:8px}\
+    .diags li:hover .anchor{color:var(--muted)}.anchor:hover{color:var(--fg)}\
+    .diags li:target{background:#fffbe6;outline:2px solid #f0d98a;outline-offset:2px;\
+    scroll-margin-top:16px}\
+    .diags li:target .anchor{color:var(--fg)}\
     .badge{display:inline-block;font-size:11px;padding:1px 6px;border-radius:10px;\
     border:1px solid var(--line);white-space:nowrap}\
     .badge.import{background:#eef4ff;border-color:#cdd9f0}\
@@ -2131,6 +2178,8 @@ mod tests {
             verification: "re-run scry".into(),
             counterexample: None,
             obligation_id: format!("test-{i:04x}"),
+            site_key: format!("site-{i:04x}"),
+            group_key: format!("grp-{:04x}", i / 4),
         };
         for i in 0..(ADVISORY_PER_CLASS_CAP as u32 + 25) {
             r.advisories.push(mk(i));
@@ -2212,4 +2261,612 @@ mod tests {
         assert_eq!(depth, 0, "unbalanced braces/brackets in JSON");
         assert!(!in_str, "unterminated string in JSON");
     }
+
+    // ── FEAT-068 / FEAT-072 ─────────────────────────────────────────────
+
+    /// One `i32.div_s` on an unknown divisor — the smallest fixture that
+    /// raises a real, identity-stamped obligation.
+    const DIV_A: &str = "(module (func (export \"a\") (param i32) (result i32) \
+                         i32.const 10 local.get 0 i32.div_s))";
+
+    #[test]
+    fn feat068_guidance_json_carries_a_schema_version_and_the_identity_keys() {
+        let r = analyze_wat(DIV_A);
+        assert!(!r.advisories.is_empty(), "fixture must raise an advisory");
+        // Non-vacuity: the analyzer must actually have stamped an id, else the
+        // feed could carry three empty strings and still "contain" the keys.
+        assert!(
+            r.advisories.iter().any(|a| !a.obligation_id.is_empty()),
+            "FEAT-064 must stamp an obligation_id"
+        );
+        assert!(
+            r.advisories.iter().any(|a| !a.site_key.is_empty()),
+            "site_key must be stamped"
+        );
+        let json = render_guidance_json(&r);
+        assert!(
+            json.contains("\"guidance_schema\":2"),
+            "v2 feed must declare its version"
+        );
+        for k in ["obligation_id", "site_key", "group_key"] {
+            assert!(json.contains(&format!("\"{k}\":\"")), "feed must carry {k}");
+        }
+        // And the values must be the real ones, not placeholders.
+        let a = r
+            .advisories
+            .iter()
+            .find(|a| !a.obligation_id.is_empty())
+            .unwrap();
+        assert!(
+            json.contains(&format!("\"obligation_id\":\"{}\"", a.obligation_id)),
+            "the feed's id must be the analyzer's id"
+        );
+    }
+
+    #[test]
+    fn feat072_advisory_rows_are_addressable_by_stable_id() {
+        let r = analyze_wat(DIV_A);
+        let a = r
+            .advisories
+            .iter()
+            .find(|a| !a.obligation_id.is_empty())
+            .expect("an identity-stamped advisory");
+        let html = render_html(&r, "anchors");
+        assert!(
+            html.contains(&format!("id=\"ob-{}\"", a.obligation_id)),
+            "every identified obligation must be an anchor target"
+        );
+        assert!(
+            html.contains(&format!("href=\"#ob-{}\"", a.obligation_id)),
+            "and must carry its own permalink"
+        );
+    }
+
+    /// FEAT-072 AC: the citable URL must survive an edit in a DIFFERENT
+    /// function — otherwise the anchor is no better than the `fn:pc` it
+    /// replaces.
+    #[test]
+    fn feat072_anchor_survives_an_edit_in_an_unrelated_function() {
+        let before = analyze_wat(
+            "(module \
+             (func (export \"a\") (param i32) (result i32) i32.const 10 local.get 0 i32.div_s) \
+             (func (export \"b\") (param i32) (result i32) local.get 0))",
+        );
+        let after = analyze_wat(
+            "(module \
+             (func (export \"a\") (param i32) (result i32) i32.const 10 local.get 0 i32.div_s) \
+             (func (export \"b\") (param i32) (result i32) local.get 0 i32.const 1 i32.add \
+             local.get 0 i32.add))",
+        );
+        // Non-vacuity: the edit must actually have changed the module.
+        assert_ne!(
+            before.invariants.module_sha256, after.invariants.module_sha256,
+            "the two fixtures must really differ, or this test proves nothing"
+        );
+        let id = before
+            .advisories
+            .iter()
+            .find(|a| a.func_index == 0 && !a.obligation_id.is_empty())
+            .map(|a| a.obligation_id.clone())
+            .expect("fn a raises an identified obligation");
+        let frag = format!("id=\"ob-{id}\"");
+        assert!(render_html(&before, "before").contains(&frag));
+        assert!(
+            render_html(&after, "after").contains(&frag),
+            "a link handed out before the edit must still resolve after it"
+        );
+    }
+
+    /// The delta's own vacuity check: comparing a module with ITSELF must
+    /// report nothing changed. A delta that "found changes" here would make
+    /// every later number meaningless.
+    #[test]
+    fn feat072_delta_of_a_module_with_itself_reports_no_change() {
+        let r = analyze_wat(DIV_A);
+        let d = compute_delta(&r, &r);
+        assert!(
+            d.sites_before() > 0,
+            "fixture must produce sites to compare"
+        );
+        assert_eq!(d.changed(), 0, "self-comparison must show no change");
+        assert_eq!(d.only_before(), 0, "self-comparison loses no site");
+        assert_eq!(d.only_after(), 0, "self-comparison gains no site");
+        assert_eq!(d.unchanged(), d.sites_before(), "every site unchanged");
+        assert_eq!(d.attributable_changes(), 0);
+    }
+
+    /// The DUAL check — without it, "no changes" could silently be the result
+    /// of a broken match rather than of two equivalent modules.
+    #[test]
+    fn feat072_delta_of_known_different_modules_is_non_empty() {
+        // Same site, but the divisor is now a non-zero constant, so the
+        // div-by-zero obligation is discharged into a proven-safe fact.
+        let before = analyze_wat(DIV_A);
+        let after = analyze_wat(
+            "(module (func (export \"a\") (param i32) (result i32) \
+             i32.const 10 i32.const 2 i32.div_s))",
+        );
+        assert_ne!(
+            before.invariants.module_sha256, after.invariants.module_sha256,
+            "fixtures must differ"
+        );
+        let d = compute_delta(&before, &after);
+        assert!(
+            d.changed() > 0 || d.only_before() > 0 || d.only_after() > 0,
+            "a real edit must show up somewhere in the delta; got {d:?}"
+        );
+    }
+
+    /// The soundness carve-out. Aliasing needs a same-kind SIBLING in the same
+    /// ordinal domain (`ObligationId.v: survivor_inherits_deleted_identity`),
+    /// so a singleton domain is provably alias-free and a populated one is not.
+    #[test]
+    fn feat072_alias_free_requires_a_singleton_ordinal_domain() {
+        let one = analyze_wat(DIV_A);
+        let d1 = compute_delta(&one, &one);
+        assert!(
+            d1.alias_free() > 0,
+            "a lone div_s must be provably alias-free"
+        );
+        assert_eq!(
+            d1.not_excluded(),
+            0,
+            "…and nothing in that module should be flagged"
+        );
+
+        // Two same-kind operators in one region share an ordinal domain, so a
+        // deletion could shift ordinals within it.
+        let two = analyze_wat(
+            "(module (func (export \"a\") (param i32) (result i32) \
+             i32.const 10 local.get 0 i32.div_s local.get 0 i32.div_s))",
+        );
+        let d2 = compute_delta(&two, &two);
+        assert!(
+            d2.not_excluded() > 0,
+            "two same-kind sites must NOT be certified alias-free"
+        );
+        assert_eq!(
+            d2.alias_free(),
+            0,
+            "no site in a populated domain may be certified"
+        );
+    }
+
+    /// DD-022, enforced mechanically: the published page must not make a
+    /// verdict claim while scry#122 is open. Checked by grepping the rendered
+    /// output, not by reviewer discipline.
+    #[test]
+    fn feat072_delta_page_makes_no_verdict_claim() {
+        let before = analyze_wat(DIV_A);
+        let after = analyze_wat(
+            "(module (func (export \"a\") (param i32) (result i32) \
+             i32.const 10 i32.const 2 i32.div_s))",
+        );
+        let html = render_delta_html(&compute_delta(&before, &after), "delta");
+        let lower = html.to_lowercase();
+        for banned in ["discharg", "verified fix", "obligation closed"] {
+            assert!(
+                !lower.contains(banned),
+                "the delta page must not claim {banned:?} while scry#122 is open"
+            );
+        }
+        // It must instead say what it DOES claim, and cite the refutation.
+        assert!(
+            lower.contains("alias-free"),
+            "the honest headline must appear"
+        );
+        assert!(
+            lower.contains("scry#122"),
+            "the page must cite the refutation"
+        );
+        // The machine feed must be equally explicit.
+        let json = render_delta_json(&compute_delta(&before, &after));
+        assert!(json.contains("\"adjudicated\":false"));
+        assert!(!json.to_lowercase().contains("discharg"));
+    }
+}
+
+// ── FEAT-072: the delta view ────────────────────────────────────────────────
+//
+// The dashboard renders ONE snapshot, but the whole value of a stable
+// obligation identity (FEAT-064) is ACROSS TIME. This module compares two
+// analyses by identity rather than by position.
+//
+// WHAT IT DELIBERATELY DOES NOT DO: adjudicate. It reports no `discharged`
+// count and draws no conclusion about whether a fix worked. Matching on a
+// positional ordinal was refuted in review (scry#122) — a deletion paired with
+// a same-kind insertion leaves a group's site set byte-identical, so "the
+// group is unchanged" does NOT imply "identity did not alias".
+//
+// WHAT IT CAN SAY SOUNDLY. `ObligationId.v` proves aliasing via
+// `survivor_inherits_deleted_identity`: a surviving site inherits a DELETED
+// SIBLING's ordinal. That requires a sibling *in the same ordinal domain*.
+// A domain (`group_key`) holding exactly one site in both runs therefore has
+// no sibling to inherit from, and identity there provably cannot have aliased.
+// That is a real, checkable carve-out, and it is the honest headline: not "K
+// adjudicable" but "K provably alias-free, the rest not excluded".
+
+/// FEAT-072: whether an obligation's identity could have aliased between two
+/// runs — the only soundness claim the delta view makes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AliasStatus {
+    /// The site's ordinal domain (`group_key`) holds exactly ONE site in both
+    /// runs. Aliasing needs a deleted same-kind sibling to inherit an ordinal
+    /// from (`ObligationId.v: survivor_inherits_deleted_identity`); a singleton
+    /// domain has none, so identity here provably did not alias.
+    AliasFree,
+    /// The domain holds two or more sites in one or both runs, so a deletion
+    /// could have shifted ordinals within it. NOT a claim that aliasing
+    /// happened — a claim that it is not excluded, which is the honest default.
+    NotExcluded,
+}
+
+/// FEAT-072: one site's fate across two analyses, keyed on `site_key` (stable
+/// across a code/class change) rather than on `(func_index, pc)`.
+#[derive(Clone, Debug)]
+pub struct DeltaRow {
+    pub site_key: String,
+    pub group_key: String,
+    /// Advisory codes at this site in each run. A SET, not a scalar: one
+    /// operator can raise several obligations (an `i32.div_s` raises both
+    /// div-by-zero and signed-overflow), and `site_key` excludes the code, so
+    /// they share a site. Modelling it as a set surfaces that multiplicity
+    /// rather than silently picking one.
+    pub codes_before: Vec<String>,
+    pub codes_after: Vec<String>,
+    pub func_index: u32,
+    pub pc_before: Option<u32>,
+    pub pc_after: Option<u32>,
+    pub alias: AliasStatus,
+}
+
+impl DeltaRow {
+    /// Present in both runs.
+    pub fn in_both(&self) -> bool {
+        !self.codes_before.is_empty() && !self.codes_after.is_empty()
+    }
+    /// The set of obligations at this site differs between the runs. NOTE: this
+    /// is an OBSERVATION about the two reports, never a verdict about a fix.
+    pub fn changed(&self) -> bool {
+        self.codes_before != self.codes_after
+    }
+}
+
+/// FEAT-072: the computed delta between two analyses.
+#[derive(Clone, Debug, Default)]
+pub struct Delta {
+    pub rows: Vec<DeltaRow>,
+    pub sha_before: String,
+    pub sha_after: String,
+}
+
+impl Delta {
+    pub fn sites_before(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|r| !r.codes_before.is_empty())
+            .count()
+    }
+    pub fn sites_after(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|r| !r.codes_after.is_empty())
+            .count()
+    }
+    pub fn only_before(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|r| !r.codes_before.is_empty() && r.codes_after.is_empty())
+            .count()
+    }
+    pub fn only_after(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|r| r.codes_before.is_empty() && !r.codes_after.is_empty())
+            .count()
+    }
+    pub fn changed(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|r| r.in_both() && r.changed())
+            .count()
+    }
+    pub fn unchanged(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|r| r.in_both() && !r.changed())
+            .count()
+    }
+    /// Sites present in both runs whose identity provably did not alias.
+    pub fn alias_free(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|r| r.in_both() && r.alias == AliasStatus::AliasFree)
+            .count()
+    }
+    /// Sites present in both runs where aliasing is not excluded.
+    pub fn not_excluded(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|r| r.in_both() && r.alias == AliasStatus::NotExcluded)
+            .count()
+    }
+    /// The rows a future adjudicator (REQ-021) could act on soundly TODAY:
+    /// present in both runs, obligation set changed, and provably alias-free.
+    /// Reported as a COUNT OF CANDIDATES, never as discharges.
+    pub fn attributable_changes(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|r| r.in_both() && r.changed() && r.alias == AliasStatus::AliasFree)
+            .count()
+    }
+}
+
+/// FEAT-072: compare two analyses by stable identity.
+///
+/// Both inputs must come from the same producer version — `site_key` is a hash
+/// over a key tuple whose derivation is not a cross-version contract.
+pub fn compute_delta(before: &AnalysisResult, after: &AnalysisResult) -> Delta {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    // group_key -> the set of distinct sites in that ordinal domain, per run.
+    fn groups(r: &AnalysisResult) -> BTreeMap<&str, BTreeSet<&str>> {
+        let mut m: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+        for a in r.advisories.iter().filter(|a| !a.site_key.is_empty()) {
+            m.entry(a.group_key.as_str())
+                .or_default()
+                .insert(a.site_key.as_str());
+        }
+        m
+    }
+    // site_key -> (group_key, func_index, pc, sorted distinct codes)
+    fn sites(r: &AnalysisResult) -> BTreeMap<&str, (&str, u32, u32, BTreeSet<&str>)> {
+        let mut m: BTreeMap<&str, (&str, u32, u32, BTreeSet<&str>)> = BTreeMap::new();
+        for a in r.advisories.iter().filter(|a| !a.site_key.is_empty()) {
+            let e = m.entry(a.site_key.as_str()).or_insert((
+                a.group_key.as_str(),
+                a.func_index,
+                a.pc,
+                BTreeSet::new(),
+            ));
+            e.3.insert(a.code.as_str());
+        }
+        m
+    }
+
+    let (gb, ga) = (groups(before), groups(after));
+    let (sb, sa) = (sites(before), sites(after));
+
+    let mut keys: BTreeSet<&str> = BTreeSet::new();
+    keys.extend(sb.keys().copied());
+    keys.extend(sa.keys().copied());
+
+    let mut rows = Vec::with_capacity(keys.len());
+    for k in keys {
+        let b = sb.get(k);
+        let a = sa.get(k);
+        let group = b.map(|x| x.0).or_else(|| a.map(|x| x.0)).unwrap_or("");
+        // Alias-free ONLY when the ordinal domain is a singleton in BOTH runs:
+        // with no sibling there is nothing for a survivor to inherit from.
+        // A domain absent from one run cannot be certified, so `is_some_and`
+        // (false when absent) is the correct conservative default — a vacuous
+        // `true` here would certify exactly the sites we know least about.
+        let alias = if gb.get(group).is_some_and(|s| s.len() == 1)
+            && ga.get(group).is_some_and(|s| s.len() == 1)
+        {
+            AliasStatus::AliasFree
+        } else {
+            AliasStatus::NotExcluded
+        };
+        rows.push(DeltaRow {
+            site_key: k.to_string(),
+            group_key: group.to_string(),
+            codes_before: b
+                .map(|x| x.3.iter().map(|s| s.to_string()).collect())
+                .unwrap_or_default(),
+            codes_after: a
+                .map(|x| x.3.iter().map(|s| s.to_string()).collect())
+                .unwrap_or_default(),
+            func_index: b.map(|x| x.1).or_else(|| a.map(|x| x.1)).unwrap_or(0),
+            pc_before: b.map(|x| x.2),
+            pc_after: a.map(|x| x.2),
+            alias,
+        });
+    }
+
+    Delta {
+        rows,
+        sha_before: before.invariants.module_sha256.clone(),
+        sha_after: after.invariants.module_sha256.clone(),
+    }
+}
+
+/// FEAT-072: render a [`Delta`] as a self-contained page.
+///
+/// HONESTY CONSTRAINT (DD-022, enforced by `delta_page_makes_no_discharge_claim`):
+/// this page contains NO discharge count and no verdict vocabulary. Its
+/// headline is the alias-free fraction, because that is the one figure the
+/// scry#122 refutation did not undermine and because it states exactly how far
+/// a future adjudicator (REQ-021) could be trusted on this pair. When REQ-021
+/// lands, verdicts are ADDED here — the framing above does not have to be
+/// walked back.
+pub fn render_delta_html(d: &Delta, title: &str) -> String {
+    let mut s = String::with_capacity(8 * 1024);
+    let _ = write!(s, "{}", DOCTYPE_AND_HEAD_OPEN);
+    let _ = write!(s, "<title>{} — {}</title>", esc(HERO_TITLE), esc(title));
+    let _ = write!(s, "{}", STYLE);
+    s.push_str("</head><body>");
+    let _ = write!(s, "<h1>{} — {}</h1>", esc(HERO_TITLE), esc(title));
+
+    // What this page is, and — more importantly — what it is not.
+    s.push_str(
+        "<section><h2>What this page claims</h2>\
+         <p>This is a comparison of two analyses <strong>by stable obligation \
+         identity</strong> (FEAT-064), not by <code>(func_index, pc)</code>. \
+         It reports what <em>changed</em>. It does <strong>not</strong> report \
+         that anything was proved.</p>\
+         <p>Adjudication — turning an observed change into a <em>verdict</em> — \
+         is deliberately absent. Matching obligations on a positional ordinal \
+         was refuted in review (<code>scry#122</code>): a deletion paired with a \
+         same-kind insertion leaves an ordinal domain's site set byte-identical, \
+         so an unchanged domain does <em>not</em> imply identity held. An \
+         adjudicator that can wrongly report success is worse than none, \
+         because the cheapest way to satisfy it is to delete the code.</p>\
+         <p>The one claim made here is <strong>alias-free</strong>: a site whose \
+         ordinal domain holds exactly one member in <em>both</em> runs. Aliasing \
+         requires a deleted same-kind sibling to inherit an ordinal from \
+         (<code>ObligationId.v: survivor_inherits_deleted_identity</code>); a \
+         singleton domain has none. Everything else is <strong>not \
+         excluded</strong> — which is a statement about our knowledge, not about \
+         the code.</p></section>",
+    );
+
+    let both = d.alias_free() + d.not_excluded();
+    let pct = if both == 0 {
+        0.0
+    } else {
+        100.0 * d.alias_free() as f64 / both as f64
+    };
+    s.push_str("<section><h2>Summary</h2><dl>");
+    let _ = write!(
+        s,
+        "<dt>module before</dt><dd><code>{}</code></dd>\
+         <dt>module after</dt><dd><code>{}</code></dd>\
+         <dt>sites before / after</dt><dd>{} / {}</dd>\
+         <dt>present in both</dt><dd>{}</dd>\
+         <dt class=\"ok\">…provably alias-free</dt><dd class=\"ok\">{} ({:.1}%)</dd>\
+         <dt class=\"warn\">…aliasing not excluded</dt><dd class=\"warn\">{}</dd>\
+         <dt>only in before (site gone)</dt><dd>{}</dd>\
+         <dt>only in after (site new)</dt><dd>{}</dd>\
+         <dt>obligation set changed</dt><dd>{}</dd>\
+         <dt>…of those, attributable</dt><dd>{}</dd>",
+        esc(&d.sha_before),
+        esc(&d.sha_after),
+        d.sites_before(),
+        d.sites_after(),
+        both,
+        d.alias_free(),
+        pct,
+        d.not_excluded(),
+        d.only_before(),
+        d.only_after(),
+        d.changed(),
+        d.attributable_changes(),
+    );
+    s.push_str("</dl>");
+    s.push_str(
+        "<p class=\"muted\"><em>Attributable</em> = present in both runs, the \
+         obligation set changed, and the site is provably alias-free — so the \
+         change can be pinned to <em>this</em> site rather than to a neighbour \
+         that inherited its ordinal. These are the rows a sound adjudicator \
+         could act on today. They are candidates, not verdicts.</p>",
+    );
+    s.push_str(
+        "<p class=\"muted\">A site \"only in before\" is <strong>not</strong> a \
+         fix: the code that carried the obligation may simply be gone, which \
+         proves nothing.</p></section>",
+    );
+
+    // Changed rows only — an unchanged row carries no information and the
+    // whole point of a delta is that it is small.
+    s.push_str("<section><h2>Changed sites</h2>");
+    let changed: Vec<&DeltaRow> = d
+        .rows
+        .iter()
+        .filter(|r| r.changed())
+        .take(SECTION_ROW_CAP)
+        .collect();
+    let total_changed = d.rows.iter().filter(|r| r.changed()).count();
+    if total_changed == 0 {
+        s.push_str(
+            "<p class=\"empty\">No site changed its obligation set. If the two \
+             modules differ, that is itself worth investigating — see the \
+             self-comparison and known-different checks in the test suite.</p>",
+        );
+    } else {
+        let _ = write!(
+            s,
+            "<p>{} changed site(s){}.</p>\
+             <table><tr><th>site</th><th>fn:pc</th><th>alias</th>\
+             <th>before</th><th>after</th></tr>",
+            total_changed,
+            if total_changed > changed.len() {
+                format!(" — showing the first {}", changed.len())
+            } else {
+                String::new()
+            },
+        );
+        for r in changed {
+            let (acls, atxt) = match r.alias {
+                AliasStatus::AliasFree => ("ok", "alias-free"),
+                AliasStatus::NotExcluded => ("warn", "not excluded"),
+            };
+            let pcs = match (r.pc_before, r.pc_after) {
+                (Some(b), Some(a)) if b == a => format!("fn{}:{}", r.func_index, b),
+                (Some(b), Some(a)) => format!("fn{}:{}→{}", r.func_index, b, a),
+                (Some(b), None) => format!("fn{}:{} (gone)", r.func_index, b),
+                (None, Some(a)) => format!("fn{}:{} (new)", r.func_index, a),
+                (None, None) => "—".to_string(),
+            };
+            let fmt = |v: &Vec<String>| {
+                if v.is_empty() {
+                    "<span class=\"muted\">—</span>".to_string()
+                } else {
+                    v.iter()
+                        .map(|c| format!("<code>{}</code>", esc(c)))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                }
+            };
+            let _ = write!(
+                s,
+                "<tr><td><code>{}</code></td><td><code>{}</code></td>\
+                 <td class=\"{}\">{}</td><td>{}</td><td>{}</td></tr>",
+                esc(&r.site_key),
+                esc(&pcs),
+                acls,
+                atxt,
+                fmt(&r.codes_before),
+                fmt(&r.codes_after),
+            );
+        }
+        s.push_str("</table>");
+    }
+    s.push_str("</section>");
+
+    s.push_str(
+        "<footer>Rendered by scry-viz · a comparison of two analyses by stable \
+        identity. No verdict is asserted; see scry#122. MIT OR Apache-2.0.</footer>",
+    );
+    s.push_str("</body></html>");
+    s
+}
+
+/// FEAT-072: the delta as a machine-consumable summary — what the FEAT-073
+/// harness aggregates across a run of commits.
+pub fn render_delta_json(d: &Delta) -> String {
+    let mut s = String::with_capacity(1024);
+    let _ = write!(
+        s,
+        "{{\"guidance_schema\":{},\"kind\":\"delta\",\
+         \"adjudicated\":false,\"adjudication_issue\":\"scry#122\",\
+         \"module_sha256_before\":\"{}\",\"module_sha256_after\":\"{}\",\
+         \"sites_before\":{},\"sites_after\":{},\
+         \"alias_free\":{},\"not_excluded\":{},\
+         \"only_before\":{},\"only_after\":{},\
+         \"changed\":{},\"unchanged\":{},\"attributable_changes\":{}}}",
+        GUIDANCE_SCHEMA_VERSION,
+        json_esc(&d.sha_before),
+        json_esc(&d.sha_after),
+        d.sites_before(),
+        d.sites_after(),
+        d.alias_free(),
+        d.not_excluded(),
+        d.only_before(),
+        d.only_after(),
+        d.changed(),
+        d.unchanged(),
+        d.attributable_changes(),
+    );
+    s
 }

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -2432,6 +2432,47 @@ mod tests {
         );
     }
 
+    /// The page's own arithmetic must add up. This caught a real defect: the
+    /// moved-sites table filtered on `changed()` (true for gone and new rows
+    /// too) while the summary counted in-place changes only, so a page could
+    /// announce "7633 changed" above a summary saying "0 changed". Conflating
+    /// vanished / new / changed is exactly how a delta misleads.
+    #[test]
+    fn feat072_moved_rows_reconcile_with_the_summary_counts() {
+        let before = analyze_wat(
+            "(module (func (export \"a\") (param i32) (result i32) \
+             i32.const 10 local.get 0 i32.div_s) \
+             (func (export \"b\") (param i32) (result i32) \
+             i32.const 7 local.get 0 i32.div_s))",
+        );
+        // `b` is gone entirely, and `a`'s divisor becomes a non-zero constant.
+        let after = analyze_wat(
+            "(module (func (export \"a\") (param i32) (result i32) \
+             i32.const 10 i32.const 2 i32.div_s))",
+        );
+        let d = compute_delta(&before, &after);
+        let moved = d.rows.iter().filter(|r| r.changed()).count();
+        assert_eq!(
+            moved,
+            d.only_before() + d.only_after() + d.changed(),
+            "every moved row must be exactly one of gone / new / changed-in-place"
+        );
+        // Non-vacuity: this fixture must actually move something, or the
+        // identity above holds trivially at 0 == 0.
+        assert!(moved > 0, "the fixture must move at least one site");
+        // And the three buckets must be disjoint by construction.
+        for r in d.rows.iter().filter(|r| r.changed()) {
+            let gone = !r.codes_before.is_empty() && r.codes_after.is_empty();
+            let new = r.codes_before.is_empty() && !r.codes_after.is_empty();
+            let inplace = r.in_both();
+            assert_eq!(
+                u8::from(gone) + u8::from(new) + u8::from(inplace),
+                1,
+                "a moved row must fall in exactly one bucket: {r:?}"
+            );
+        }
+    }
+
     /// DD-022, enforced mechanically: the published page must not make a
     /// verdict claim while scry#122 is open. Checked by grepping the rendered
     /// output, not by reviewer discipline.
@@ -2767,36 +2808,45 @@ pub fn render_delta_html(d: &Delta, title: &str) -> String {
          proves nothing.</p></section>",
     );
 
-    // Changed rows only — an unchanged row carries no information and the
+    // Only rows that MOVED. An unchanged row carries no information, and the
     // whole point of a delta is that it is small.
-    s.push_str("<section><h2>Changed sites</h2>");
-    let changed: Vec<&DeltaRow> = d
-        .rows
-        .iter()
-        .filter(|r| r.changed())
-        .take(SECTION_ROW_CAP)
-        .collect();
-    let total_changed = d.rows.iter().filter(|r| r.changed()).count();
-    if total_changed == 0 {
+    //
+    // The `fate` column exists because "changed" is three different events and
+    // conflating them is how a delta misleads: a site that VANISHED is not a
+    // site that changed class, and neither is a fix. The summary above counts
+    // in-place changes only; this table shows all three and says which is which.
+    s.push_str("<section><h2>Sites that moved</h2>");
+    let moved: Vec<&DeltaRow> = d.rows.iter().filter(|r| r.changed()).collect();
+    let shown: Vec<&&DeltaRow> = moved.iter().take(SECTION_ROW_CAP).collect();
+    if moved.is_empty() {
         s.push_str(
-            "<p class=\"empty\">No site changed its obligation set. If the two \
-             modules differ, that is itself worth investigating — see the \
-             self-comparison and known-different checks in the test suite.</p>",
+            "<p class=\"empty\">No site moved. If the two modules differ, that is \
+             itself worth investigating — see the self-comparison and \
+             known-different controls in the test suite.</p>",
         );
     } else {
         let _ = write!(
             s,
-            "<p>{} changed site(s){}.</p>\
-             <table><tr><th>site</th><th>fn:pc</th><th>alias</th>\
+            "<p><strong>{}</strong> site(s) moved — {} gone, {} new, \
+             {} changed in place{}.</p>\
+             <table><tr><th>site</th><th>fn:pc</th><th>fate</th><th>alias</th>\
              <th>before</th><th>after</th></tr>",
-            total_changed,
-            if total_changed > changed.len() {
-                format!(" — showing the first {}", changed.len())
+            moved.len(),
+            d.only_before(),
+            d.only_after(),
+            d.changed(),
+            if moved.len() > shown.len() {
+                format!(" — showing the first {}", shown.len())
             } else {
                 String::new()
             },
         );
-        for r in changed {
+        for r in shown {
+            let (fcls, ftxt) = match (r.codes_before.is_empty(), r.codes_after.is_empty()) {
+                (true, false) => ("info", "new"),
+                (false, true) => ("muted", "gone"),
+                _ => ("warn", "changed"),
+            };
             let (acls, atxt) = match r.alias {
                 AliasStatus::AliasFree => ("ok", "alias-free"),
                 AliasStatus::NotExcluded => ("warn", "not excluded"),
@@ -2804,8 +2854,8 @@ pub fn render_delta_html(d: &Delta, title: &str) -> String {
             let pcs = match (r.pc_before, r.pc_after) {
                 (Some(b), Some(a)) if b == a => format!("fn{}:{}", r.func_index, b),
                 (Some(b), Some(a)) => format!("fn{}:{}→{}", r.func_index, b, a),
-                (Some(b), None) => format!("fn{}:{} (gone)", r.func_index, b),
-                (None, Some(a)) => format!("fn{}:{} (new)", r.func_index, a),
+                (Some(b), None) => format!("fn{}:{}", r.func_index, b),
+                (None, Some(a)) => format!("fn{}:{}", r.func_index, a),
                 (None, None) => "—".to_string(),
             };
             let fmt = |v: &Vec<String>| {
@@ -2821,9 +2871,12 @@ pub fn render_delta_html(d: &Delta, title: &str) -> String {
             let _ = write!(
                 s,
                 "<tr><td><code>{}</code></td><td><code>{}</code></td>\
-                 <td class=\"{}\">{}</td><td>{}</td><td>{}</td></tr>",
+                 <td class=\"{}\">{}</td><td class=\"{}\">{}</td>\
+                 <td>{}</td><td>{}</td></tr>",
                 esc(&r.site_key),
                 esc(&pcs),
+                fcls,
+                ftxt,
                 acls,
                 atxt,
                 fmt(&r.codes_before),

--- a/crates/scry-viz/src/main.rs
+++ b/crates/scry-viz/src/main.rs
@@ -321,6 +321,14 @@ fn run_index(args: &[String]) -> Result<PathBuf, CliError> {
             "MC/DC truth-table dashboard",
             "witness-viz coverage of scry's real analyzer decision corpus.",
         ),
+        (
+            "delta.html",
+            "delta.html",
+            "Release delta (by stable obligation identity)",
+            "What changed between this release's module and the previous one, \
+             keyed on stable obligation identity rather than on (func_index, pc). \
+             Reports what moved; asserts no verdict — see scry#122.",
+        ),
     ];
     let entries: Vec<scry_viz::IndexEntry> = known
         .iter()

--- a/crates/scry-viz/src/main.rs
+++ b/crates/scry-viz/src/main.rs
@@ -24,6 +24,7 @@ fn main() -> ExitCode {
     // bare form `scry-viz <input> ...` renders one analysis.
     let result = match args.first().map(String::as_str) {
         Some("index") => run_index(&args[1..]),
+        Some("delta") => run_delta(&args[1..]),
         _ => run(&args),
     };
     match result {
@@ -170,6 +171,104 @@ fn run(args: &[String]) -> Result<PathBuf, CliError> {
     std::fs::write(&json_out, json)
         .map_err(|e| err(4, format!("writing {}: {e}", json_out.display())))?;
     eprintln!("scry-viz: wrote {}", json_out.display());
+    Ok(out)
+}
+
+/// `scry-viz delta <before.wasm> <after.wasm> [-o out.html] [--title NAME]` —
+/// FEAT-072: compare two modules BY STABLE OBLIGATION IDENTITY and write a
+/// delta page plus a `<stem>.delta.json` summary.
+///
+/// Takes two MODULES rather than two guidance feeds on purpose: both are
+/// analyzed in-process, so the comparison cannot drift from the producer's
+/// key derivation and no JSON parser has to be trusted in the middle.
+///
+/// It reports what changed. It does NOT adjudicate — see `scry#122`.
+fn run_delta(args: &[String]) -> Result<PathBuf, CliError> {
+    let mut inputs: Vec<PathBuf> = Vec::new();
+    let mut output: Option<PathBuf> = None;
+    let mut title: Option<String> = None;
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "-h" | "--help" => {
+                return Err(err(
+                    2,
+                    "usage: scry-viz delta <before.wasm|wat> <after.wasm|wat> \
+                     [-o out.html] [--title NAME]",
+                ));
+            }
+            "-o" | "--output" => {
+                output = Some(PathBuf::from(
+                    it.next().ok_or_else(|| err(2, "-o needs a path"))?,
+                ));
+            }
+            "--title" => {
+                title = Some(
+                    it.next()
+                        .ok_or_else(|| err(2, "--title needs a value"))?
+                        .clone(),
+                );
+            }
+            other if other.starts_with('-') => {
+                return Err(err(2, format!("unknown flag: {other}")));
+            }
+            other => inputs.push(PathBuf::from(other)),
+        }
+    }
+    if inputs.len() != 2 {
+        return Err(err(
+            2,
+            format!("delta needs exactly two modules, got {}", inputs.len()),
+        ));
+    }
+
+    let mut analyzed = Vec::with_capacity(2);
+    for p in &inputs {
+        let bytes = read_module(p)?;
+        analyzed.push(
+            analyze(
+                bytes,
+                AnalysisConfig {
+                    emit_diagnostics: true,
+                    ..Default::default()
+                },
+            )
+            .map_err(|e| err(3, format!("analysis failed for {}: {e:?}", p.display())))?,
+        );
+    }
+    let delta = scry_viz::compute_delta(&analyzed[0], &analyzed[1]);
+
+    let title = title.unwrap_or_else(|| {
+        format!(
+            "{} → {}",
+            inputs[0].file_name().unwrap_or_default().to_string_lossy(),
+            inputs[1].file_name().unwrap_or_default().to_string_lossy(),
+        )
+    });
+    let out = output.unwrap_or_else(|| PathBuf::from("delta.html"));
+    std::fs::write(&out, scry_viz::render_delta_html(&delta, &title))
+        .map_err(|e| err(4, format!("writing {}: {e}", out.display())))?;
+
+    let json_out = out.with_extension("delta.json");
+    std::fs::write(&json_out, scry_viz::render_delta_json(&delta))
+        .map_err(|e| err(4, format!("writing {}: {e}", json_out.display())))?;
+    eprintln!("scry-viz: wrote {}", json_out.display());
+
+    // A one-line human summary on stderr, phrased so it cannot be mistaken for
+    // a verdict: counts of what MOVED, plus how much of it is attributable.
+    eprintln!(
+        "scry-viz delta: {} site(s) before, {} after · {} changed \
+         ({} attributable, alias-free) · {} gone, {} new · \
+         {} of {} shared sites provably alias-free · no verdict claimed (scry#122)",
+        delta.sites_before(),
+        delta.sites_after(),
+        delta.changed(),
+        delta.attributable_changes(),
+        delta.only_before(),
+        delta.only_after(),
+        delta.alias_free(),
+        delta.alias_free() + delta.not_excluded(),
+    );
     Ok(out)
 }
 

--- a/crates/scry-viz/src/main.rs
+++ b/crates/scry-viz/src/main.rs
@@ -258,16 +258,18 @@ fn run_delta(args: &[String]) -> Result<PathBuf, CliError> {
     // a verdict: counts of what MOVED, plus how much of it is attributable.
     eprintln!(
         "scry-viz delta: {} site(s) before, {} after · {} changed \
-         ({} attributable, alias-free) · {} gone, {} new · \
-         {} of {} shared sites provably alias-free · no verdict claimed (scry#122)",
+         ({} ordinal-stable) · {} gone, {} new · \
+         {} of {} shared sites ordinal-stable · no verdict claimed; \
+         ordinal-stable excludes sibling-ordinal donation only, NOT a region-path \
+         shift (scry#122, scry#123)",
         delta.sites_before(),
         delta.sites_after(),
         delta.changed(),
-        delta.attributable_changes(),
+        delta.ordinal_stable_changes(),
         delta.only_before(),
         delta.only_after(),
-        delta.alias_free(),
-        delta.alias_free() + delta.not_excluded(),
+        delta.ordinal_stable(),
+        delta.ordinal_stable() + delta.not_excluded(),
     );
     Ok(out)
 }

--- a/scripts/self-history.sh
+++ b/scripts/self-history.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# FEAT-073 — the self-adjudication harness, in OBSERVATION MODE.
+#
+# scry already analyzes its own compiled module at a single commit (FEAT-025).
+# This extends that instrument across TIME: build `scry_mcdc.wasm` at each of
+# the last N commits, then compare consecutive pairs BY STABLE OBLIGATION
+# IDENTITY (FEAT-064/072) and publish the distribution.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHY THIS EXISTS, AND WHY IT DOES NOT GATE
+#
+# scry#122 lists nine wrong-verdict paths in the (withdrawn) adjudicator and
+# nothing yet says which of them fire on real code. scry's own history is a
+# better adversary than any fixture we would write for ourselves: it contains
+# real deletions, real same-kind insertions and real renames, at a scale of
+# thousands of obligations. The measurement ORDERS the rework instead of
+# guessing at it.
+#
+# This script therefore reports and never judges:
+#   * it EXITS 0 unconditionally — observation mode is a property of the code,
+#     not a convention a later edit can quietly drop;
+#   * every artifact it writes names scry#122, so no reader — human or agent —
+#     mistakes a count here for a verdict;
+#   * it claims nothing beyond "alias-free", which holds because aliasing needs
+#     a same-kind sibling to inherit an ordinal from (ObligationId.v:
+#     survivor_inherits_deleted_identity) and a singleton ordinal domain has none.
+#
+# It graduates to a gate only when REQ-021 has closed. See DD-022.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Usage:  scripts/self-history.sh [N_COMMITS] [OUT_DIR]
+# Default: last 6 commits of the current branch, into ./self-history/
+set -uo pipefail   # deliberately NOT -e: a failed build of one old commit must
+                   # not abort the sweep, it must be reported and skipped.
+
+N="${1:-6}"
+OUT="${2:-self-history}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT" || exit 0
+
+STAGE="$OUT/modules"
+mkdir -p "$STAGE"
+
+echo "== FEAT-073 self-adjudication harness (OBSERVATION MODE) =="
+echo "   No verdict is produced. Adjudication is scry#122 / REQ-021."
+echo
+
+# ── 1. Build the delta tool ONCE, from the working tree ─────────────────────
+# The tool must be the CURRENT producer: identity is a hash over a key tuple
+# whose derivation is not a cross-version contract, so old modules are analyzed
+# with today's analyzer — never old-analyzer-vs-new-analyzer.
+echo "== build scry-viz (current working tree) =="
+cargo build --release -p scry-sai-viz || {
+  echo "!! could not build scry-viz — nothing to measure with"; exit 0; }
+VIZ="$REPO_ROOT/target/release/scry-viz"
+
+# ── 2. Build scry_mcdc.wasm at each commit ──────────────────────────────────
+# Portable to bash 3.2 (macOS default): no `mapfile`, no negative subscripts.
+COMMITS=()
+while IFS= read -r line; do COMMITS+=("$line"); done < <(git log --format=%H -n "$N")
+echo
+echo "== building scry_mcdc.wasm at ${#COMMITS[@]} commit(s) =="
+BUILT=()
+for sha in "${COMMITS[@]}"; do
+  short="${sha:0:8}"
+  dest="$STAGE/$short.wasm"
+  if [[ -f "$dest" ]]; then
+    echo "   $short — cached"; BUILT+=("$short"); continue
+  fi
+  wt="$(mktemp -d)/wt"
+  if ! git worktree add --detach -q "$wt" "$sha" 2>/dev/null; then
+    echo "   $short — SKIP (cannot check out)"; continue
+  fi
+  if (cd "$wt/crates/scry-mcdc" && cargo build --release --target wasm32-wasip1 -q 2>/dev/null) \
+     && cp "$wt/crates/scry-mcdc/target/wasm32-wasip1/release/scry_mcdc.wasm" "$dest" 2>/dev/null; then
+    echo "   $short — ok ($(wc -c <"$dest" | tr -d ' ') bytes)"
+    BUILT+=("$short")
+  else
+    # An old commit that no longer builds is a fact about the history, not a
+    # failure of the harness. Report it and carry on.
+    echo "   $short — SKIP (build failed at this commit)"
+  fi
+  git worktree remove --force "$wt" 2>/dev/null
+done
+
+if (( ${#BUILT[@]} < 2 )); then
+  echo
+  echo "!! fewer than two modules built — nothing to compare."
+  echo "   Reporting this rather than pretending agreement. Exit 0 (observation mode)."
+  exit 0
+fi
+
+# ── 3. Compare consecutive pairs (oldest → newest) ──────────────────────────
+# git log is newest-first; reverse so a delta reads forward in time.
+REV=()
+for (( i=${#BUILT[@]}-1 ; i>=0 ; i-- )); do REV+=("${BUILT[i]}"); done
+
+echo
+echo "== deltas over ${#REV[@]} module(s), oldest → newest =="
+SUMMARY="$OUT/summary.json"
+{
+  echo "{"
+  echo "  \"harness\": \"FEAT-073 self-adjudication (observation mode)\","
+  echo "  \"adjudicated\": false,"
+  echo "  \"adjudication_issue\": \"scry#122\","
+  echo "  \"note\": \"Counts describe what CHANGED between two analyses. No verdict is claimed: matching obligations on a positional ordinal was refuted in review, so no count here may be read as a fix.\","
+  echo "  \"pairs\": ["
+} > "$SUMMARY"
+
+first=1
+for (( i=0 ; i<${#REV[@]}-1 ; i++ )); do
+  a="${REV[i]}"; b="${REV[i+1]}"
+  page="$OUT/delta-$a-$b.html"
+  if ! "$VIZ" delta "$STAGE/$a.wasm" "$STAGE/$b.wasm" \
+        -o "$page" --title "$a → $b" 2>&1 | sed 's/^/   /'; then
+    echo "   $a → $b — SKIP (delta failed)"
+    continue
+  fi
+  dj="${page%.html}.delta.json"
+  if [[ -s "$dj" ]]; then
+    [[ $first -eq 0 ]] && echo "," >> "$SUMMARY"
+    first=0
+    { printf '    {"from":"%s","to":"%s","delta":' "$a" "$b"
+      cat "$dj"
+      printf '}'; } >> "$SUMMARY"
+  fi
+done
+
+{ echo; echo "  ]"; echo "}"; } >> "$SUMMARY"
+
+# ── 4. SELF-COMPARISON CONTROL ──────────────────────────────────────────────
+# The harness's own vacuity check, and the same invariant REQ-021 will be held
+# to. If comparing a module with ITSELF reports changes, every number above is
+# meaningless and the run says so — loudly, and still exits 0.
+echo
+echo "== self-comparison control (newest module vs itself) =="
+newest="${REV[$(( ${#REV[@]} - 1 ))]}"
+ctl="$OUT/control-self.html"
+"$VIZ" delta "$STAGE/$newest.wasm" "$STAGE/$newest.wasm" -o "$ctl" \
+  --title "control: $newest vs itself" 2>&1 | sed 's/^/   /'
+ctlj="${ctl%.html}.delta.json"
+if [[ -s "$ctlj" ]] && grep -q '"changed":0' "$ctlj" \
+   && grep -q '"only_before":0' "$ctlj" && grep -q '"only_after":0' "$ctlj"; then
+  echo "   CONTROL OK — a module compared with itself shows no change."
+else
+  echo "   !! CONTROL FAILED — identity is not stable under a no-op."
+  echo "      Every count in this run is suspect. (Still exit 0: observation mode.)"
+fi
+
+echo
+echo "== wrote $SUMMARY and $(ls "$OUT"/delta-*.html 2>/dev/null | wc -l | tr -d ' ') delta page(s) =="
+echo "   Reminder: observation only. No verdict. scry#122 / REQ-021."
+exit 0


### PR DESCRIPTION
Plans the next release and delivers two of its features. Nothing here depends on the adjudicator refuted in #122.

## 1. The replan — v3.3.0 was uncuttable for a traceability reason

REQ-020 is written as a conjunction: *"stable obligation identity **+** a machine-checkable oracle."* The oracle half (FEAT-065) was refuted before it shipped, so the identity half — which is fine — was being held hostage.

**Split, not reworded.** Rewording REQ-020 to hide its second half would be the artifact-level twin of a vacuous oracle.

| | |
|---|---|
| **REQ-020** → v3.3.0 | identity an agent can **cite** |
| **REQ-021** → v3.4.0 | the **gate**, with an adversarial acceptance bar taken from #122 |

FEAT-065 follows REQ-021. FEAT-066's `verify` MCP tool follows it too — the v3.3.0 server *omits the tool* rather than documenting a caveat, because exposing a refuted adjudicator over MCP puts a wrong verdict directly into an agent's tool loop.

## 2. FEAT-068 — guidance.json v2

The feed shipped un-versioned and carried no identity, so a consumer could not tell an old producer from a module with no such finding, and identity that lived only in Rust structs could not cross a process boundary. Adds `guidance_schema: 2` and the three identity keys.

`site_key` / `group_key` are lifted onto main from the withdrawn branch. Their *derivation* was never what the review refuted — the refuted part was the inference *"group set unchanged ⇒ safe to claim a discharge."*

## 3. FEAT-072 — anchors and the delta view

**Anchors.** Every advisory row is now `id="ob-<obligation_id>"` with a permalink. Until now the only quotable handle was `fn{index}:{pc}` — precisely the key that shifts on the next edit. The dashboard was handing out references it knew would break.

**Delta view.** `scry-viz delta <before.wasm> <after.wasm>` compares two analyses by identity. It takes *modules*, not feeds, so the comparison cannot drift from the producer's key derivation.

It makes exactly one soundness claim, and it is a new one — **alias-free**. `ObligationId.v` proves aliasing needs a deleted same-kind sibling to inherit an ordinal from (`survivor_inherits_deleted_identity`), so a domain holding one member in *both* runs has nothing to inherit from. Strictly stronger than DD-021's refuted rule: a singleton domain rules aliasing out; an unchanged domain does not.

No discharge count is published, enforced by a test that greps the rendered page.

## 4. FEAT-073 — the self-adjudication harness

`scripts/self-history.sh` builds `scry_mcdc.wasm` at the last N commits and compares consecutive pairs. Runs in CI on every build. **It never gates**: the script exits 0 by construction, `continue-on-error` is belt to that braces, and `if-no-files-found: warn` keeps it from becoming a gate through the back door.

## 5. What the harness found on its first run — #123

A defect on **neither** #122's nine items nor DD-020's limitations.

Rust legacy mangling ends in `17h<16 hex>E` — a **symbol disambiguator** derived from crate metadata and instantiation, *not* from the function body. FEAT-064 prefers the name-section name, and `func_ident` is hashed into every key.

582cfb06 → 524b3e0b, functions carrying advisories:

| fate of the function's site set | count |
|---|---|
| kept **every** site | 410 |
| lost **every** site | **334** |
| **partial** | **0** |

Both repairs fail in opposite directions — raw name: 1.2% collision / **43% churn**; stripped: **0% churn** / 36% collision at up to 36 functions per name. So #123 states the measured trade and **recommends nothing**; picking one deserves its own decision record.

**This is upstream of #122.** Content-corroborating `site_key` cannot help while the ident hashed in before it churns.

**FEAT-064's AC#1 is recorded as falsified in practice** on Rust-produced modules. It passes the hand-written WAT fixture and fails on real toolchain output — the first FEAT-064 claim the fixture suite structurally could not have caught, because the defect is in the producer's output rather than in scry's logic. This blocks calling REQ-020 verified; it does not affect what has landed.

## Test discipline

The new oracles were **mutation-checked, not just run**: forcing `alias` to `AliasFree` kills only the alias test; deleting the anchor kills only the two anchor tests. Both vacuity directions are covered — self-comparison must show no change **and** a known-different pair must show one.

Two things were caught and corrected before shipping:
- The moved-sites table filtered on `changed()` (true for gone/new too) while the summary counted in-place changes, so the page could announce "7633 changed" above "0 changed". Fixed with a `fate` column and a reconciliation test.
- I expected ordinal shifts to masquerade as gone+new. The discriminating probe found **zero** partial-overlap functions. "A fix cannot present as `changed`" is recorded as an **open hypothesis with a named probe**, not as a finding.

135 tests · clippy `-D warnings` clean · `rivet validate` PASS · both workflows parse.