### PR TITLE
FEAT-076 (#132, #133): the release machinery stops failing silently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,6 +354,11 @@ jobs:
       WITNESS_REV: 6ff96e75a1b495aa165f1ee91abda3049fffe628
     steps:
       - uses: actions/checkout@v6
+        with:
+          # scry#132: the delta view resolves the PREVIOUS tag, so this job
+          # needs tags and history. Without it `git tag --list` is empty and the
+          # step silently rendered nothing (delta.html 404 on v3.2.5).
+          fetch-depth: 0
 
       - name: Resolve version from tag
         env:
@@ -424,21 +429,39 @@ jobs:
       - name: Render release delta vs the previous tag (FEAT-072)
         continue-on-error: true
         run: |
+          # scry#132: every exit path MUST print why. The first version of this
+          # step produced ZERO output and a 404: GitHub's default shell is
+          # `bash -e`, `set -uo pipefail` does not turn that off, and `grep -v`
+          # exits 1 on empty input — so it aborted on the PREV= line, before the
+          # "no previous tag" message it was supposed to print. A
+          # continue-on-error step that says nothing is indistinguishable from
+          # one that never ran, which is how this shipped broken in v3.2.5.
           set -uo pipefail
-          PREV="$(git tag --list 'v*' --sort=-v:refname | grep -v "^${VERSION}$" | head -1)"
+          status() { echo "DELTA-STEP: $1"; }
+          PREV="$(git tag --list 'v*' --sort=-v:refname | grep -v "^${VERSION}$" | head -1 || true)"
           if [[ -z "$PREV" ]]; then
-            echo "no previous tag — skipping the delta view (first release)"; exit 0
+            status "SKIPPED — no previous tag found (tags fetched: $(git tag --list 'v*' | wc -l | tr -d ' '))"
+            exit 0
           fi
-          echo "delta: $PREV -> $VERSION"
+          status "rendering $PREV -> $VERSION"
           WT="$(mktemp -d)/prev"
-          git worktree add --detach -q "$WT" "$PREV" || exit 0
-          ( cd "$WT/crates/scry-mcdc" && cargo build --release --target wasm32-wasip1 -q ) || exit 0
+          if ! git worktree add --detach -q "$WT" "$PREV"; then
+            status "SKIPPED — cannot check out $PREV"; exit 0
+          fi
+          if ! ( cd "$WT/crates/scry-mcdc" && cargo build --release --target wasm32-wasip1 -q ); then
+            status "SKIPPED — $PREV does not build"; exit 0
+          fi
           cargo run --release -p scry-sai-viz -- delta \
             "$WT/crates/scry-mcdc/target/wasm32-wasip1/release/scry_mcdc.wasm" \
             crates/scry-mcdc/target/wasm32-wasip1/release/scry_mcdc.wasm \
             -o "$GITHUB_WORKSPACE/dist/delta.html" \
             --title "${PREV} → ${VERSION} (by stable obligation identity)"
           git worktree remove --force "$WT" 2>/dev/null || true
+          if [[ -s "$GITHUB_WORKSPACE/dist/delta.html" ]]; then
+            status "OK — wrote dist/delta.html ($(wc -c <"$GITHUB_WORKSPACE/dist/delta.html" | tr -d ' ') bytes)"
+          else
+            status "FAILED — the renderer produced no dist/delta.html"
+          fi
 
       - name: Build landing page (scry-viz index)
         run: |

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1489,3 +1489,68 @@ artifacts:
         target: REQ-017
       - type: traces-to
         target: REQ-001
+
+  # ══════════════════════════════════════════════════════════════════════
+  # RELEASE v3.2.6 — "The release machinery holds itself to the standard"
+  # Accumulating. Both items are defects in OUR OWN tooling found while
+  # shipping v3.2.5, and both are the failure mode this project spends its
+  # time arguing against: a thing that reports success while doing nothing.
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: FEAT-076
+    type: feature
+    title: "v3.2.6 — The release machinery stops failing silently (scry#132, #133)"
+    status: proposed
+    release: v3.2.6
+    description: >
+      Two defects found by inspecting what v3.2.5 ACTUALLY shipped rather than
+      what CI said about it. Neither was caught by a gate, because both live in
+      places no gate looks.
+
+      scry#133 — SCRY_VERSION WAS A HAND-MAINTAINED LITERAL. The v3.2.5 bump
+      moved the workspace version and all 11 inter-crate pins; a `const
+      SCRY_VERSION: &str = "3.2.4"` was invisible to that sweep, so the shipped
+      3.2.5 component emitted `"scry 3.2.4 — ..."` in its own diagnostics.
+      Consumers identify the producing analyzer from that string, and BOTH
+      issues fixed in v3.2.5 were reported against a specific released version —
+      a component that misidentifies itself sends the next report to the wrong
+      build. Now `env!("CARGO_PKG_VERSION")`: derived, not maintained.
+      This is the drift class claims.yaml gates (#97) — but that gate reads
+      DOCS, and cannot see a Rust string literal. Deriving the value is what
+      closes it; the test only keeps it derived.
+
+      scry#132 — THE DELTA VIEW NEVER RENDERED, AND SAID NOTHING. FEAT-072's
+      release-over-release page 404'd on v3.2.5. Two compounding causes: the
+      publish-pages job checks out WITHOUT `fetch-depth: 0`, so no tags exist;
+      and `grep -v` exits 1 on empty input under GitHub's default `bash -e`
+      shell, which `set -uo pipefail` does NOT disable — so the step aborted on
+      the `PREV=` line, BEFORE the "no previous tag" message it was written to
+      print. Reproduced mechanically rather than assumed: `bash -e -c 'set -uo
+      pipefail; X="$(echo -n "" | grep -v "^v9$")"; echo reached'` exits 1 with
+      no output; adding `|| true` reaches the echo.
+
+      THE SHARED LESSON, and why these ship together. I wrote
+      `continue-on-error` and `|| exit 0` guards specifically so a missing
+      previous tag would degrade gracefully instead of blocking a release. What
+      they produced was a SILENT failure: green job, shipped release, missing
+      page, nothing anywhere saying the feature had not run. That is the same
+      defect class as scry#126's `<unsupported>` fallback — announcing a
+      degradation without identifying it — and it violates DD-022's own rule
+      that observation modes be properties of the code rather than conventions.
+      The rule was applied to the analyzer and broken in the release machinery
+      in the same session.
+    tags: [release-machinery, honesty, observability, issue-driven, v3.2.6]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given any build of scry-sai-core, When it reports its version in a diagnostic, Then the string equals the crate's package version — asserted by issue133_scry_version_is_derived_from_the_package_version, which was RED before the fix (left \"3.2.4\", right \"3.2.5\")."
+        - "Given the publish-pages job, When it runs, Then it has the git history the delta view needs (`fetch-depth: 0`), and EVERY exit path of the delta step prints a `DELTA-STEP:` line stating OK / SKIPPED-with-reason / FAILED. A continue-on-error step that produces no output must be treated as a defect, not as a skip."
+        - "Given the next release, When it completes, Then delta.html returns 200 on the live site OR the job log states explicitly why it was skipped. NOT YET VERIFIABLE — this AC can only be discharged by an actual release, and must not be marked met before one."
+      residual: >
+        scry#130 — main has NO required_status_checks, so the CI gate is
+        advisory rather than enforced. That is the root reason a silently broken
+        step could ship: nothing structural stops a red or vacuous check. It
+        needs repo-admin rights and is deliberately NOT bundled here.
+    links:
+      - type: traces-to
+        target: REQ-017

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -888,7 +888,13 @@ mod domain {
         scry_taint::join(a, b)
     }
 }
-const SCRY_VERSION: &str = "3.2.4";
+/// scry#133: DERIVED, never hand-maintained. This was a literal, the v3.2.5
+/// bump missed it, and the shipped 3.2.5 component reported itself as 3.2.4 in
+/// its own diagnostics. Consumers identify the producing analyzer from this
+/// string, so a stale value misattributes bug reports to the wrong build.
+/// `env!` resolves at compile time from the crate's version, which the
+/// workspace sets — so it cannot drift from the published version again.
+const SCRY_VERSION: &str = env!("CARGO_PKG_VERSION");
 const INVARIANT_SCHEMA_URL: &str = "https://pulseengine.eu/scry-invariants/v1";
 
 /// Default Wasm linear-memory page size (64 KiB).
@@ -8963,6 +8969,33 @@ mod tests {
                 d.message
             );
         }
