### PR TITLE
FEAT-077 (#123): two-tier function identity — unique stripped name, else raw name marked build-local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ### Added — scry-sai-core
 
-- **FEAT-076 (scry#123): two-tier function identity.** `func_ident` — the
+- **FEAT-077 (scry#123): two-tier function identity.** `func_ident` — the
   first component of `obligation_id` / `site_key` / `group_key` — no longer
   hashes Rust's legacy-mangling symbol disambiguator (`17h<16 hex>E`), which
   derives from crate metadata and re-rolls on any upstream edit (measured:
@@ -25,7 +25,7 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ### Changed — scry-sai-viz
 
-- **Guidance feed schema v3** (FEAT-076): every advisory now carries
+- **Guidance feed schema v3** (FEAT-077): every advisory now carries
   `id_build_local`; the HTML guidance row shows a `build-local id` badge; the
   FEAT-072 delta view carries a per-row `build_local` flag, a
   `build_local_sites` summary count (JSON + page), and discloses that a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added — scry-sai-core
+
+- **FEAT-076 (scry#123): two-tier function identity.** `func_ident` — the
+  first component of `obligation_id` / `site_key` / `group_key` — no longer
+  hashes Rust's legacy-mangling symbol disambiguator (`17h<16 hex>E`), which
+  derives from crate metadata and re-rolls on any upstream edit (measured:
+  raw-name survival 54.8% across an unrelated one-commit edit, 54.9% across an
+  own-body edit — the identity was destroyed by the very edit it exists to
+  survive). A name whose disambiguator-stripped form is UNIQUE within the
+  module uses the stripped name (measured 100% stable across both edit kinds);
+  a shared stripped form (dependency generics — 37.8% of functions, none of
+  scry's own) falls back to the raw name and the advisory is marked with the
+  new `Advisory::id_build_local` flag: unique within this build, not
+  comparable across builds. Names with no disambiguator, export names, and the
+  body-shape-hash fallback are byte-identical to v3.2.5 (regression-pinned).
+
+### Changed — scry-sai-viz
+
+- **Guidance feed schema v3** (FEAT-076): every advisory now carries
+  `id_build_local`; the HTML guidance row shows a `build-local id` badge; the
+  FEAT-072 delta view carries a per-row `build_local` flag, a
+  `build_local_sites` summary count (JSON + page), and discloses that a
+  build-local site vanishing/appearing between builds is expected identity
+  churn, not evidence a site came or went.
+
+
 ## [3.2.5] — 2026-08-21
 
 Issue-driven patch, cut ahead of v3.3.0. Both defects were reported by a user

--- a/artifacts/design.yaml
+++ b/artifacts/design.yaml
@@ -663,7 +663,12 @@ artifacts:
             therefore keep only a build-local identity — honest and visible,
             but not comparable across builds; a stable identity there needs
             stable-name PLUS instantiation disambiguation, a synthesis that
-            needs its own design decision.
+            needs its own design decision. A second, theoretical residual
+            (clean-room): the uniqueness count covers named functions only, so
+            a stripped name that is itself exactly 16 lowercase hex characters
+            could collide with an UNNAMED function's body-shape hash — real
+            Rust legacy symbols start `_ZN…` and are never pure hex, so this
+            needs a hand-crafted name plus a SHA-256-prefix coincidence.
       alternatives: >
         (a) Source-line identity via DWARF — rejected as the primary: scry
             analyses Wasm binaries that frequently carry no DWARF, and it would

--- a/artifacts/design.yaml
+++ b/artifacts/design.yaml
@@ -590,7 +590,7 @@ artifacts:
         An obligation ID is a content address over four components, in this
         order: (1) FUNCTION IDENTITY — the name-section name if present, else the
         export name, else a hash of the function body's structural shape (opcode
-        sequence with immediates elided). AMENDED 2026-08-25 (FEAT-076,
+        sequence with immediates elided). AMENDED 2026-08-25 (FEAT-077,
         scry#123): a name-section name carrying Rust's `17h<16 hex>E`
         disambiguator is used STRIPPED when the stripped form is unique within
         the module; when it is not unique the raw name is kept and the advisory
@@ -650,12 +650,12 @@ artifacts:
             opened and the paths below are wrong for exception-handling modules.
             Tracked; no panic and no intra-function collision.
         (6) DISAMBIGUATOR CHURN (scry#123, measured by FEAT-073's first run;
-            REPAIRED in part by FEAT-076). The name-section name inherits Rust
+            REPAIRED in part by FEAT-077). The name-section name inherits Rust
             legacy mangling's `17h<16 hex>E` symbol disambiguator, derived from
             crate metadata rather than the body — raw-name survival across an
             unrelated one-commit edit measured 54.8%, and 54.9% across an edit
             to the function's OWN body, so the raw name is destroyed by the
-            very edit the identity exists to survive. FEAT-076 makes function
+            very edit the identity exists to survive. FEAT-077 makes function
             identity two-tier: the stripped name when unique within the module
             (measured 100% stable), else the raw name with the advisory marked
             `id_build_local: true`. RESIDUAL: 37.8% of functions (all

--- a/artifacts/design.yaml
+++ b/artifacts/design.yaml
@@ -590,7 +590,11 @@ artifacts:
         An obligation ID is a content address over four components, in this
         order: (1) FUNCTION IDENTITY — the name-section name if present, else the
         export name, else a hash of the function body's structural shape (opcode
-        sequence with immediates elided); (2) STRUCTURAL PATH — the chain of
+        sequence with immediates elided). AMENDED 2026-08-25 (FEAT-076,
+        scry#123): a name-section name carrying Rust's `17h<16 hex>E`
+        disambiguator is used STRIPPED when the stripped form is unique within
+        the module; when it is not unique the raw name is kept and the advisory
+        is marked `id_build_local` — see limitation (6); (2) STRUCTURAL PATH — the chain of
         enclosing block/loop/if indices from the function root, NOT raw pcs;
         (3) OPERATOR KIND — e.g. `i32.load`, `i32.div_s`; (4) ORDINAL — the
         operator's index among same-kind operators within its own basic block.
@@ -645,6 +649,21 @@ artifacts:
             not treated as path markers, so their `End` pops a region they never
             opened and the paths below are wrong for exception-handling modules.
             Tracked; no panic and no intra-function collision.
+        (6) DISAMBIGUATOR CHURN (scry#123, measured by FEAT-073's first run;
+            REPAIRED in part by FEAT-076). The name-section name inherits Rust
+            legacy mangling's `17h<16 hex>E` symbol disambiguator, derived from
+            crate metadata rather than the body — raw-name survival across an
+            unrelated one-commit edit measured 54.8%, and 54.9% across an edit
+            to the function's OWN body, so the raw name is destroyed by the
+            very edit the identity exists to survive. FEAT-076 makes function
+            identity two-tier: the stripped name when unique within the module
+            (measured 100% stable), else the raw name with the advisory marked
+            `id_build_local: true`. RESIDUAL: 37.8% of functions (all
+            dependency generics, none of scry's own) share a stripped name and
+            therefore keep only a build-local identity — honest and visible,
+            but not comparable across builds; a stable identity there needs
+            stable-name PLUS instantiation disambiguation, a synthesis that
+            needs its own design decision.
       alternatives: >
         (a) Source-line identity via DWARF — rejected as the primary: scry
             analyses Wasm binaries that frequently carry no DWARF, and it would

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1037,7 +1037,7 @@ artifacts:
     fields:
       phase: phase-3
       acceptance-criteria:
-        - "Given a module and an edit that changes code in an unrelated function, When scry re-analyzes, Then every obligation ID outside the edited function is unchanged. FALSIFIED IN PRACTICE on Rust-produced modules (measured 2026-08-20 by FEAT-073, scry#123) — holds only for functions whose name-section name is itself stable. It is met by the unit fixture and NOT met by real toolchain output; see the AC below, which states what was measured. REPAIR: FEAT-076 (v3.4.0) makes the identity two-tier — the disambiguator-stripped name when unique in the module (measured 100% stable across both edit kinds), else the raw name explicitly marked `id_build_local` — so this AC holds for uniquely-named functions (every scry-own function in the measurement) and degrades HONESTLY, not silently, for the rest."
+        - "Given a module and an edit that changes code in an unrelated function, When scry re-analyzes, Then every obligation ID outside the edited function is unchanged. FALSIFIED IN PRACTICE on Rust-produced modules (measured 2026-08-20 by FEAT-073, scry#123) — holds only for functions whose name-section name is itself stable. It is met by the unit fixture and NOT met by real toolchain output; see the AC below, which states what was measured. REPAIR: FEAT-077 (v3.4.0) makes the identity two-tier — the disambiguator-stripped name when unique in the module (measured 100% stable across both edit kinds), else the raw name explicitly marked `id_build_local` — so this AC holds for uniquely-named functions (every scry-own function in the measurement) and degrades HONESTLY, not silently, for the rest."
         - "MEASURED, not assumed (FEAT-073 over scry's own history, commits 582cfb06→524b3e0b). Given two builds of the same Rust source differing by an unrelated edit, When identities are compared, Then 334 of 744 functions carrying advisories (45%) lose EVERY obligation identity and 410 keep every one — an all-or-nothing split with ZERO partial cases. Cause: Rust legacy mangling ends in `17h<16 hex>E`, a symbol disambiguator derived from crate metadata and instantiation rather than from the function body, so an unrelated edit renames the function. `func_ident` is the first component of every key, so the churn takes the whole function's obligations with it."
         - "OPEN, deliberately not claimed: whether a genuine FIX presents as a changed obligation at a surviving site. Across 7 consecutive commit pairs of scry's own history, ZERO shared sites changed their obligation set. That is a fact about the SAMPLE — scry's commits alter analyzer logic, which recompiles into different monomorphizations — and must not be restated as a structural claim without a fixture that isolates it."
         - "Given an edit that inserts instructions EARLIER in the same function AND the inserted code contains no operator of the same kind in the same region and opens no new block/loop/if at the same-or-shallower depth, When scry re-analyzes, Then obligation IDs for later sites in that function are unchanged (pc-shift immunity). QUALIFIED after clean-room review: the unrestricted form of this AC is FALSE — see DD-020's limitation section. The original wording was met only by a fixture selected around the failing case."
@@ -1554,7 +1554,8 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-017
-  - id: FEAT-076
+
+  - id: FEAT-077
     type: feature
     title: "v3.4 — Two-tier function identity: unique stripped name, else raw name marked build-local (scry#123)"
     status: implemented

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1037,7 +1037,7 @@ artifacts:
     fields:
       phase: phase-3
       acceptance-criteria:
-        - "Given a module and an edit that changes code in an unrelated function, When scry re-analyzes, Then every obligation ID outside the edited function is unchanged. FALSIFIED IN PRACTICE on Rust-produced modules (measured 2026-08-20 by FEAT-073, scry#123) — holds only for functions whose name-section name is itself stable. It is met by the unit fixture and NOT met by real toolchain output; see the AC below, which states what was measured."
+        - "Given a module and an edit that changes code in an unrelated function, When scry re-analyzes, Then every obligation ID outside the edited function is unchanged. FALSIFIED IN PRACTICE on Rust-produced modules (measured 2026-08-20 by FEAT-073, scry#123) — holds only for functions whose name-section name is itself stable. It is met by the unit fixture and NOT met by real toolchain output; see the AC below, which states what was measured. REPAIR: FEAT-076 (v3.4.0) makes the identity two-tier — the disambiguator-stripped name when unique in the module (measured 100% stable across both edit kinds), else the raw name explicitly marked `id_build_local` — so this AC holds for uniquely-named functions (every scry-own function in the measurement) and degrades HONESTLY, not silently, for the rest."
         - "MEASURED, not assumed (FEAT-073 over scry's own history, commits 582cfb06→524b3e0b). Given two builds of the same Rust source differing by an unrelated edit, When identities are compared, Then 334 of 744 functions carrying advisories (45%) lose EVERY obligation identity and 410 keep every one — an all-or-nothing split with ZERO partial cases. Cause: Rust legacy mangling ends in `17h<16 hex>E`, a symbol disambiguator derived from crate metadata and instantiation rather than from the function body, so an unrelated edit renames the function. `func_ident` is the first component of every key, so the churn takes the whole function's obligations with it."
         - "OPEN, deliberately not claimed: whether a genuine FIX presents as a changed obligation at a surviving site. Across 7 consecutive commit pairs of scry's own history, ZERO shared sites changed their obligation set. That is a fact about the SAMPLE — scry's commits alter analyzer logic, which recompiles into different monomorphizations — and must not be restated as a structural claim without a fixture that isolates it."
         - "Given an edit that inserts instructions EARLIER in the same function AND the inserted code contains no operator of the same kind in the same region and opens no new block/loop/if at the same-or-shallower depth, When scry re-analyzes, Then obligation IDs for later sites in that function are unchanged (pc-shift immunity). QUALIFIED after clean-room review: the unrestricted form of this AC is FALSE — see DD-020's limitation section. The original wording was met only by a fixture selected around the failing case."
@@ -1554,3 +1554,66 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-017
+  - id: FEAT-076
+    type: feature
+    title: "v3.4 — Two-tier function identity: unique stripped name, else raw name marked build-local (scry#123)"
+    status: implemented
+    release: v3.4.0
+    description: >
+      The repair for the MEASURED identity-churn defect (scry#123, FEAT-073's
+      first run): `func_ident` — the FIRST component hashed into
+      `obligation_id` / `site_key` / `group_key` — inherited Rust legacy
+      mangling's trailing `17h<16 hex>E` symbol disambiguator, which derives
+      from crate metadata and instantiation, NOT the function body. Measured on
+      real builds of scry_mcdc.wasm: raw-name survival across an UNRELATED
+      one-commit edit was 54.8%, and across an edit to a function's OWN body
+      54.9% — the identity was destroyed by the very edit it exists to survive.
+      Stripping the suffix is 100% stable on ground-truth-paired functions but
+      makes 37.8% of functions share a stripped name (max multiplicity 39) —
+      ALL of them dependency generics; ZERO of scry's own functions collide.
+      Neither tier alone is acceptable, so the identity is TWO-TIER and honest
+      about which tier it used:
+        1. the stripped name, IF unique within the module (stable across
+           builds — the common case, and every scry-own function);
+        2. otherwise today's raw name (unique within one build), with the
+           advisory MARKED `id_build_local: true` — its identity keys are NOT
+           comparable across builds, and a consumer can tell WITHOUT parsing
+           the id.
+      Only the exact shape `17h` + 16 lowercase hex + `E` is stripped; the
+      uniqueness check counts stripped AND plain candidates, so a stripped name
+      landing on an existing plain name is also rejected. Names with no
+      disambiguator, export-derived names, and the body-shape-hash fallback are
+      byte-identical to v3.2.5 (regression-pinned against ids captured from the
+      unmodified code). Surfaced end-to-end: `Advisory.id_build_local`,
+      guidance feed v3 (`id_build_local` on every advisory), an HTML
+      "build-local id" badge, and the FEAT-072 delta view (per-row
+      `build_local`, a summary count, and a disclosure that such rows are
+      expected churn, not evidence a site came or went).
+    tags: [ai-agent, identity, fix-verify-loop, issue-driven, honesty, v3.4]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given two builds whose function names differ ONLY in the `17h<16 hex>E` disambiguator (the measured churn), When the stripped name is unique within the module, Then every obligation id in that function is unchanged and NOT marked build-local. RED-FIRST: on the unmodified code this failed with ids 848ca91acb777c5d != 542c78e69e6c2622."
+        - "Given two functions whose names differ only in the disambiguator (two monomorphizations of one generic, identical bodies), When identities are stamped, Then they do NOT collapse onto one identity — the raw name keeps them apart within the build — and BOTH are marked `id_build_local: true`."
+        - "Given a stripped name that collides with another function's PLAIN name (`foo17h…E` vs `foo`), When identities are stamped, Then the disambiguated function falls back to its raw name marked build-local and the plain-named function keeps its stable identity — uniqueness is counted over stripped AND plain candidates."
+        - "Given a name whose suffix is a NEAR MISS (uppercase hex, or 15 digits), When identities are stamped, Then nothing is stripped: the id tracks the raw name exactly as in v3.2.5 and is not marked. MUTATION-CHECKED: widening the shape to accept uppercase hex turns exactly this test red."
+        - "Given a plain name (`compute`) or an unnamed function (body-shape-hash fallback), When identities are stamped, Then the obligation id is BYTE-IDENTICAL to v3.2.5 — pinned against constants (dd7c4231ce161f87 / 4f61c85b63648dc7) captured from the unmodified code on main (5cd2a89) before the change."
+        - "Given the guidance feed, When rendered, Then `guidance_schema` is 3 and every advisory carries `id_build_local` — a consumer can tell a stable id from a build-local one without parsing the id (FEAT-068 versioning discipline). The delta view carries the flag per row plus a summary count, and its page discloses that a build-local site vanishing/appearing between builds is expected churn."
+        - "MUTATION-CHECKED, five mutants all killed by exactly the intended tests and nothing else: (M1) stripping disabled -> 3 core tests red; (M2) uniqueness check dropped -> the two collision tests red; (M3) uppercase hex accepted -> the exact-shape test red; (M4) marking suppressed -> 2 core + all 3 viz tests red; (M5) everything marked -> 5 core + 3 viz tests red."
+      residual: >
+        Build-local identities remain build-local: for the ~37.8% of functions
+        (all dependency generics) sharing a stripped name there is still no
+        cross-build identity — a stable identity there needs the stable name
+        PLUS instantiation disambiguation, which is its own design decision
+        (noted in scry#123). The marking makes the limitation visible instead
+        of letting a consumer diff churn. The delta view treats such rows as
+        non-evidence; the FEAT-065 adjudicator (REQ-021) must treat a
+        build-local identity as at most `uncertain`. Measured collision figures
+        are from scry's own binary; other corpora may differ in degree, not in
+        the all-collisions-are-dependency-generics mechanism (unverified
+        elsewhere).
+    links:
+      - type: traces-to
+        target: REQ-020
+      - type: traces-to
+        target: REQ-021

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -698,6 +698,22 @@ pub struct Advisory {
     /// rule aliasing out — the pairing of a deletion with a same-kind insertion
     /// leaves the group unchanged, which is precisely what falsified DD-021.
     pub group_key: String,
+    /// FEAT-076 (scry#123, DD-020): TRUE when this advisory's identity keys
+    /// (`obligation_id` / `site_key` / `group_key`) are BUILD-LOCAL — unique
+    /// within THIS analysis but NOT comparable across builds of the same
+    /// source. Set when the function's name-section name carries a Rust legacy
+    /// symbol disambiguator (`17h<16 hex>E`) whose stripped form is shared by
+    /// another function in the module (dependency generics, measured at 37.8%
+    /// of functions on scry's own binary): the disambiguator cannot be dropped
+    /// without merging distinct monomorphizations onto one identity, so the
+    /// raw name — which churns with crate metadata — is kept, and this flag
+    /// says so INSTEAD of letting a consumer diff the id across builds and
+    /// read the churn as discharged/new obligations.
+    ///
+    /// FALSE for every other identity tier (unique stripped name, a name with
+    /// no disambiguator, export names, the body-shape hash, module-scoped
+    /// advisories): those behave exactly as before this flag existed.
+    pub id_build_local: bool,
 }
 
 /// FEAT-055 (REQ-018): a candidate counterexample for an `UnprovenObligation`
@@ -3112,6 +3128,30 @@ fn body_shape_hash(ops: &[Operator<'_>]) -> String {
     out
 }
 
+/// FEAT-076 (scry#123): strip Rust's LEGACY-mangling symbol disambiguator — a
+/// trailing `17h` + exactly 16 LOWERCASE hex digits + `E` — from a
+/// name-section name. Returns `None` for any other shape; nothing broader is
+/// attempted (an over-matching heuristic would rename functions that were
+/// never Rust symbols). The disambiguator is derived from crate metadata and
+/// the instantiation, NOT the function body — measured on real builds
+/// (scry#123) it re-rolls on ANY upstream edit, destroying every obligation
+/// identity in 45% of identified functions per commit, while the stripped
+/// prefix was 100% stable across both an unrelated edit and an edit to the
+/// function's own body.
+fn strip_rust_disambiguator(name: &str) -> Option<&str> {
+    let no_e = name.strip_suffix('E')?;
+    if no_e.len() < 16 {
+        return None;
+    }
+    let (head, hex) = no_e.split_at(no_e.len() - 16);
+    if !hex.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')) {
+        return None;
+    }
+    let base = head.strip_suffix("17h")?;
+    // A name that IS only the disambiguator would strip to nothing; keep it raw.
+    if base.is_empty() { None } else { Some(base) }
+}
+
 /// FEAT-064: the content address itself. Opaque, fixed-width; consumers must not
 /// parse it (DD-020).
 fn obligation_id_of(func_ident: &str, path: &str, kind: &str, ordinal: u32, code: &str) -> String {
@@ -3184,9 +3224,24 @@ fn is_module_scoped(code: &str) -> bool {
     code == "unbounded-stack"
 }
 
-/// FEAT-064: stamp every advisory with its stable obligation identity.
-/// Function identity is the name-section / export name when the module carries
-/// one, else the body-shape hash (DD-020's precedence).
+/// FEAT-064 + FEAT-076: stamp every advisory with its obligation identity.
+///
+/// Function identity is TWO-TIER (scry#123, DD-020). The raw name-section name
+/// inherits Rust's legacy symbol disambiguator (`17h<16 hex>E`), which is
+/// derived from crate metadata rather than the body — measured, it re-rolls on
+/// any upstream edit and destroyed every obligation identity in 45% of
+/// identified functions per commit, including the very function a fix edits.
+/// So:
+///   1. named, disambiguated, and the STRIPPED name is unique in the module →
+///      the stripped name (stable: measured 100% survival across both an
+///      unrelated edit and an own-body edit);
+///   2. named, disambiguated, stripped name SHARED (dependency generics —
+///      measured 37.8% of functions, all of them dependencies, none scry's
+///      own) → the raw name, and the advisory is MARKED
+///      [`Advisory::id_build_local`]: unique within this build, not comparable
+///      across builds;
+///   3. named, no disambiguator → the raw name (unchanged from v3.2.5);
+///   4. unnamed → the body-shape hash (unchanged from v3.2.5).
 fn stamp_obligation_ids(
     advisories: &mut [Advisory],
     defined_funcs: &[DefinedFunc<'_>],
@@ -3197,12 +3252,36 @@ fn stamp_obligation_ids(
         a.site_key = site_key_of("<module>", "", "<module>", 0);
         a.group_key = group_key_of("<module>", "", "<module>");
     }
+    // FEAT-076: a stripped name may serve as the identity ONLY when unique in
+    // the module. Count every named function's CANDIDATE — stripped when the
+    // exact disambiguator shape is present, else the raw name — so a stripped
+    // name that lands on another function's candidate (a sibling
+    // monomorphization OR a plain name that never had a disambiguator) is
+    // rejected.
+    let mut candidates: alloc::collections::BTreeMap<&str, u32> =
+        alloc::collections::BTreeMap::new();
+    for m in function_meta {
+        if let Some(n) = m.name.as_deref() {
+            *candidates
+                .entry(strip_rust_disambiguator(n).unwrap_or(n))
+                .or_insert(0) += 1;
+        }
+    }
     for f in defined_funcs {
-        let ident = function_meta
+        let name = function_meta
             .iter()
             .find(|m| m.func_index == f.abs_index)
-            .and_then(|m| m.name.clone())
-            .unwrap_or_else(|| body_shape_hash(&f.ops));
+            .and_then(|m| m.name.as_deref());
+        let (ident, build_local) = match name {
+            None => (body_shape_hash(&f.ops), false),
+            Some(raw) => match strip_rust_disambiguator(raw) {
+                Some(stripped) if candidates.get(stripped) == Some(&1) => {
+                    (String::from(stripped), false)
+                }
+                Some(_) => (String::from(raw), true),
+                None => (String::from(raw), false),
+            },
+        };
         let keys = structural_keys(&f.ops);
         for a in advisories
             .iter_mut()
@@ -3217,6 +3296,7 @@ fn stamp_obligation_ids(
                 a.obligation_id = obligation_id_of(&ident, path, &kind, *ordinal, &a.code);
                 a.site_key = site_key_of(&ident, path, &kind, *ordinal);
                 a.group_key = group_key_of(&ident, path, &kind);
+                a.id_build_local = build_local;
             }
         }
     }
@@ -3262,6 +3342,7 @@ fn compute_advisories(
             obligation_id: String::new(),
             site_key: String::new(),
             group_key: String::new(),
+            id_build_local: false,
         });
     }
 
@@ -3304,6 +3385,7 @@ fn compute_advisories(
                 obligation_id: String::new(),
                 site_key: String::new(),
                 group_key: String::new(),
+            id_build_local: false,
                 });
             }
             TrapVerdict::ProvenSafe => {
@@ -3333,6 +3415,7 @@ fn compute_advisories(
                 obligation_id: String::new(),
                 site_key: String::new(),
                 group_key: String::new(),
+            id_build_local: false,
                 });
             }
         }
@@ -3376,6 +3459,7 @@ fn compute_advisories(
                 obligation_id: String::new(),
                 site_key: String::new(),
                 group_key: String::new(),
+            id_build_local: false,
         });
     }
 
@@ -3397,6 +3481,7 @@ fn compute_advisories(
                 obligation_id: String::new(),
                 site_key: String::new(),
                 group_key: String::new(),
+            id_build_local: false,
         });
     }
 
