### PR TITLE
FEAT-079 (#121): every havoc'd region records a gap — close the laundering hole

### DIFF
--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1716,4 +1716,58 @@ artifacts:
         - "Given the explicit package list, Then it is deliberately not `--workspace`: the workspace holds wasm32 cdylib members a host `cargo test` cannot build. The guard is what makes the explicit list safe."
     links:
       - type: traces-to
+
+  - id: FEAT-079
+    type: feature
+    title: "v3.2.6 — Every havoc'd region records a gap: close the laundering hole (scry#121)"
+    status: proposed
+    release: v3.2.6
+    description: >
+      `havoc_region` never interprets the region body, yet it recorded a gap ONLY
+      when the write set was non-empty or the region contained a call. A typed
+      region that writes no local and calls nothing therefore vanished with NO
+      record of any kind — no trap check, no gap, no advisory.
+
+      Reproduced exactly as filed: `(block (result i32) i32.const 10 local.get 0
+      i32.div_s)` yields an empty report, while the same expression unwrapped
+      reports a div-by-zero POTENTIAL-TRAP. A typed `if` behaves identically.
+
+      THREE CONSEQUENCES, and only the first is about precision.
+      (1) The gap report was not complete: an assessor reading `gaps` as the
+      scope boundary got a region that was never analysed and never disclosed.
+      (2) It was a ONE-LINE LAUNDERING VECTOR — wrapping a flagged expression in
+      a typed block removed it from the report entirely, requiring no
+      understanding of any internal scheme.
+      (3) It promoted to a WRONG VERDICT downstream: the adjudicator reads
+      "absent from the after-run" as `removed-with-code` — literally "the site no
+      longer exists" — while the code is still there and the obligation live
+      (DD-021 finding 3).
+
+      This is a hole in REQ-017's invariant, not merely a missing record. Here
+      the analyzer is MAXIMALLY conservative — it interprets nothing — and says
+      nothing at all, which is the one thing that invariant forbids.
+
+      FIX: emit the gap unconditionally. The old gate's call half was added
+      correctly (FEAT-043: a void call inside an `if` must still record, or
+      `resolved_stack_callees` silently under-counts), but the lesson
+      generalises — the reason to record is that the region WAS NOT ANALYSED,
+      not that it happened to write a local. An empty write set makes a region
+      cheaper to havoc, not more analysed.
+
+      MEASURED IMPACT on scry's own compiled module: gaps 2046 -> 2100. Those 54
+      regions were always being havoc'd; they were simply not disclosed. The
+      dashboard number rising is VISIBILITY, not a regression, and the release
+      note should say so before someone reads it as one.
+    tags: [soundness-honesty, gap-reporting, laundering, issue-driven, v3.2.6]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given a typed region with an EMPTY write set and no call, When scry havocs it, Then a Gap{kind: UnmodeledControlFlow} is recorded — for `block` and for `if` alike."
+        - "CONTROL, asserted first in the same test: the unwrapped expression raises a trap check. Without it the laundering test proves nothing, since an empty report would satisfy it either way."
+        - "Given scry's own module, When gaps are counted before and after, Then the count rises 2046 -> 2100 — measured on the same module with both binaries, so the change is attributable to this fix rather than to module drift."
+        - "Given claims.yaml, Then no claim predicate is bound to a gap count, so the increase breaks no gated claim — checked rather than assumed."
+    links:
+      - type: traces-to
+        target: REQ-017
+      - type: traces-to
         target: REQ-001

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1716,7 +1716,7 @@ artifacts:
         - "Given the explicit package list, Then it is deliberately not `--workspace`: the workspace holds wasm32 cdylib members a host `cargo test` cannot build. The guard is what makes the explicit list safe."
     links:
       - type: traces-to
-
+        target: REQ-001
   - id: FEAT-079
     type: feature
     title: "v3.2.6 — Every havoc'd region records a gap: close the laundering hole (scry#121)"

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -9112,6 +9112,8 @@ mod tests {
             SCRY_VERSION.split('.').count() == 3
                 && SCRY_VERSION.split('.').all(|p| p.parse::<u32>().is_ok()),
             "expected a three-part numeric version, got {SCRY_VERSION:?}"
+        );
+    }
 
     /// scry#121: `havoc_region` never interprets the region body, but recorded a
     /// gap ONLY when the write set was non-empty or the region held a call. So a

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -4668,31 +4668,29 @@ impl Interp<'_, '_> {
             let _ = ctx.operand_stack.pop();
         }
         let written = region_write_set(self.ops, opener + 1, end);
