### PR TITLE
v3.2.5 (#125, #126): don't trap the host, and name every fallback

### DIFF
--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1442,3 +1442,50 @@ artifacts:
         target: REQ-001
       - type: traces-to
         target: REQ-017
+
+  - id: FEAT-075
+    type: feature
+    title: "v3.2.5 — Every unsoundness fallback names its operator (scry#126)"
+    status: proposed
+    release: v3.2.5
+    description: >
+      In avrabe's real-world corpus run (scry#126) the LARGEST bucket of
+      fallback diagnostics was not an operator at all: 579 of them said only
+      `<unsupported>`, more than any named operator including `i32.and` (433).
+      A consumer was told THAT analysis degraded but not WHAT caused it — the
+      diagnostic is non-actionable in exactly the case it exists for, and the
+      operator ranking that makes the precision work prioritisable had to be
+      reconstructed from outside rather than read off scry's own output.
+
+      ROOT CAUSE, and it is embarrassing in the useful way: the fix already
+      existed. `op_report_name()` falls back to the operator's Debug variant
+      name precisely so an unsupported op is still identified, and it was
+      already wired into the GAP records. The fallback DIAGNOSTIC used the
+      lower-level `op_name()`, which returns the literal `<unsupported>` for
+      anything outside its short hardcoded list. So the two surfaces disagreed
+      about the same event at the same pc: the gap named the operator and the
+      diagnostic did not.
+
+      This is a REQ-017 defect, not merely cosmetic. "No silent top" is not met
+      by a record that announces a degradation without identifying its cause —
+      an unnameable fallback is only marginally better than silence, and it is
+      worse than silence for an agent, which cannot ask a follow-up question.
+    tags: [diagnostics, observability, issue-driven, honesty, v3.2.5]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given a module containing an unmodelled operator, When analysis emits its unsoundness-fallback diagnostic, Then the message names the operator and never contains the literal `<unsupported>`."
+        - "Given the same site, When a consumer correlates the diagnostic with the gap record, Then both name the SAME operator — the surfaces may not disagree about one event."
+        - "MUTATION-CHECKED: reverting the one-word change reproduces the reporter's exact string, `unsupported operator at v0.2 AC#1: <unsupported> — locals degraded to top`, so the oracle is known to test the fix rather than the fixture."
+        - "NON-VACUITY, learned the hard way: the first version of this test used AnalysisConfig::default(), where emit_diagnostics is FALSE, so it asserted on an empty diagnostic set and would have passed against no fix at all. The second version asserted on the wrong operator — `f64.const` is itself unmodelled and takes the fallback first, and only ONE fallback fires per function. The fixture now makes the operator under test the only unmodelled one."
+      residual: >
+        This names the operators; it does not MODEL any of them. avrabe's
+        ranking (nop/drop/unreachable 215, the bitwise/shift family 597,
+        select 203) is the actual precision work and is not in this release.
+        What changes here is that the ranking becomes readable from scry's own
+        output instead of reconstructed by a third party.
+    links:
+      - type: traces-to
+        target: REQ-017
+      - type: traces-to
+        target: REQ-001

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1373,3 +1373,72 @@ artifacts:
         target: FEAT-064
       - type: traces-to
         target: DD-022
+
+  # ══════════════════════════════════════════════════════════════════════
+  # RELEASE v3.2.5 — "Do not trap the host" (patch, issue-driven)
+  # Cut ahead of v3.3.0 rather than folded into it: scry#125 is a crash in the
+  # RELEASED 3.2.4 that traps the guest, so a consumer is blocked TODAY and
+  # v3.3.0's scope is nowhere near closed. A single high-value fix is allowed
+  # to be its own release.
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: FEAT-074
+    type: feature
+    title: "v3.2.5 — A branch to the function label must not panic (scry#125)"
+    status: proposed
+    release: v3.2.5
+    description: >
+      `analyze` PANICKED with "index out of bounds: the len is 0 but the index
+      is 0" on valid, tiny modules from the official WebAssembly test suite —
+      reported by avrabe (scry#125) after running the released
+      scry-3.2.4-wasm32-wasip2.wasm over a 468-module real-world corpus, where
+      2 of 281 analysed modules crashed deterministically.
+
+      WHY A PANIC IS WORSE THAN AN ERROR HERE. The WIT signature is
+      `analyze: func(...) -> result<analysis-result, analyze-error>`, and
+      `analyze-error` exists precisely so an unanalysable module gets a
+      STRUCTURED refusal. A panic inside the component traps the guest, so the
+      host receives NEITHER arm of the result. The interface's own channel for
+      "I could not analyse this" is bypassed, and a consumer cannot distinguish
+      "scry declined" from "scry died".
+
+      ROOT CAUSE. `Interp::target()` resolves a branch's label with
+      `labels.len().saturating_sub(1 + relative_depth)` and then INDEXES. The
+      label stack is pushed only on ENTERING a block/loop/if, so the function
+      body's own implicit label is never on it — and a branch at function top
+      level (`br 0` with no enclosing region) indexes an empty slice.
+      `saturating_sub` guards `relative_depth >= n` but not `n == 0`.
+
+      SECOND DEFECT IN THE SAME LINE. The clamp was also wrong when it did NOT
+      panic: a branch that exits the function from inside a region (`(block br 1)`)
+      was clamped to index 0 and recorded the function-exit state into the
+      OUTERMOST region's label — a state that never arrives there. Over-approximate
+      and therefore sound, but attributed to the wrong label. `checked_sub` fixes
+      both: past every enclosing region means the function label, which is a
+      RETURN with no in-function successor to carry state to.
+
+      NOT A GAP. Returning `None` records nothing, and that is not an
+      unsoundness fallback: a return is fully modelled. Emitting a gap here
+      would inflate the gap report with an ordinary construct and make
+      REQ-017's "no silent top" surface less readable, not more.
+    tags: [robustness, crash, spec-suite, issue-driven, v3.2.5]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given a module whose function branches to the function label (`br 0` / `br_if 0` at top level, or `br 1` out of a single block), When analyze runs, Then it returns normally instead of panicking."
+        - "Given the two spec-suite sources the reporter named — test/core/func.wast and test/core/unwind.wast — When their first modules are analysed, Then neither traps. MEASURED before/after on the real sources: both PANICKED at HEAD; after the fix unwind.wast analyses cleanly (49 functions, 100 program points) and func.wast returns a STRUCTURED Internal error rather than a trap."
+        - "Given the fix, When the existing suite runs, Then no analyzer test regresses — the change alters which label a function-exiting branch records into, so a silent precision or soundness regression must be excluded rather than assumed."
+        - "REGRESSION ORACLE, written RED FIRST: issue125_branch_to_the_function_label_does_not_panic reproduced the reporter's exact message (`index out of bounds: the len is 0 but the index is 0`) at the same site from a one-line module BEFORE the fix, and covers every branch form that resolves a label — a fix guarding only `br` would leave `br_if` live."
+      residual: >
+        Fixing the panic UNMASKED a separate, pre-existing defect that the crash
+        was hiding: func.wast now reports `Internal("func 90 pc 7: i32 binop
+        with single operand")`. That is an operand-stack modelling defect, not a
+        crash, and it is filed separately rather than folded in here. Two
+        hypotheses were tested and REFUTED (a polymorphic stack after `br`, and
+        after `unreachable` — both analyse cleanly in isolation), so its cause is
+        recorded as uncharacterised rather than guessed at.
+    links:
+      - type: traces-to
+        target: REQ-001
+      - type: traces-to
+        target: REQ-017

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -5630,8 +5630,16 @@ fn interpret_op(
                     func_index,
                     pc,
                     message: format!(
+                        // scry#126: `op_report_name`, NOT `op_name`. The latter
+                        // returns the literal "<unsupported>" for anything
+                        // outside its small hardcoded list, which made the
+                        // LARGEST bucket of fallbacks in a real-world corpus
+                        // (579 of them) name nothing at all. The operator is
+                        // known here, the Debug-variant fallback already
+                        // existed, and the GAP record was already using it —
+                        // so the two surfaces disagreed about the same event.
                         "unsupported operator at v0.2 AC#1: {} — locals degraded to top",
-                        op_name(other)
+                        op_report_name(other)
                     ),
                 });
             }
