### PR TITLE
FEAT-080 (#141): CI actually runs the analyzer's tests, plus a guard that keeps it that way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,47 @@ jobs:
       # host harness (tests/octagon.rs) re-exercises it on the cargo
       # path. The Rocq interval-soundness proof
       # (proofs/rocq/Soundness.v) is gated by the dedicated Rocq job.
+      # scry#141: for most of this project's life the Test job ran FOUR
+      # packages, and `scry-sai-core` — the analyzer itself — was not one of
+      # them. 222 of 273 workspace tests (81%) never executed in CI, including
+      # every domain crate except octagon, all of scry-viz, and every regression
+      # oracle written for scry#121/#125/#126/#123.
+      #
+      # The Bazel `rust_test(name = "scry_analyze_core_test")` target exists but
+      # no workflow invokes it: the only `bazel test` calls are for
+      # //proofs/rocq/... and //proofs/verus/....
+      #
+      # Listed explicitly rather than `--workspace` on purpose: the workspace
+      # contains wasm32 cdylib members that a host-target `cargo test` cannot
+      # build (the reason PR #41 set default-members in the first place). Adding
+      # a crate here is a deliberate act; a new crate is NOT covered until its
+      # name appears below.
+      # scry#141: gate the gate. Adding the crates above fixes the hole ONCE;
+      # this stops it reopening. Every publishable crate in crates/ must appear
+      # in a `cargo test` invocation in this workflow, or the job fails with the
+      # crate named. Without it the next new domain crate silently joins the 81%
+      # that were never tested — which is exactly how this happened.
+      - name: Guard — every publishable crate is actually tested
+        run: |
+          set -euo pipefail
+          missing=""
+          for d in crates/*/; do
+            name=$(grep -m1 '^name = ' "$d/Cargo.toml" 2>/dev/null | cut -d'"' -f2) || continue
+            [ -z "$name" ] && continue
+            grep -q '^publish = false' "$d/Cargo.toml" && continue
+            grep -qE -- "(-p|--package) $name( |$|\\)" .github/workflows/ci.yml || missing="$missing $name"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::publishable crate(s) never run by any cargo test step:$missing"
+            exit 1
+          fi
+          echo "OK — every publishable crate appears in a cargo test invocation"
+      - name: cargo test — analyzer core, viz, and the domain crates
+        run: |
+          cargo test -p scry-sai-core -p scry-sai-viz -p scry-sai-interval \
+                     -p scry-sai-bits -p scry-sai-float -p scry-sai-handle \
+                     -p scry-sai-pentagon -p scry-sai-segment -p scry-sai-poly \
+                     -- --nocapture
       - name: cargo test --package scry-sai-octagon
         run: cargo test --package scry-sai-octagon -- --nocapture
       # FEAT-011: the full-stack Rocq soundness proofs (Soundness /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,13 +170,23 @@ jobs:
       # that were never tested — which is exactly how this happened.
       - name: Guard — every publishable crate is actually tested
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          # Extract the tested package names ONCE, then do fixed-string
+          # membership. The first version built a regex per crate name and
+          # failed in CI with `grep: Unmatched ( or \(` — the alternation
+          # survived YAML and BSD grep locally but not GNU grep. It failed
+          # CLOSED (red, naming all 12 crates) rather than open, which is the
+          # right direction, but a guard whose own matching is fragile is not
+          # a guard. No dynamic regex now.
+          tested=$(grep -oE -- '(-p|--package) [A-Za-z0-9_-]+' .github/workflows/ci.yml \
+                   | awk '{print $2}' | sort -u)
           missing=""
           for d in crates/*/; do
-            name=$(grep -m1 '^name = ' "$d/Cargo.toml" 2>/dev/null | cut -d'"' -f2) || continue
+            [ -f "$d/Cargo.toml" ] || continue
+            name=$(grep -m1 '^name = ' "$d/Cargo.toml" | cut -d'"' -f2)
             [ -z "$name" ] && continue
             grep -q '^publish = false' "$d/Cargo.toml" && continue
-            grep -qE -- "(-p|--package) $name( |$|\\)" .github/workflows/ci.yml || missing="$missing $name"
+            printf '%s\n' "$tested" | grep -qxF "$name" || missing="$missing $name"
           done
           if [ -n "$missing" ]; then
             echo "::error::publishable crate(s) never run by any cargo test step:$missing"

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1664,6 +1664,56 @@ artifacts:
         - "Given the same check on main at wasmtime 45 (the control), Then zero ignores are stale — establishing that the bump cleared the four, rather than their having been stale already."
         - "Given `cargo test -p scry-host-tests` on wasmtime 47, Then the harness passes unmodified: 32 pass; the single failure is `feat013_live_analyze_gate`, which names its own precondition (composed component missing at bazel-bin/scry.wasm) and is environmental, not an API regression."
         - "Given deny.toml after this change, Then exactly one ignore remains and its comment states what was re-evaluated and what would actually clear it — not a re-worded version of the check already performed."
+
+  - id: FEAT-080
+    type: feature
+    title: "v3.2.6 — CI actually runs the analyzer's tests, and a guard keeps it that way (scry#141)"
+    status: proposed
+    release: v3.2.6
+    description: >
+      The CI Test job ran `cargo test` on FOUR packages. `scry-sai-core` — the
+      analyzer itself — was not one of them. Measured across the workspace:
+      222 of 273 tests (81%) never executed in CI.
+
+      Nine of twelve published crates were uncovered, and with them the entire
+      interpreter, the fixpoint, guard refinement, obligation identity, advisory
+      classification, eight of ten abstract domains, all of scry-viz — and every
+      regression oracle recently added for scry#121, #123, #125 and #126. Those
+      were written red-first and mutation-checked, and not one of them could
+      have failed a build.
+
+      The Bazel `rust_test(name = "scry_analyze_core_test")` target existed but
+      no workflow invoked it; the only `bazel test` calls are //proofs/rocq/...
+      and //proofs/verus/....
+
+      WHAT A GREEN CHECK ACTUALLY MEANT: "host-tests, provenance, taint and
+      octagon pass." Not "the analyzer works." Combined with scry#130 (main has
+      no required_status_checks, so the gate is advisory anyway), a change could
+      break every analyzer test and merge on a green board. Claims made elsewhere
+      on the strength of "CI is green" — including the qualification dossier's
+      CI-gate citations — need re-reading against what CI actually ran.
+
+      TWO PARTS, because fixing it once is not enough. (1) Add the nine missing
+      packages. (2) GATE THE GATE: a step that fails, naming the crate, if any
+      publishable crate in crates/ is absent from a `cargo test` invocation.
+      Listed explicitly rather than `--workspace` because the workspace holds
+      wasm32 cdylib members a host-target `cargo test` cannot build (the reason
+      PR #41 set default-members); the guard is what makes "explicit" safe, by
+      making omission loud instead of silent.
+
+      HOW IT WAS FOUND, because the method transfers: incidentally, while wiring
+      `verification` artifacts for the dev V-model and needing to cite a CI job
+      as evidence for each requirement. No job could be found that ran the tests
+      the citation wanted. Asking "what gate proves this?" per requirement is
+      what surfaced the missing gate — the traceability exercise doing its job
+      rather than a coverage number being chased.
+    tags: [ci, gate-potency, honesty, issue-driven, v3.2.6]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given the CI Test job, When it runs, Then every publishable crate in crates/ is exercised by a `cargo test` invocation — verified locally at 222 tests, exit 0, across the nine previously-missing packages."
+        - "Given a publishable crate absent from every `cargo test` step, When the guard runs, Then the job FAILS and names that crate. MUTATION-CHECKED: removing `-p scry-sai-bits` makes it fire with `missing: scry-sai-bits`; restoring it clears. A guard that cannot fail would be the same defect one level up."
+        - "Given the explicit package list, Then it is deliberately not `--workspace`: the workspace holds wasm32 cdylib members a host `cargo test` cannot build. The guard is what makes the explicit list safe."
     links:
       - type: traces-to
         target: REQ-001


### PR DESCRIPTION
Closes #141.

## The Test job ran four packages. `scry-sai-core` was not one of them.

| pkg | tests | in CI? |
|---|---:|---|
| **scry-sai-core** | **106** | **NO** |
| scry-sai-viz | 34 | **NO** |
| scry-sai-bits | 23 | **NO** |
| scry-sai-pentagon | 17 | **NO** |
| scry-sai-segment | 10 | **NO** |
| scry-sai-float | 9 | **NO** |
| scry-sai-poly | 9 | **NO** |
| scry-sai-interval | 8 | **NO** |
| scry-sai-handle | 6 | **NO** |
| scry-sai-octagon | 26 | yes |
| scry-sai-provenance | 13 | yes |
| scry-sai-taint | 12 | yes |

**222 of 273 tests — 81% — never executed in CI.**

The Bazel `rust_test(name = "scry_analyze_core_test")` target exists, but no workflow invokes it: the only `bazel test` calls are `//proofs/rocq/...` and `//proofs/verus/...`.

## What that means for recent work

Every regression oracle added for #121, #123, #125 and #126 lives in `scry-sai-core` or `scry-sai-viz`. They were written **red-first and mutation-checked** — and not one of them could have failed a build. So could the whole interpreter, the fixpoint, guard refinement, obligation identity, advisory classification, and eight of ten abstract domains.

A green Test check meant *"host-tests, provenance, taint and octagon pass."* It did not mean the analyzer works.

Paired with **#130** — `main` has no `required_status_checks`, so the gate is advisory anyway — a change could break every analyzer test and merge on a green board. Claims made elsewhere on the strength of "CI is green", including the qualification dossier's CI-gate citations, want re-reading against what CI actually ran.

## Two parts, because fixing it once is not enough

**1. Add the nine missing packages.** Verified locally: 222 tests, **exit 0**.

**2. Gate the gate.** A step that fails, naming the crate, if any publishable crate in `crates/` is absent from a `cargo test` invocation.

That guard is **mutation-checked**, because a guard that cannot fail is the same defect one level up:

```
### MUTATION: drop -p scry-sai-bits ###
  GUARD FIRES — missing: scry-sai-bits
### restored ###
  OK again
```

Listed explicitly rather than `--workspace` on purpose: the workspace holds wasm32 cdylib members a host-target `cargo test` cannot build — the reason PR #41 set `default-members`. The guard is what makes the explicit list safe, by making omission **loud** instead of silent.

## How it was found

Incidentally, while a subagent wired `verification` artifacts for the dev V-model (#140) and needed to cite a CI job as evidence for each requirement. It could not find a job running the tests it wanted to cite.

The method transfers: **asking "what gate proves this?" per requirement is what surfaced the missing gate** — the traceability exercise doing its job, rather than a coverage number being chased.

`ci.yml` parses · guard verified locally (passes now, fires under mutation) · `rivet validate` PASS.

CI not claimed — GitHub runners are heavily backed up.