-        // FEAT-040 / FEAT-043: an unmodelled control-flow region is a give-up
-        // worth a gap when it either widens a local to ⊤ (write-set non-empty)
-        // OR contains a CALL — havoc does not interpret the region body, so any
-        // call inside it is NEVER recorded in `call_graph`. Recording the gap
-        // keeps the invariant "a gap-free function's call_graph is COMPLETE",
-        // which `resolved_stack_callees` (FEAT-043) and the gap report rely on;
-        // without it, a void call (empty write-set) inside an `if` would be
-        // silently dropped from the stack weighting (clean-room finding).
-        let region_has_call = self.ops[opener + 1..end].iter().any(|op| {
-            matches!(
-                op,
-                Operator::Call { .. }
-                    | Operator::CallIndirect { .. }
-                    | Operator::ReturnCall { .. }
-                    | Operator::ReturnCallIndirect { .. }
-            )
+        // FEAT-040 / FEAT-043 / scry#121: an unmodelled control-flow region is
+        // ALWAYS worth a gap. `havoc_region` does not interpret the body at all,
+        // so the reason to record is that the region WAS NOT ANALYSED — not that
+        // it happened to write a local.
+        //
+        // This used to be gated on `!written.is_empty() || region_has_call`. The
+        // call half was added correctly (FEAT-043: a void call inside an `if`
+        // must still record, or `resolved_stack_callees` silently under-counts),
+        // but the gate as a whole let a typed region with an empty write set and
+        // no call vanish with NO record of any kind. That is:
+        //   * a hole in REQ-017's invariant — maximally conservative, and silent;
+        //   * a one-line laundering vector, since wrapping a flagged expression
+        //     in a typed block removed it from the report entirely;
+        //   * a source of WRONG adjudicator verdicts, which read the resulting
+        //     absence as `removed-with-code` while the code was still there.
+        //
+        // An empty write set makes a region CHEAPER TO HAVOC, not more analysed.
+        ctx.gaps.push(Gap {
+            func_index: self.func_index,
+            pc: opener as u32,
+            op: op_report_name(&self.ops[opener]),
+            kind: GapKind::UnmodeledControlFlow,
         });
-        if !written.is_empty() || region_has_call {
-            ctx.gaps.push(Gap {
-                func_index: self.func_index,
-                pc: opener as u32,
-                op: op_report_name(&self.ops[opener]),
-                kind: GapKind::UnmodeledControlFlow,
-            });
-        }
         for idx in &written {
             if let Some(slot) = ctx.locals.get_mut(*idx as usize) {
                 *slot = AbstractValue::I32Interval(domain::top());
@@ -9114,6 +9112,65 @@ mod tests {
             SCRY_VERSION.split('.').count() == 3
                 && SCRY_VERSION.split('.').all(|p| p.parse::<u32>().is_ok()),
             "expected a three-part numeric version, got {SCRY_VERSION:?}"
+
+    /// scry#121: `havoc_region` never interprets the region body, but recorded a
+    /// gap ONLY when the write set was non-empty or the region held a call. So a
+    /// typed region that writes no local and calls nothing vanished with no
+    /// record of any kind — no trap check, no gap, no advisory.
+    ///
+    /// That breaks the invariant REQ-017 exists for: every place the analysis is
+    /// conservative is recorded as DATA, never as silence. Here scry is
+    /// maximally conservative — it interprets nothing — and says nothing.
+    ///
+    /// It is also a one-line laundering vector: wrapping a flagged expression in
+    /// a typed block removed it from the report entirely, no understanding of
+    /// any internal scheme required. And it promotes to a WRONG VERDICT in the
+    /// adjudicator, which reads "absent from the after-run" as
+    /// `removed-with-code` — "the site no longer exists" — while the code is
+    /// still there and the obligation still live (DD-021 finding 3).
+    #[test]
+    fn issue121_havocked_region_always_records_a_gap() {
+        // CONTROL FIRST: unwrapped, the obligation is reported. If this ever
+        // stops holding, the test below proves nothing about laundering.
+        let bare = analyze_default(
+            "(module (func (export \"b\") (param i32) (result i32) \
+             i32.const 10 local.get 0 i32.div_s))",
+        );
+        assert!(
+            !bare.trap_checks.is_empty(),
+            "control: the unwrapped div must raise a trap check"
+        );
+
+        // The laundering case: same expression inside a typed block. The block
+        // writes NO local and contains NO call, so it took the silent path.
+        let wrapped = analyze_default(
+            "(module (func (export \"b\") (param i32) (result i32) \
+             (block (result i32) i32.const 10 local.get 0 i32.div_s)))",
+        );
+        assert!(
+            !wrapped.gaps.is_empty(),
+            "a region that was NEVER INTERPRETED must record a gap — it is \
+             maximally conservative, so silence is the one thing it must not be"
+        );
+        let g = wrapped
+            .gaps
+            .iter()
+            .find(|g| g.kind == GapKind::UnmodeledControlFlow)
+            .expect("the havoc must be recorded as unmodelled control flow");
+        assert_eq!(g.func_index, 0);
+
+        // Same for a typed `if`, which took the identical path.
+        let iffed = analyze_default(
+            "(module (func (export \"b\") (param i32) (result i32) \
+             local.get 0 (if (result i32) (then i32.const 10 local.get 0 i32.div_s) \
+             (else i32.const 1))))",
+        );
+        assert!(
+            iffed
+                .gaps
+                .iter()
+                .any(|g| g.kind == GapKind::UnmodeledControlFlow),
+            "a typed `if` havoc must record a gap too"
         );
     }
 


### PR DESCRIPTION
Closes #121.

## The hole

`havoc_region` never interprets the region body, yet it recorded a gap **only** when the write set was non-empty or the region contained a call. A typed region that writes no local and calls nothing vanished with **no record of any kind** — no trap check, no gap, no advisory.

Reproduced exactly as filed:

```wat
(block (result i32) i32.const 10 local.get 0 i32.div_s)   ;; empty report
i32.const 10 local.get 0 i32.div_s                        ;; div-by-zero POTENTIAL-TRAP
```

A typed `if` behaved identically.

## Only the first consequence is about precision

1. **The gap report was not complete.** An assessor reading `gaps` as the scope boundary got a region that was never analysed and never disclosed.
2. **A one-line laundering vector.** Wrapping a flagged expression in a typed block removed it from the report entirely — no understanding of any internal scheme required.
3. **It promoted to a wrong verdict downstream.** The adjudicator reads "absent from the after-run" as `removed-with-code` — literally *"the site no longer exists"* — while the code is still there and the obligation live.

This is a hole in **REQ-017's invariant**, not merely a missing record: here the analyzer is *maximally* conservative — it interprets nothing — and says nothing at all, which is exactly what that invariant forbids.

## The fix, and why the old gate existed

Emit the gap unconditionally. The old gate's call half was added **correctly** (FEAT-043: a void call inside an `if` must still record, or `resolved_stack_callees` silently under-counts). The lesson just generalises further than it was applied: *the reason to record is that the region **was not analysed**, not that it happened to write a local.* An empty write set makes a region **cheaper to havoc, not more analysed**.

## Test discipline

Written **red first**, and it asserts its **control first** — that the unwrapped expression raises a trap check. Without that, an empty report would satisfy the laundering assertion either way, which is the precise vacuity this repo keeps producing.

## Measured impact — read this before the dashboard moves

Same module through both binaries, so it's attributable to this change rather than module drift:

| | gaps on `scry_mcdc.wasm` |
|---|---|
| before | **2046** |
| after | **2100** |

Those **54 regions were always being havoc'd** — they were simply not disclosed. The number rising is **visibility, not regression**, and the release note should say so before someone reads it the other way.

Checked rather than assumed: **no `claims.yaml` predicate is bound to a gap count** (0 matches), so the increase breaks no gated claim.

## Gates (exit codes)

tests **0** (106 core + 37 viz) · clippy `-D warnings` **0** · fmt **0** · `rivet validate` **PASS** · claim-check **5/5**

CI not claimed.