@@ -9959,5 +10044,202 @@ mod tests {
             "const frame + dynamic alloca must be Unknown, never the under-counted constant"
         );
         assert_eq!(res.stack_usage.max_stack_bytes, StackBound::Unknown);
+    }
+
+    // ── FEAT-076 (scry#123): two-tier function identity ─────────────────────
+
+    /// All identity-stamped advisories for `func`, asserted non-empty —
+    /// anti-vacuity: a fixture that never produces a stamped advisory would
+    /// let every assertion below pass without touching the code path.
+    fn stamped(r: &AnalysisResult, func: u32) -> Vec<&Advisory> {
+        let v: Vec<&Advisory> = r
+            .advisories
+            .iter()
+            .filter(|a| a.func_index == func && !a.obligation_id.is_empty())
+            .collect();
+        assert!(
+            !v.is_empty(),
+            "fixture must produce an identity-stamped advisory for func {func}; got {:?}",
+            r.advisories
+        );
+        v
+    }
+
+    /// FEAT-076 tier 1 — a UNIQUE stripped name survives the disambiguator
+    /// re-rolling. Rust legacy mangling ends in `17h<16 hex>E`, a symbol
+    /// disambiguator derived from crate metadata and instantiation, NOT the
+    /// body — so an unrelated edit renames the function and (before this fix)
+    /// destroyed every obligation identity in it (measured: 45% of identified
+    /// functions churn per commit, scry#123).
+    #[test]
+    fn feat076_unique_stripped_ident_survives_disambiguator_churn() {
+        let base = analyze_default(
+            "(module \
+               (func $\"_ZN4demo3foo17h0123456789abcdefE\" (param i32) (result i32) \
+                 i32.const 10 local.get 0 i32.div_s) \
+               (func $\"_ZN4demo3bar17h00aabbccddeeff11E\" (param i32) (result i32) \
+                 i32.const 20 local.get 0 i32.div_s))",
+        );
+        // The SAME source rebuilt after an unrelated edit: both disambiguators
+        // re-rolled, both bodies identical.
+        let rebuilt = analyze_default(
+            "(module \
+               (func $\"_ZN4demo3foo17hfedcba9876543210E\" (param i32) (result i32) \
+                 i32.const 10 local.get 0 i32.div_s) \
+               (func $\"_ZN4demo3bar17h22aabbccddeeff33E\" (param i32) (result i32) \
+                 i32.const 20 local.get 0 i32.div_s))",
+        );
+        for f in [0, 1] {
+            assert_eq!(
+                adv_id(&base, f),
+                adv_id(&rebuilt, f),
+                "a unique stripped name must survive a disambiguator change (func {f})"
+            );
+            for a in stamped(&base, f) {
+                assert!(
+                    !a.id_build_local,
+                    "a unique stripped name is stable — it must NOT be marked build-local"
+                );
+            }
+        }
+    }
+
+    /// FEAT-076 tier 2 — two functions sharing a stripped name (two
+    /// monomorphizations of one dependency generic; measured 37.8% of
+    /// functions, max multiplicity 39) must NOT collapse onto one identity.
+    /// The raw name keeps them apart WITHIN the build, and the advisory is
+    /// marked build-local because that raw name churns ACROSS builds.
+    #[test]
+    fn feat076_shared_stripped_name_does_not_collide_and_is_marked_build_local() {
+        let r = analyze_default(
+            "(module \
+               (func $\"_ZN3dep7generic17haaaaaaaaaaaaaaaaE\" (param i32) (result i32) \
+                 i32.const 10 local.get 0 i32.div_s) \
+               (func $\"_ZN3dep7generic17hbbbbbbbbbbbbbbbbE\" (param i32) (result i32) \
+                 i32.const 10 local.get 0 i32.div_s))",
+        );
+        // Identical bodies + identical stripped names: naive stripping would
+        // merge these onto ONE identity (wrong attribution, the scry#122
+        // class). They must stay distinct …
+        assert_ne!(
+            adv_id(&r, 0),
+            adv_id(&r, 1),
+            "two functions sharing a stripped name must NOT collapse onto one identity"
+        );
+        // … and be HONEST about the price: the id is unique only in this build.
+        for f in [0, 1] {
+            for a in stamped(&r, f) {
+                assert!(
+                    a.id_build_local,
+                    "an ambiguous stripped name means the id is not comparable \
+                     across builds — it must be marked build-local (func {f})"
+                );
+            }
+        }
+    }
+
+    /// FEAT-076 — the uniqueness check must count PLAIN names too: `foo17h…E`
+    /// strips to `foo`, which another function already IS. Using the stripped
+    /// form would collide with a name that never had a disambiguator.
+    #[test]
+    fn feat076_stripped_name_colliding_with_plain_name_falls_back() {
+        let r = analyze_default(
+            "(module \
+               (func $foo (param i32) (result i32) \
+                 i32.const 10 local.get 0 i32.div_s) \
+               (func $\"foo17h0123456789abcdefE\" (param i32) (result i32) \
+                 i32.const 10 local.get 0 i32.div_s))",
+        );
+        assert_ne!(
+            adv_id(&r, 0),
+            adv_id(&r, 1),
+            "a stripped name must not collide with an existing plain name"
+        );
+        for a in stamped(&r, 0) {
+            assert!(
+                !a.id_build_local,
+                "the plain name keeps today's stable identity"
+            );
+        }
+        for a in stamped(&r, 1) {
+            assert!(a.id_build_local, "ambiguous after stripping → build-local");
+        }
+    }
+
+    /// FEAT-076 — only the EXACT shape `17h` + 16 LOWERCASE hex + `E` is a
+    /// Rust disambiguator. Near misses (uppercase hex, 15 digits) are ordinary
+    /// names: the id tracks the raw name exactly as today, unmarked.
+    #[test]
+    fn feat076_only_the_exact_disambiguator_shape_is_stripped() {
+        let base = analyze_default(
+            "(module \
+               (func $\"upper17h0123456789ABCDEFE\" (param i32) (result i32) \
+                 i32.const 10 local.get 0 i32.div_s) \
+               (func $\"short17h012345678abcdefE\" (param i32) (result i32) \
+                 i32.const 20 local.get 0 i32.div_s))",
+        );
+        let renamed = analyze_default(
+            "(module \
+               (func $\"upper17h0123456799ABCDEFE\" (param i32) (result i32) \
+                 i32.const 10 local.get 0 i32.div_s) \
+               (func $\"short17h012345679abcdefE\" (param i32) (result i32) \
+                 i32.const 20 local.get 0 i32.div_s))",
+        );
+        for f in [0, 1] {
+            assert_ne!(
+                adv_id(&base, f),
+                adv_id(&renamed, f),
+                "a near-miss suffix is part of the name; renaming it changes the \
+                 id — today's behaviour must not be widened (func {f})"
+            );
+            for a in stamped(&base, f) {
+                assert!(!a.id_build_local, "a near-miss name is not build-local");
+            }
+        }
+    }
+
+    /// FEAT-076 regression pin — for a name with NO disambiguator the identity
+    /// derivation is byte-identical to v3.2.5. The constant was captured from
+    /// the UNMODIFIED code (main, 5cd2a89) on this exact fixture.
+    #[test]
+    fn feat076_plain_name_id_is_byte_identical_to_v325() {
+        let r = analyze_default(
+            "(module (func $compute (param i32) (result i32) \
+               i32.const 10 local.get 0 i32.div_s))",
+        );
+        let a = r
+            .advisories
+            .iter()
+            .find(|a| a.code == "div-by-zero" && !a.obligation_id.is_empty())
+            .expect("fixture must raise an identity-stamped div-by-zero advisory");
+        assert_eq!(
+            a.obligation_id, "dd7c4231ce161f87",
+            "a plain name's obligation id must not change across FEAT-076"
+        );
+        assert!(!a.id_build_local, "a plain name is not build-local");
+    }
+
+    /// FEAT-076 regression pin — the body-shape-hash fallback (no name section,
+    /// no export) is byte-identical to v3.2.5 and unmarked. Constant captured
+    /// from the UNMODIFIED code (main, 5cd2a89) on this exact fixture.
+    #[test]
+    fn feat076_shape_hash_fallback_id_is_byte_identical_to_v325() {
+        let r = analyze_default(
+            "(module (func (param i32) (result i32) \
+               i32.const 10 local.get 0 i32.div_s))",
+        );
+        let a = r
+            .advisories
+            .iter()
+            .find(|a| a.code == "div-by-zero" && !a.obligation_id.is_empty())
+            .expect("fixture must raise an identity-stamped div-by-zero advisory");
+        assert_eq!(
+            a.obligation_id, "4f61c85b63648dc7",
+            "the shape-hash fallback id must not change across FEAT-076"
+        );
+        assert!(
+            !a.id_build_local,
+            "the shape-hash fallback is not build-local"
+        );
     }
 }

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -3257,7 +3257,12 @@ fn stamp_obligation_ids(
     // exact disambiguator shape is present, else the raw name — so a stripped
     // name that lands on another function's candidate (a sibling
     // monomorphization OR a plain name that never had a disambiguator) is
-    // rejected.
+    // rejected. Known residual (clean-room, accepted): the count does NOT
+    // cover UNNAMED functions' body-shape hashes, so a stripped name that is
+    // itself exactly 16 lowercase hex characters could in principle collide
+    // with a shape hash. A real Rust legacy symbol starts `_ZN…`, so its
+    // stripped form is never pure hex; reaching this needs a hand-crafted
+    // name plus a SHA-256-prefix coincidence.
     let mut candidates: alloc::collections::BTreeMap<&str, u32> =
         alloc::collections::BTreeMap::new();
     for m in function_meta {

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -698,7 +698,7 @@ pub struct Advisory {
     /// rule aliasing out — the pairing of a deletion with a same-kind insertion
     /// leaves the group unchanged, which is precisely what falsified DD-021.
     pub group_key: String,
-    /// FEAT-076 (scry#123, DD-020): TRUE when this advisory's identity keys
+    /// FEAT-077 (scry#123, DD-020): TRUE when this advisory's identity keys
     /// (`obligation_id` / `site_key` / `group_key`) are BUILD-LOCAL — unique
     /// within THIS analysis but NOT comparable across builds of the same
     /// source. Set when the function's name-section name carries a Rust legacy
@@ -3128,7 +3128,7 @@ fn body_shape_hash(ops: &[Operator<'_>]) -> String {
     out
 }
 
-/// FEAT-076 (scry#123): strip Rust's LEGACY-mangling symbol disambiguator — a
+/// FEAT-077 (scry#123): strip Rust's LEGACY-mangling symbol disambiguator — a
 /// trailing `17h` + exactly 16 LOWERCASE hex digits + `E` — from a
 /// name-section name. Returns `None` for any other shape; nothing broader is
 /// attempted (an over-matching heuristic would rename functions that were
@@ -3224,7 +3224,7 @@ fn is_module_scoped(code: &str) -> bool {
     code == "unbounded-stack"
 }
 
-/// FEAT-064 + FEAT-076: stamp every advisory with its obligation identity.
+/// FEAT-064 + FEAT-077: stamp every advisory with its obligation identity.
 ///
 /// Function identity is TWO-TIER (scry#123, DD-020). The raw name-section name
 /// inherits Rust's legacy symbol disambiguator (`17h<16 hex>E`), which is
@@ -3252,7 +3252,7 @@ fn stamp_obligation_ids(
         a.site_key = site_key_of("<module>", "", "<module>", 0);
         a.group_key = group_key_of("<module>", "", "<module>");
     }
-    // FEAT-076: a stripped name may serve as the identity ONLY when unique in
+    // FEAT-077: a stripped name may serve as the identity ONLY when unique in
     // the module. Count every named function's CANDIDATE — stripped when the
     // exact disambiguator shape is present, else the raw name — so a stripped
     // name that lands on another function's candidate (a sibling
@@ -10051,7 +10051,7 @@ mod tests {
         assert_eq!(res.stack_usage.max_stack_bytes, StackBound::Unknown);
     }
 
-    // ── FEAT-076 (scry#123): two-tier function identity ─────────────────────
+    // ── FEAT-077 (scry#123): two-tier function identity ─────────────────────
 
     /// All identity-stamped advisories for `func`, asserted non-empty —
     /// anti-vacuity: a fixture that never produces a stamped advisory would
@@ -10070,14 +10070,14 @@ mod tests {
         v
     }
 
-    /// FEAT-076 tier 1 — a UNIQUE stripped name survives the disambiguator
+    /// FEAT-077 tier 1 — a UNIQUE stripped name survives the disambiguator
     /// re-rolling. Rust legacy mangling ends in `17h<16 hex>E`, a symbol
     /// disambiguator derived from crate metadata and instantiation, NOT the
     /// body — so an unrelated edit renames the function and (before this fix)
     /// destroyed every obligation identity in it (measured: 45% of identified
     /// functions churn per commit, scry#123).
     #[test]
-    fn feat076_unique_stripped_ident_survives_disambiguator_churn() {
+    fn feat077_unique_stripped_ident_survives_disambiguator_churn() {
         let base = analyze_default(
             "(module \
                (func $\"_ZN4demo3foo17h0123456789abcdefE\" (param i32) (result i32) \
@@ -10109,13 +10109,13 @@ mod tests {
         }
     }
 
-    /// FEAT-076 tier 2 — two functions sharing a stripped name (two
+    /// FEAT-077 tier 2 — two functions sharing a stripped name (two
     /// monomorphizations of one dependency generic; measured 37.8% of
     /// functions, max multiplicity 39) must NOT collapse onto one identity.
     /// The raw name keeps them apart WITHIN the build, and the advisory is
     /// marked build-local because that raw name churns ACROSS builds.
     #[test]
-    fn feat076_shared_stripped_name_does_not_collide_and_is_marked_build_local() {
+    fn feat077_shared_stripped_name_does_not_collide_and_is_marked_build_local() {
         let r = analyze_default(
             "(module \
                (func $\"_ZN3dep7generic17haaaaaaaaaaaaaaaaE\" (param i32) (result i32) \
@@ -10143,11 +10143,11 @@ mod tests {
         }
     }
 
-    /// FEAT-076 — the uniqueness check must count PLAIN names too: `foo17h…E`
+    /// FEAT-077 — the uniqueness check must count PLAIN names too: `foo17h…E`
     /// strips to `foo`, which another function already IS. Using the stripped
     /// form would collide with a name that never had a disambiguator.
     #[test]
-    fn feat076_stripped_name_colliding_with_plain_name_falls_back() {
+    fn feat077_stripped_name_colliding_with_plain_name_falls_back() {
         let r = analyze_default(
             "(module \
                (func $foo (param i32) (result i32) \
@@ -10171,11 +10171,11 @@ mod tests {
         }
     }
 
-    /// FEAT-076 — only the EXACT shape `17h` + 16 LOWERCASE hex + `E` is a
+    /// FEAT-077 — only the EXACT shape `17h` + 16 LOWERCASE hex + `E` is a
     /// Rust disambiguator. Near misses (uppercase hex, 15 digits) are ordinary
     /// names: the id tracks the raw name exactly as today, unmarked.
     #[test]
-    fn feat076_only_the_exact_disambiguator_shape_is_stripped() {
+    fn feat077_only_the_exact_disambiguator_shape_is_stripped() {
         let base = analyze_default(
             "(module \
                (func $\"upper17h0123456789ABCDEFE\" (param i32) (result i32) \
@@ -10203,11 +10203,11 @@ mod tests {
         }
     }
 
-    /// FEAT-076 regression pin — for a name with NO disambiguator the identity
+    /// FEAT-077 regression pin — for a name with NO disambiguator the identity
     /// derivation is byte-identical to v3.2.5. The constant was captured from
     /// the UNMODIFIED code (main, 5cd2a89) on this exact fixture.
     #[test]
-    fn feat076_plain_name_id_is_byte_identical_to_v325() {
+    fn feat077_plain_name_id_is_byte_identical_to_v325() {
         let r = analyze_default(
             "(module (func $compute (param i32) (result i32) \
                i32.const 10 local.get 0 i32.div_s))",
@@ -10219,16 +10219,16 @@ mod tests {
             .expect("fixture must raise an identity-stamped div-by-zero advisory");
         assert_eq!(
             a.obligation_id, "dd7c4231ce161f87",
-            "a plain name's obligation id must not change across FEAT-076"
+            "a plain name's obligation id must not change across FEAT-077"
         );
         assert!(!a.id_build_local, "a plain name is not build-local");
     }
 
-    /// FEAT-076 regression pin — the body-shape-hash fallback (no name section,
+    /// FEAT-077 regression pin — the body-shape-hash fallback (no name section,
     /// no export) is byte-identical to v3.2.5 and unmarked. Constant captured
     /// from the UNMODIFIED code (main, 5cd2a89) on this exact fixture.
     #[test]
-    fn feat076_shape_hash_fallback_id_is_byte_identical_to_v325() {
+    fn feat077_shape_hash_fallback_id_is_byte_identical_to_v325() {
         let r = analyze_default(
             "(module (func (param i32) (result i32) \
                i32.const 10 local.get 0 i32.div_s))",
@@ -10240,7 +10240,7 @@ mod tests {
             .expect("fixture must raise an identity-stamped div-by-zero advisory");
         assert_eq!(
             a.obligation_id, "4f61c85b63648dc7",
-            "the shape-hash fallback id must not change across FEAT-076"
+            "the shape-hash fallback id must not change across FEAT-077"
         );
         assert!(
             !a.id_build_local,

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -902,7 +902,7 @@ fn render_advisory_row(s: &mut String, a: &scry_analyze_core::Advisory) {
              name and structure are (see scry#123)\">¶</a>",
             esc(&a.obligation_id),
         );
-        // FEAT-076 (scry#123): a build-local identity must be visibly marked —
+        // FEAT-077 (scry#123): a build-local identity must be visibly marked —
         // the id above is unique within THIS build only, so citing it across
         // builds is meaningless and a consumer must be able to tell without
         // parsing the id.
@@ -1454,7 +1454,7 @@ fn esc(raw: &str) -> String {
 /// v2 added `guidance_schema` itself plus `obligation_id`, `site_key` and
 /// `group_key` on every advisory.
 ///
-/// v3 (FEAT-076, scry#123) adds `id_build_local` on every advisory: `true`
+/// v3 (FEAT-077, scry#123) adds `id_build_local` on every advisory: `true`
 /// means the three identity keys are unique within THIS analysis but NOT
 /// comparable across builds (the function's stripped name is shared by
 /// another function, so the raw, disambiguated — and churning — name is
@@ -1472,7 +1472,7 @@ pub const GUIDANCE_SCHEMA_VERSION: u32 = 3;
 /// FEAT-068: `guidance_schema` is an explicit integer version. v1 (the v3.2.2
 /// feed) had none, so a consumer could not tell a field's ABSENCE from an old
 /// producer. v2 adds the version and the three FEAT-064/DD-021 identity keys;
-/// v3 (FEAT-076) adds `id_build_local`. Absence of `guidance_schema` means
+/// v3 (FEAT-077) adds `id_build_local`. Absence of `guidance_schema` means
 /// v1; a consumer requiring identity must check for it rather than assume.
 ///
 /// Each advisory is
@@ -2585,7 +2585,7 @@ mod tests {
         assert!(!json.to_lowercase().contains("discharg"));
     }
 
-    // ── FEAT-076 (scry#123): surfacing build-local identity ─────────────────
+    // ── FEAT-077 (scry#123): surfacing build-local identity ─────────────────
 
     /// A module reaching BOTH identity tiers: two monomorphizations sharing a
     /// stripped name (→ build-local) and one unique stripped name (→ stable).
@@ -2618,7 +2618,7 @@ mod tests {
         r
     }
 
-    /// FEAT-076: the guidance feed must let a consumer tell a stable id from a
+    /// FEAT-077: the guidance feed must let a consumer tell a stable id from a
     /// build-local one WITHOUT parsing the id — and the schema version must
     /// say the field exists (FEAT-068: absence of a field from an old producer
     /// must be distinguishable).
@@ -2640,7 +2640,7 @@ mod tests {
         );
     }
 
-    /// FEAT-076: the HTML guidance row must disclose a build-local id visibly,
+    /// FEAT-077: the HTML guidance row must disclose a build-local id visibly,
     /// and must NOT stamp the disclosure on stable ids.
     #[test]
     fn guidance_html_marks_build_local_ids_only() {
@@ -2667,7 +2667,7 @@ mod tests {
         );
     }
 
-    /// FEAT-076: the delta view compares runs BY identity, so it is exactly
+    /// FEAT-077: the delta view compares runs BY identity, so it is exactly
     /// where a build-local id would be misread — a churned raw name shows up
     /// as one site vanishing and an unrelated one appearing. The row and the
     /// summaries must carry the flag, and the page must disclose it.
@@ -2761,7 +2761,7 @@ pub struct DeltaRow {
     pub pc_before: Option<u32>,
     pub pc_after: Option<u32>,
     pub alias: AliasStatus,
-    /// FEAT-076 (scry#123): TRUE when any advisory at this site, in either
+    /// FEAT-077 (scry#123): TRUE when any advisory at this site, in either
     /// run, carries a BUILD-LOCAL identity (`Advisory::id_build_local`) — the
     /// site's keys are unique within one analysis but NOT comparable across
     /// builds, so its appearance/disappearance here is NOT evidence a site
@@ -2840,7 +2840,7 @@ impl Delta {
             .filter(|r| r.in_both() && r.alias == AliasStatus::NotExcluded)
             .count()
     }
-    /// FEAT-076 (scry#123): sites whose identity is BUILD-LOCAL in at least
+    /// FEAT-077 (scry#123): sites whose identity is BUILD-LOCAL in at least
     /// one run — rows on which cross-build comparison is not meaningful.
     pub fn build_local_sites(&self) -> usize {
         self.rows.iter().filter(|r| r.build_local).count()
@@ -2874,7 +2874,7 @@ pub fn compute_delta(before: &AnalysisResult, after: &AnalysisResult) -> Delta {
         m
     }
     // site_key -> (group_key, func_index, pc, sorted distinct codes,
-    //              any advisory here build-local (FEAT-076))
+    //              any advisory here build-local (FEAT-077))
     #[allow(clippy::type_complexity)]
     fn sites(r: &AnalysisResult) -> BTreeMap<&str, (&str, u32, u32, BTreeSet<&str>, bool)> {
         let mut m: BTreeMap<&str, (&str, u32, u32, BTreeSet<&str>, bool)> = BTreeMap::new();
@@ -2929,7 +2929,7 @@ pub fn compute_delta(before: &AnalysisResult, after: &AnalysisResult) -> Delta {
             pc_before: b.map(|x| x.2),
             pc_after: a.map(|x| x.2),
             alias,
-            // FEAT-076: build-local in EITHER run poisons cross-run
+            // FEAT-077: build-local in EITHER run poisons cross-run
             // comparability of the row, so either flag marks it.
             build_local: b.map(|x| x.4).unwrap_or(false) || a.map(|x| x.4).unwrap_or(false),
         });
@@ -3040,7 +3040,7 @@ pub fn render_delta_html(d: &Delta, title: &str) -> String {
          fix: the code that carried the obligation may simply be gone, which \
          proves nothing.</p>",
     );
-    // FEAT-076 (scry#123): rows whose identity is build-local are hashed from
+    // FEAT-077 (scry#123): rows whose identity is build-local are hashed from
     // a raw disambiguated name that churns across builds — their appearance
     // or disappearance between two builds is expected noise, not evidence.
     s.push_str(

--- a/crates/scry-viz/src/lib.rs
+++ b/crates/scry-viz/src/lib.rs
@@ -902,6 +902,20 @@ fn render_advisory_row(s: &mut String, a: &scry_analyze_core::Advisory) {
              name and structure are (see scry#123)\">¶</a>",
             esc(&a.obligation_id),
         );
+        // FEAT-076 (scry#123): a build-local identity must be visibly marked —
+        // the id above is unique within THIS build only, so citing it across
+        // builds is meaningless and a consumer must be able to tell without
+        // parsing the id.
+        if a.id_build_local {
+            let _ = write!(
+                s,
+                "<span class=\"badge\" title=\"this function's stripped name is \
+                 shared by another function (dependency generics), so the raw \
+                 disambiguated name is hashed — the id is unique within this \
+                 build only and NOT comparable across builds (scry#123)\">\
+                 build-local id</span> "
+            );
+        }
     }
     let _ = write!(
         s,
@@ -1437,27 +1451,34 @@ fn esc(raw: &str) -> String {
 /// "this module has no such finding" — the distinction the un-versioned v1 feed
 /// could not express.
 ///
-/// v2 (this release) adds `guidance_schema` itself plus `obligation_id`,
-/// `site_key` and `group_key` on every advisory.
-pub const GUIDANCE_SCHEMA_VERSION: u32 = 2;
+/// v2 added `guidance_schema` itself plus `obligation_id`, `site_key` and
+/// `group_key` on every advisory.
+///
+/// v3 (FEAT-076, scry#123) adds `id_build_local` on every advisory: `true`
+/// means the three identity keys are unique within THIS analysis but NOT
+/// comparable across builds (the function's stripped name is shared by
+/// another function, so the raw, disambiguated — and churning — name is
+/// hashed). A consumer diffing two runs must skip such advisories rather than
+/// read the churn as discharged/new obligations.
+pub const GUIDANCE_SCHEMA_VERSION: u32 = 3;
 
 /// Serialize the actionable findings as a machine-consumable JSON document — the
 /// feed an AI-agent consumer reads instead of scraping the (now capped) HTML.
 ///
 /// Shape: a top-level object
-/// `{ "guidance_schema": 2, "module_sha256": "…", "schema": "…",
+/// `{ "guidance_schema": 3, "module_sha256": "…", "schema": "…",
 ///    "advisories": [ … ], "trap_checks": [ … ] }`.
 ///
 /// FEAT-068: `guidance_schema` is an explicit integer version. v1 (the v3.2.2
 /// feed) had none, so a consumer could not tell a field's ABSENCE from an old
-/// producer. v2 adds the version and the three FEAT-064/DD-021 identity keys.
-/// Absence of `guidance_schema` means v1; a consumer requiring identity must
-/// check for it rather than assume.
+/// producer. v2 adds the version and the three FEAT-064/DD-021 identity keys;
+/// v3 (FEAT-076) adds `id_build_local`. Absence of `guidance_schema` means
+/// v1; a consumer requiring identity must check for it rather than assume.
 ///
 /// Each advisory is
 /// `{ "func_index", "pc", "class", "code", "detail", "suggested_action",
 ///    "verification", "obligation_id", "site_key", "group_key",
-///    "counterexample"? }`, mirroring the [`Advisory`] fields
+///    "id_build_local", "counterexample"? }`, mirroring the [`Advisory`] fields
 /// (`class` uses the machine-stable name, e.g. `"unproven-obligation"`). Each
 /// trap check is `{ "func_index", "pc", "op", "kind", "verdict" }`.
 ///
@@ -1484,7 +1505,8 @@ pub fn render_guidance_json(result: &AnalysisResult) -> String {
             s,
             "{{\"func_index\":{},\"pc\":{},\"class\":\"{}\",\"code\":\"{}\",\
              \"detail\":\"{}\",\"suggested_action\":\"{}\",\"verification\":\"{}\",\
-             \"obligation_id\":\"{}\",\"site_key\":\"{}\",\"group_key\":\"{}\"",
+             \"obligation_id\":\"{}\",\"site_key\":\"{}\",\"group_key\":\"{}\",\
+             \"id_build_local\":{}",
             a.func_index,
             a.pc,
             advisory_class_name(a.class),
@@ -1495,6 +1517,7 @@ pub fn render_guidance_json(result: &AnalysisResult) -> String {
             json_esc(&a.obligation_id),
             json_esc(&a.site_key),
             json_esc(&a.group_key),
+            a.id_build_local,
         );
         if let Some(cx) = &a.counterexample {
             let _ = write!(
@@ -2181,6 +2204,7 @@ mod tests {
             obligation_id: format!("test-{i:04x}"),
             site_key: format!("site-{i:04x}"),
             group_key: format!("grp-{:04x}", i / 4),
+            id_build_local: false,
         };
         for i in 0..(ADVISORY_PER_CLASS_CAP as u32 + 25) {
             r.advisories.push(mk(i));
@@ -2286,7 +2310,7 @@ mod tests {
         );
         let json = render_guidance_json(&r);
         assert!(
-            json.contains("\"guidance_schema\":2"),
+            json.contains("\"guidance_schema\":3"),
             "v2 feed must declare its version"
         );
         for k in ["obligation_id", "site_key", "group_key"] {
@@ -2560,6 +2584,117 @@ mod tests {
         assert!(json.contains("\"adjudicated\":false"));
         assert!(!json.to_lowercase().contains("discharg"));
     }
+
+    // ── FEAT-076 (scry#123): surfacing build-local identity ─────────────────
+
+    /// A module reaching BOTH identity tiers: two monomorphizations sharing a
+    /// stripped name (→ build-local) and one unique stripped name (→ stable).
+    fn mixed_tier_result() -> AnalysisResult {
+        let r = analyze_wat(
+            "(module \
+               (func $\"_ZN3dep7generic17haaaaaaaaaaaaaaaaE\" (param i32) (result i32) \
+                 i32.const 10 local.get 0 i32.div_s) \
+               (func $\"_ZN3dep7generic17hbbbbbbbbbbbbbbbbE\" (param i32) (result i32) \
+                 i32.const 10 local.get 0 i32.div_s) \
+               (func $\"_ZN4demo6unique17hccccccccccccccccE\" (param i32) (result i32) \
+                 i32.const 30 local.get 0 i32.div_s))",
+        );
+        // Preconditions (anti-vacuity): the fixture must actually reach both
+        // tiers, or every assertion downstream passes without testing anything.
+        assert!(
+            r.advisories
+                .iter()
+                .any(|a| !a.obligation_id.is_empty() && a.id_build_local),
+            "fixture must produce a build-local identity; got {:?}",
+            r.advisories
+        );
+        assert!(
+            r.advisories
+                .iter()
+                .any(|a| !a.obligation_id.is_empty() && !a.id_build_local),
+            "fixture must produce a stable identity; got {:?}",
+            r.advisories
+        );
+        r
+    }
+
+    /// FEAT-076: the guidance feed must let a consumer tell a stable id from a
+    /// build-local one WITHOUT parsing the id — and the schema version must
+    /// say the field exists (FEAT-068: absence of a field from an old producer
+    /// must be distinguishable).
+    #[test]
+    fn guidance_json_carries_id_build_local_and_v3_schema() {
+        let r = mixed_tier_result();
+        let json = render_guidance_json(&r);
+        assert!(
+            json.contains("\"guidance_schema\":3"),
+            "id_build_local is a new field — the schema version must be bumped"
+        );
+        assert!(
+            json.contains("\"id_build_local\":true"),
+            "the ambiguous tier must be marked in the feed"
+        );
+        assert!(
+            json.contains("\"id_build_local\":false"),
+            "the stable tier must be explicitly unmarked in the feed"
+        );
+    }
+
+    /// FEAT-076: the HTML guidance row must disclose a build-local id visibly,
+    /// and must NOT stamp the disclosure on stable ids.
+    #[test]
+    fn guidance_html_marks_build_local_ids_only() {
+        let html = render_html(&mixed_tier_result(), "bl");
+        assert!(
+            html.contains("build-local"),
+            "a build-local id must be visibly marked in the HTML"
+        );
+        let stable = analyze_wat(
+            "(module (func $compute (param i32) (result i32) \
+               i32.const 10 local.get 0 i32.div_s))",
+        );
+        assert!(
+            stable
+                .advisories
+                .iter()
+                .any(|a| !a.obligation_id.is_empty() && !a.id_build_local),
+            "precondition: stable fixture must produce a stable identity"
+        );
+        let html = render_html(&stable, "stable");
+        assert!(
+            !html.contains("build-local"),
+            "a stable id must NOT carry the build-local marking"
+        );
+    }
+
+    /// FEAT-076: the delta view compares runs BY identity, so it is exactly
+    /// where a build-local id would be misread — a churned raw name shows up
+    /// as one site vanishing and an unrelated one appearing. The row and the
+    /// summaries must carry the flag, and the page must disclose it.
+    #[test]
+    fn delta_carries_build_local() {
+        let r = mixed_tier_result();
+        let d = compute_delta(&r, &r);
+        assert!(
+            d.rows.iter().any(|row| row.build_local),
+            "a build-local site must be flagged in the delta rows"
+        );
+        assert!(
+            d.rows.iter().any(|row| !row.build_local),
+            "a stable site must not be flagged"
+        );
+        assert!(d.build_local_sites() >= 1, "summary count must see it");
+        let json = render_delta_json(&d);
+        assert!(
+            json.contains("\"build_local_sites\":"),
+            "delta JSON must carry the build-local count"
+        );
+        let html = render_delta_html(&d, "t").to_lowercase();
+        assert!(
+            html.contains("build-local"),
+            "the delta page must disclose that some identities are build-local"
+        );
+    }
 }
 
 // ── FEAT-072: the delta view ────────────────────────────────────────────────
@@ -2626,6 +2761,12 @@ pub struct DeltaRow {
     pub pc_before: Option<u32>,
     pub pc_after: Option<u32>,
     pub alias: AliasStatus,
+    /// FEAT-076 (scry#123): TRUE when any advisory at this site, in either
+    /// run, carries a BUILD-LOCAL identity (`Advisory::id_build_local`) — the
+    /// site's keys are unique within one analysis but NOT comparable across
+    /// builds, so its appearance/disappearance here is NOT evidence a site
+    /// came or went: a churned raw name presents exactly the same way.
+    pub build_local: bool,
 }
 
 impl DeltaRow {
@@ -2699,6 +2840,11 @@ impl Delta {
             .filter(|r| r.in_both() && r.alias == AliasStatus::NotExcluded)
             .count()
     }
+    /// FEAT-076 (scry#123): sites whose identity is BUILD-LOCAL in at least
+    /// one run — rows on which cross-build comparison is not meaningful.
+    pub fn build_local_sites(&self) -> usize {
+        self.rows.iter().filter(|r| r.build_local).count()
+    }
     /// The rows a future adjudicator (REQ-021) could act on soundly TODAY:
     /// present in both runs, obligation set changed, and provably alias-free.
     /// Reported as a COUNT OF CANDIDATES, never as discharges.
@@ -2727,17 +2873,21 @@ pub fn compute_delta(before: &AnalysisResult, after: &AnalysisResult) -> Delta {
         }
         m
     }
-    // site_key -> (group_key, func_index, pc, sorted distinct codes)
-    fn sites(r: &AnalysisResult) -> BTreeMap<&str, (&str, u32, u32, BTreeSet<&str>)> {
-        let mut m: BTreeMap<&str, (&str, u32, u32, BTreeSet<&str>)> = BTreeMap::new();
+    // site_key -> (group_key, func_index, pc, sorted distinct codes,
+    //              any advisory here build-local (FEAT-076))
+    #[allow(clippy::type_complexity)]
+    fn sites(r: &AnalysisResult) -> BTreeMap<&str, (&str, u32, u32, BTreeSet<&str>, bool)> {
+        let mut m: BTreeMap<&str, (&str, u32, u32, BTreeSet<&str>, bool)> = BTreeMap::new();
         for a in r.advisories.iter().filter(|a| !a.site_key.is_empty()) {
             let e = m.entry(a.site_key.as_str()).or_insert((
                 a.group_key.as_str(),
                 a.func_index,
                 a.pc,
                 BTreeSet::new(),
+                false,
             ));
             e.3.insert(a.code.as_str());
+            e.4 |= a.id_build_local;
         }
         m
     }
@@ -2779,6 +2929,9 @@ pub fn compute_delta(before: &AnalysisResult, after: &AnalysisResult) -> Delta {
             pc_before: b.map(|x| x.2),
             pc_after: a.map(|x| x.2),
             alias,
+            // FEAT-076: build-local in EITHER run poisons cross-run
+            // comparability of the row, so either flag marks it.
+            build_local: b.map(|x| x.4).unwrap_or(false) || a.map(|x| x.4).unwrap_or(false),
         });
     }
 
@@ -2852,6 +3005,7 @@ pub fn render_delta_html(d: &Delta, title: &str) -> String {
         "<dt>module before</dt><dd><code>{}</code></dd>\
          <dt>module after</dt><dd><code>{}</code></dd>\
          <dt>sites before / after</dt><dd>{} / {}</dd>\
+         <dt class=\"warn\">…with a build-local identity</dt><dd class=\"warn\">{}</dd>\
          <dt>present in both</dt><dd>{}</dd>\
          <dt class=\"ok\">…ordinal-stable</dt><dd class=\"ok\">{} ({:.1}%)</dd>\
          <dt class=\"warn\">…ordinal donation not excluded</dt><dd class=\"warn\">{}</dd>\
@@ -2863,6 +3017,7 @@ pub fn render_delta_html(d: &Delta, title: &str) -> String {
         esc(&d.sha_after),
         d.sites_before(),
         d.sites_after(),
+        d.build_local_sites(),
         both,
         d.ordinal_stable(),
         pct,
@@ -2883,7 +3038,19 @@ pub fn render_delta_html(d: &Delta, title: &str) -> String {
     s.push_str(
         "<p class=\"muted\">A site \"only in before\" is <strong>not</strong> a \
          fix: the code that carried the obligation may simply be gone, which \
-         proves nothing.</p></section>",
+         proves nothing.</p>",
+    );
+    // FEAT-076 (scry#123): rows whose identity is build-local are hashed from
+    // a raw disambiguated name that churns across builds — their appearance
+    // or disappearance between two builds is expected noise, not evidence.
+    s.push_str(
+        "<p class=\"muted\">A <strong>build-local</strong> identity (the count \
+         above) is unique within one build only: the function's stripped name \
+         is shared (dependency generics), so the raw name — which carries a \
+         crate-metadata disambiguator and churns across builds — is hashed. \
+         Such a site vanishing or appearing between builds is expected \
+         identity churn, not evidence a site came or went (scry#123).\
+         </p></section>",
     );
 
     // Only rows that MOVED. An unchanged row carries no information, and the
@@ -2983,6 +3150,7 @@ pub fn render_delta_json(d: &Delta) -> String {
          \"adjudicated\":false,\"adjudication_issue\":\"scry#122\",\
          \"module_sha256_before\":\"{}\",\"module_sha256_after\":\"{}\",\
          \"sites_before\":{},\"sites_after\":{},\
+         \"build_local_sites\":{},\
          \"ordinal_stable\":{},\"not_excluded\":{},\
          \"only_before\":{},\"only_after\":{},\
          \"changed\":{},\"unchanged\":{},\"ordinal_stable_changes\":{}}}",
@@ -2991,6 +3159,7 @@ pub fn render_delta_json(d: &Delta) -> String {
         json_esc(&d.sha_after),
         d.sites_before(),
         d.sites_after(),
+        d.build_local_sites(),
         d.ordinal_stable(),
         d.not_excluded(),
         d.only_before(),


### PR DESCRIPTION
Fixes #123 (upstream of #122 — content-corroborating `site_key` cannot help while the ident hashed in before it churns).

## What changed

`func_ident` — the FIRST component hashed into `obligation_id` / `site_key` / `group_key` — is now **two-tier**, per the measurement in #123:

1. **Strip** a trailing `17h<16 lowercase hex>E` (Rust legacy mangling's symbol disambiguator — derived from crate metadata/instantiation, not the body). Only that exact shape; uppercase hex or 15 digits are left alone.
2. If the stripped name is **unique within the module** (uniqueness counted over every named function's *candidate* — stripped where the shape matches, else the raw name, so `foo17h…E` colliding with a plain `foo` is also caught), the stripped name is the identity. Measured 100% stable across both an unrelated edit and an own-body edit.
3. If not unique (dependency generics — 37.8% of functions, max multiplicity 39, **zero** of scry's own), fall back to today's raw name so the id stays unique within the build, and mark the advisory with the new **`Advisory::id_build_local: bool`** — the identity keys are not comparable across builds, and a consumer can tell **without parsing the id**.
4. Names with no disambiguator, export names, and the `body_shape_hash` fallback are **byte-identical to v3.2.5** — regression-pinned in tests against id constants captured from the unmodified code on main (`5cd2a89`) before the change (`dd7c4231ce161f87` plain name, `4f61c85b63648dc7` shape hash).

Surfacing (scry-sai-viz):
- **Guidance feed v3**: `GUIDANCE_SCHEMA_VERSION` 2 → 3; every advisory carries `"id_build_local"` (FEAT-068 discipline: field absence vs old producer stays distinguishable).
- HTML guidance row: a `build-local id` badge (with an explanatory hover) on marked advisories only.
- FEAT-072 delta view: per-row `DeltaRow::build_local` (build-local in **either** run poisons the row), `Delta::build_local_sites()`, a `"build_local_sites"` field in the delta JSON, a summary row and a disclosure paragraph on the delta page — a build-local site vanishing/appearing between builds is expected identity churn, **not** evidence a site came or went.

rivet artifacts: new **FEAT-076** under `release: v3.4.0` (status `implemented`); FEAT-064 AC#1 (falsified-in-practice) now carries the repair note and its honest scope; DD-020 gains limitation **(6)** (disambiguator churn, the repair, and the residual) and an in-place AMENDED note on the function-identity component. `proofs/rocq/ObligationId.v` untouched (its theorems are about the ordinal, not the ident). WIT and the component wrapper untouched (advisories are library-only fields — house pattern).

## Red-first evidence (actual failure output against the unmodified logic)

All behavioral tests were written and run against a skeleton that added only the inert `id_build_local` field (always `false`, nothing emitted) — i.e. the unmodified identity logic:

```
---- tests::feat076_unique_stripped_ident_survives_disambiguator_churn stdout ----
assertion `left == right` failed: a unique stripped name must survive a disambiguator change (func 0)
  left: "848ca91acb777c5d"
 right: "542c78e69e6c2622"
---- tests::feat076_shared_stripped_name_does_not_collide_and_is_marked_build_local stdout ----
an ambiguous stripped name means the id is not comparable across builds — it must be marked build-local (func 0)
---- tests::feat076_stripped_name_colliding_with_plain_name_falls_back stdout ----
ambiguous after stripping → build-local
test result: FAILED. 3 passed; 3 failed; ... 105 filtered out
```

viz, same skeleton state (all three failed on the anti-vacuity precondition — "fixture must produce a build-local identity" — plus, before the schema bump, `"guidance_schema":3` absent):

```
failures:
    tests::delta_carries_build_local
    tests::guidance_html_marks_build_local_ids_only
    tests::guidance_json_carries_id_build_local_and_v3_schema
test result: FAILED. 0 passed; 3 failed; ... 34 filtered out
```

Three tests are guard/pin tests that are green **by construction** against the unmodified code (that is their job — they pin today's behavior): `feat076_only_the_exact_disambiguator_shape_is_stripped` and the two `…byte_identical_to_v325` pins. Their potency is established by mutation (below), not by red-first.

## Mutation checks (each mutant run against the full suites)

| mutant | expected killer | result |
|---|---|---|
| M1: `strip_rust_disambiguator` always `None` (stripping disabled) | the 3 behavioral core tests | exactly `feat076_unique_stripped_ident_survives_disambiguator_churn`, `feat076_shared_stripped_name_…`, `feat076_stripped_name_colliding_…` FAILED; 108 others passed |
| M2: uniqueness check dropped (always trust the stripped name) | the two collision tests | exactly `feat076_shared_stripped_name_…`, `feat076_stripped_name_colliding_…` FAILED; 109 passed |
| M3: shape widened to accept uppercase hex | the exact-shape test | exactly `feat076_only_the_exact_disambiguator_shape_is_stripped` FAILED; 110 passed |
| M4: marking suppressed (`id_build_local = false` always) | marking assertions + all viz surfacing | core: the two marking tests FAILED; viz: all 3 new tests FAILED |
| M5: everything marked (`id_build_local = true` always) | the "must NOT be marked" side | core: 5 tests FAILED (churn, exact-shape, plain-name pin, shape-hash pin, plain-vs-stripped); viz: all 3 new tests FAILED |

No mutant survived; no mutant killed an unintended test.

## Local verification (exit codes, not greps)

- `cargo test -p scry-sai-core -p scry-sai-viz` → exit 0; `scry-sai-core: 111 passed; 0 failed`, `scry-sai-viz: 37 passed; 0 failed`
- `cargo clippy -p scry-sai-core -p scry-sai-viz --all-targets -- -D warnings` → exit 0
- `cargo fmt --all --check` → exit 0
- `rivet validate` → **PASS** (exit 0; 135 warnings, all pre-existing classes — FEAT-076's new INFO/WARN lines are the same `residual`-field and prose-mention classes FEAT-074/075 already carry)
- `python3 tools/claim-check.py` → 5/5 claims hold, exit 0
- `cargo check` (workspace host default-members, includes the component wrapper deps) → exit 0

## Not verified here

- **CI is currently backed up GitHub-side; no claim is made about CI.** Local verification above is what exists.
- The 100% / 37.8% / 54.8–54.9% figures are #123's measurement on real `scry_mcdc.wasm` builds; this PR verifies the **mechanism** on WAT fixtures and does **not** re-run the corpus measurement. FEAT-073's self-history harness over two real builds is the natural follow-up check.
- Behavior on non-Rust corpora with accidental `17h<hex>E`-shaped names: only the exact shape is stripped and only when unique, so the worst case is a rename-tracking id identical to a genuine Rust one — but this is argued, not measured.
- The Bazel build and the wasm component build were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc

## Clean-room verification (independent cold-context pass, after the above)

A fresh-context verifier re-ran the suites (111 + 37, exit 0), independently re-applied mutation M2 and confirmed it is killed by exactly the two collision tests (109 passed / 2 failed, nothing unrelated red), audited the new tests for vacuity (none found — preconditions force the code path, and the HTML test's negative assert rules out static-page-furniture matches), and confirmed `proofs/` is untouched vs main. It found **one theoretical residual**, now documented in the code and DD-020 (commit `ba16306`): the uniqueness count covers named functions only, so a stripped name that is itself exactly 16 lowercase hex characters could collide with an *unnamed* function's `body_shape_hash`. A real Rust legacy symbol starts `_ZN…` and is never pure hex, so reaching it requires a hand-crafted name plus a SHA-256-prefix coincidence; accepted and disclosed rather than engineered around.