@@ -8834,6 +8842,80 @@ mod tests {
         // And a branch nested one level deep that targets PAST its own region
         // out to the function label — depth 1 with a single pushed label.
         let _ = analyze_default("(module (func (export \"f\") (block br 1)))");
+    }
+
+    /// scry#126 (avrabe): 579 of the fallback diagnostics in a real-world
+    /// corpus — the LARGEST bucket, larger than any named operator — said only
+    /// `<unsupported>`. A consumer was told THAT analysis degraded but not WHAT
+    /// caused it, which makes the diagnostic non-actionable in exactly the case
+    /// it exists for.
+    ///
+    /// The operator is known at the point the fallback is raised, and the
+    /// naming helper already existed: `op_report_name` falls back to the Debug
+    /// variant name. It was wired into the GAP records but not into this
+    /// diagnostic, so the two surfaces disagreed about the same event.
+    #[test]
+    fn issue126_fallback_diagnostic_names_the_operator() {
+        // f64.add is outside the modelled set, so it takes the fallback path.
+        // `emit_diagnostics` is OFF in the default config, so the fallback
+        // diagnostic is never pushed — using analyze_default here made the test
+        // pass its own precondition vacuously the first time.
+        let r = analyze(
+            wat::parse_str(
+                "(module (func (param f64) (result f64) local.get 0 local.get 0 f64.add))",
+            )
+            .expect("assemble"),
+            AnalysisConfig {
+                emit_diagnostics: true,
+                ..Default::default()
+            },
+        )
+        .expect("analyze");
+        let fallbacks: Vec<&Diagnostic> = r
+            .diagnostics
+            .iter()
+            .filter(|d| d.severity == DiagnosticSeverity::UnsoundnessFallback)
+            .collect();
+        assert!(
+            !fallbacks.is_empty(),
+            "f64 ops must raise unsoundness fallbacks"
+        );
+        // The property that matters: NO fallback names a placeholder.
+        for d in &fallbacks {
+            assert!(
+                !d.message.contains("<unsupported>"),
+                "every fallback must name its operator: {:?}",
+                d.message
+            );
+        }
+        // Non-vacuity: it must name the operators actually present. `f64.const`
+        // is itself unmodelled and raises the FIRST fallback — asserting only
+        // on `F64Add` made this test fail against a working fix.
+        let all = fallbacks
+            .iter()
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        // Non-vacuity: it must name the operator actually present. Only ONE
+        // fallback fires per function (the scrub degrades the locals once), so
+        // the fixture makes f64.add the only unmodelled op — `local.get` is
+        // modelled; `f64.const` takes the fallback first and the test would
+        // otherwise assert on the wrong operator.
+        assert!(all.contains("F64Add"), "must name f64.add: {all}");
+        let d = fallbacks[0];
+        // The gap record already named it; the two surfaces must now agree, so
+        // a consumer correlating them does not see two different events.
+        let g = r
+            .gaps
+            .iter()
+            .find(|g| g.pc == d.pc && g.func_index == d.func_index)
+            .expect("the same site must carry a gap record");
+        assert!(
+            d.message.contains(&g.op),
+            "diagnostic {:?} must name the same operator as its gap {:?}",
+            d.message,
+            g.op
+        );
     }
 
     fn analyze_default(src: &str) -> AnalysisResult {

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -4047,11 +4047,10 @@ impl Interp<'_, '_> {
             // ── Branches: contribute to the targeted label ──────────
             match &self.ops[pc] {
                 Operator::Br { relative_depth } => {
-                    self.target(labels, *relative_depth).record(
-                        &ctx.locals,
-                        &ctx.octagon,
-                        &ctx.mem,
-                    );
+                    // `None` = the branch exits the function; nothing to record.
+                    if let Some(l) = self.target(labels, *relative_depth) {
+                        l.record(&ctx.locals, &ctx.octagon, &ctx.mem);
+                    }
                     return Ok(Flow::Diverged);
                 }
                 Operator::BrIf { relative_depth } => {
@@ -4059,11 +4058,11 @@ impl Interp<'_, '_> {
                     // locals reach the target, on the not-taken edge we fall
                     // through (both modelled — sound).
                     let _ = ctx.operand_stack.pop();
-                    self.target(labels, *relative_depth).record(
-                        &ctx.locals,
-                        &ctx.octagon,
-                        &ctx.mem,
-                    );
+                    // `None` = the taken edge exits the function; the
+                    // fall-through below is still modelled.
+                    if let Some(l) = self.target(labels, *relative_depth) {
+                        l.record(&ctx.locals, &ctx.octagon, &ctx.mem);
+                    }
                     pc += 1;
                     continue;
                 }
@@ -4119,11 +4118,30 @@ impl Interp<'_, '_> {
         Ok(Flow::Fall)
     }
 
-    /// The label a `br relative_depth` targets (innermost = depth 0).
-    fn target<'l>(&self, labels: &'l mut [Label], relative_depth: u32) -> &'l mut Label {
-        let n = labels.len();
-        let idx = n.saturating_sub(1 + relative_depth as usize);
-        &mut labels[idx]
+    /// The label a `br relative_depth` targets (innermost = depth 0), or `None`
+    /// when the branch leaves the FUNCTION rather than an enclosing region.
+    ///
+    /// scry#125: `labels` is pushed only on ENTERING a block/loop/if, so the
+    /// function body's own implicit label is never on it. A branch whose depth
+    /// reaches past every enclosing region therefore targets that label — which
+    /// is a RETURN, with no in-function successor to carry state to. `n == 0`
+    /// (a branch at function top level) is the degenerate case of the same
+    /// thing, and it used to index an empty slice and PANIC, trapping the guest
+    /// so the host got neither arm of `result<analysis-result, analyze-error>`.
+    ///
+    /// `checked_sub` rather than `saturating_sub` is deliberate and fixes a
+    /// second defect: clamping sent a branch that exits the function into the
+    /// OUTERMOST region's label, so `(block br 1)` recorded the function-exit
+    /// state as if it reached that block. Over-approximate, hence sound, but
+    /// attributed to a label the state never arrives at.
+    ///
+    /// Returning `None` records nothing, which is sound: the branch genuinely
+    /// leaves the function, so no in-function path is being dropped. It is not
+    /// a gap either — a return is fully modelled, and emitting one would
+    /// inflate the gap report with an ordinary construct.
+    fn target<'l>(&self, labels: &'l mut [Label], relative_depth: u32) -> Option<&'l mut Label> {
+        let idx = labels.len().checked_sub(1 + relative_depth as usize)?;
+        labels.get_mut(idx)
     }
 
     /// FEAT-016 slice-2b-i guard refinement, extended by FEAT-070 (REQ-020).
@@ -4226,8 +4244,9 @@ impl Interp<'_, '_> {
         // injecting it into the octagon would be redundant for projection).
         let mut taken_locals = ctx.locals.clone();
         taken_locals[local as usize] = AbstractValue::I32Interval(taken_iv);
-        self.target(labels, depth)
-            .record(&taken_locals, &ctx.octagon, &ctx.mem);
+        if let Some(l) = self.target(labels, depth) {
+            l.record(&taken_locals, &ctx.octagon, &ctx.mem);
+        }
 
         // Not-taken edge (guard false) → fall through.
         ctx.locals[local as usize] = AbstractValue::I32Interval(not_taken_iv);
@@ -4270,9 +4289,11 @@ impl Interp<'_, '_> {
         }
         let taken_oct = refine_octagon_rel(&ctx.octagon, a, b, op, true);
         let not_taken_oct = refine_octagon_rel(&ctx.octagon, a, b, op, false);
-        // Taken edge (guard true) → label D (locals unchanged).
-        self.target(labels, depth)
-            .record(&ctx.locals, &taken_oct, &ctx.mem);
+        // Taken edge (guard true) → label D (locals unchanged). `None` when
+        // that edge exits the function; the not-taken refinement still applies.
+        if let Some(l) = self.target(labels, depth) {
+            l.record(&ctx.locals, &taken_oct, &ctx.mem);
+        }
         // Not-taken edge (guard false) → fall through.
         ctx.octagon = not_taken_oct;
         Some(next)
@@ -8780,6 +8801,39 @@ mod tests {
         assert_eq!(res.function_meta.len(), 1);
         assert_eq!(res.function_meta[0].name, None, "no name source → None");
         assert!(!res.function_meta[0].imported);
+    }
+
+    /// scry#125 (avrabe): `analyze` PANICKED with "index out of bounds: the len
+    /// is 0 but the index is 0" on two valid spec-suite modules. A panic inside
+    /// the component TRAPS the guest, so a host gets neither arm of
+    /// `result<analysis-result, analyze-error>` — the interface's own channel
+    /// for "I could not analyse this" is bypassed entirely.
+    ///
+    /// Root cause: `target()` clamps `relative_depth` with `saturating_sub`, but
+    /// nothing guards `labels.len() == 0`. The label stack is pushed only when
+    /// ENTERING a block/loop/if, so the function body's own implicit label is
+    /// never on it — and a branch at function top level targets exactly that.
+    /// `unwind.wast`, one of the two reported modules, is the spec suite's test
+    /// for unwinding out of blocks, which is why it found this.
+    #[test]
+    fn issue125_branch_to_the_function_label_does_not_panic() {
+        // `br 0` with no enclosing region targets the function label = return.
+        let r = analyze_default("(module (func (export \"f\") br 0))");
+        assert_eq!(
+            r.function_meta.len(),
+            1,
+            "the function must still be analysed"
+        );
+
+        // The same shape for every branch form that resolves a label, since
+        // they share `target()` and a fix that guards only `br` would leave the
+        // others live.
+        let _ = analyze_default("(module (func (export \"f\") (param i32) local.get 0 br_if 0))");
+        let _ =
+            analyze_default("(module (func (export \"f\") (param i32) local.get 0 br_table 0 0))");
+        // And a branch nested one level deep that targets PAST its own region
+        // out to the function label — depth 1 with a single pushed label.
+        let _ = analyze_default("(module (func (export \"f\") (block br 1)))");
     }
 
     fn analyze_default(src: &str) -> AnalysisResult {


### PR DESCRIPTION
Fixes #125. Fixes the diagnostic half of #126.

Two issue-driven fixes from @avrabe's corpus run, cut as a **patch release ahead of v3.3.0** — #125 is a crash in the released 3.2.4, so a consumer is blocked today and v3.3.0's scope is nowhere near closed.

---

## FEAT-074 — a branch to the function label must not panic (#125)

**Why a panic is worse than an error.** The WIT signature is `analyze -> result<analysis-result, analyze-error>`, and `analyze-error` exists precisely so an unanalysable module gets a *structured refusal*. A panic traps the guest, so the host receives **neither arm** — a consumer cannot tell "scry declined" from "scry died".

**Root cause.**

```rust
let idx = labels.len().saturating_sub(1 + relative_depth as usize);
&mut labels[idx]        // len 0 ⇒ idx 0 ⇒ panic
```

The label stack is pushed only on **entering** a block/loop/if, so the function body's own implicit label is never on it. `br 0` at function top level indexes an empty slice. `saturating_sub` guards `relative_depth >= n` but **not** `n == 0`. Your guess — "an operand-stack or block-frame lookup on an empty stack" — was right in shape; it's the *label* stack.

**A second defect in the same line.** The clamp was also wrong when it *didn't* panic: `(block br 1)` exits the function, but clamping sent it to index 0, recording the function-exit state into the **outermost region's label** — a state that never arrives there. Sound, but attributed to a label it cannot reach. `checked_sub` fixes both.

**Verified on your sources, before and after.** `pulseengine/w2c2` wasn't reachable, so I went to what those files are generated from. Both contain the triggering shape verbatim (`func.wast:150`, `unwind.wast:7`). Against a worktree at the pre-fix commit:

| module | before | after |
|---|---|---|
| `unwind.wast` | **PANIC** | **OK** — 49 functions, 100 program points |
| `func.wast` | **PANIC** | `Internal("func 90 pc 7: i32 binop with single operand")` — structured |

That residual is filed as #128 — the crash was hiding it. I tested two hypotheses for it and **refuted both**, so its cause is recorded as uncharacterised rather than guessed at.

---

## FEAT-075 — every unsoundness fallback names its operator (#126)

Your largest bucket wasn't an operator: **579 fallbacks said only `<unsupported>`**, more than `i32.and` at 433.

**The fix already existed.** `op_report_name()` falls back to the Debug variant name precisely so an unsupported op is still identified — and it was already wired into the **gap** records. The **diagnostic** used the lower-level `op_name()`. So the two surfaces disagreed about the same event at the same pc.

I'm treating this as a **REQ-017 defect**, not a cosmetic one: "no silent ⊤" isn't met by a record that announces a degradation without identifying its cause. An unnameable fallback is marginally better than silence for a human and *worse* than silence for an agent, which can't ask a follow-up.

This **names** the operators; it doesn't **model** any. Your ranking — nop/drop/unreachable (215), the bitwise/shift family (597), select (203) — is the real precision work and isn't in this release. What changes is that the ranking becomes readable from scry's own output instead of reconstructed from outside.

---

## Test discipline

Both oracles were written **red first**. Worth stating plainly: the #126 test was **vacuous twice** before it was right.

1. It used `AnalysisConfig::default()`, where `emit_diagnostics` is **false** — it asserted over an empty diagnostic set and would have passed against no fix at all.
2. It then asserted on `F64Add`, but `f64.const` is itself unmodelled and takes the fallback first, and only **one** fallback fires per function. It failed against a *working* fix.

Both fixes are **mutation-checked**: reverting each reproduces the reporter's exact symptom.

104 core tests + 34 viz · clippy `-D warnings` clean · `rivet validate` PASS.