+    }
+
+    /// scry#133: `SCRY_VERSION` was a hand-maintained literal and the v3.2.5
+    /// bump missed it, so the SHIPPED 3.2.5 component emitted
+    /// `"scry 3.2.4 — wasm-lattice cross-component import alive"`. Consumers
+    /// use that string to identify which analyzer produced a result, and both
+    /// #125 and #126 were reported against a specific released version — a
+    /// component that misreports itself sends a bug report to the wrong build.
+    ///
+    /// This is the same drift class `claims.yaml` gates in the docs (#97), but
+    /// the claim-check gate cannot see a Rust string literal. Deriving the
+    /// value is what actually closes it; this test only proves it stays derived.
+    #[test]
+    fn issue133_scry_version_is_derived_from_the_package_version() {
+        assert_eq!(
+            SCRY_VERSION,
+            env!("CARGO_PKG_VERSION"),
+            "SCRY_VERSION must be derived, not hand-maintained — a literal drifts \
+             silently and ships a component that misidentifies itself"
+        );
+        // Non-vacuity: a bare `assert_eq!(X, X)` would pass on any value, so
+        // pin the shape too — the released artifact showed this string verbatim.
+        assert!(
+            SCRY_VERSION.split('.').count() == 3
+                && SCRY_VERSION.split('.').all(|p| p.parse::<u32>().is_ok()),
+            "expected a three-part numeric version, got {SCRY_VERSION:?}"
+        );
     }
 
     fn analyze_default(src: &str) -> AnalysisResult {


### PR DESCRIPTION
Two defects found by inspecting what v3.2.5 **actually shipped**, rather than what CI said about it. Neither was caught by a gate, because both live where no gate looks.

## #133 — `SCRY_VERSION` was a hand-maintained literal

The v3.2.5 bump moved the workspace version and all 11 inter-crate pins. `const SCRY_VERSION: &str = "3.2.4"` was invisible to that sweep, so the shipped 3.2.5 component emitted **"scry 3.2.4"** in its own diagnostics.

That matters more than a cosmetic string: consumers identify the producing analyzer from it, and *both* issues fixed in v3.2.5 were reported against a specific released version. A component that misidentifies itself sends the next report to the wrong build.

Now `env!("CARGO_PKG_VERSION")` — derived, not maintained. The test was **red first** and showed the drift directly (`left: "3.2.4"`, `right: "3.2.5"`). Swept for other hand-written version literals in Rust: none.

This is the drift class `claims.yaml` gates (#97) — but that gate reads *docs* and cannot see a Rust string literal.

## #132 — the delta view never rendered, and said nothing

FEAT-072's release-over-release page 404'd on v3.2.5. Two compounding causes:

1. `publish-pages` checks out **without `fetch-depth: 0`**, so no tags exist.
2. `grep -v` exits 1 on empty input under GitHub's default `bash -e` shell — which `set -uo pipefail` does **not** disable. The step aborted on the `PREV=` line, *before* the "no previous tag" message it was written to print.

Reproduced mechanically rather than assumed:

```
bash -e -c 'set -uo pipefail; X="$(echo -n "" | grep -v "^v9$")"; echo reached'
  → exit 1, no output          ← the shipped failure mode
... | grep -v "^v9$" || true
  → exit 0, "reached"          ← the fix
```

Every exit path now prints a `DELTA-STEP:` line — `OK` with a byte count, `SKIPPED` with a reason, or `FAILED`. **A `continue-on-error` step that produces no output is indistinguishable from one that never ran**, which is exactly how this shipped broken.

## The shared lesson

I wrote `continue-on-error` and `|| exit 0` specifically so a missing previous tag would degrade *gracefully* instead of blocking a release. What they produced was a **silent** failure: green job, shipped release, missing page, nothing anywhere saying the feature hadn't run.

Same defect class as #126's `<unsupported>` fallback — announcing a degradation without identifying it — and it breaks DD-022's own rule that observation modes be *properties of the code* rather than conventions. Applied to the analyzer and broken in the release machinery, in the same session.

## One AC deliberately not claimed

`delta.html` returning 200 can only be discharged by an actual release. It is written into FEAT-076 as **not yet verifiable** rather than marked met.

## Residual

#130 — `main` has no `required_status_checks`, so the CI gate is advisory. That's the root reason a silently broken step could ship at all. Needs repo-admin, deliberately not bundled here.

106 core + 34 viz tests · clippy `-D warnings` clean · `rivet validate` PASS · claim-check 5/5 · `release.yml` parses.