### PR TITLE
dossier: correct the CI-gate citations to what CI actually ran (#141)

### DIFF
--- a/claims.yaml
+++ b/claims.yaml
@@ -28,6 +28,32 @@ claims:
         glob: ['Cargo.toml']
         min: 1
 
+  # ── Dossier CI-gate scope (scry#141) ──────────────────────────────────────
+  # The qualification dossier cited `bazel test //...` as a DO-330 T-1(4) gate.
+  # CI never ran that — only the two proof trees. An assessor-facing document
+  # claiming a broader gate than exists is the drift this ledger is for, so the
+  # corrected text is now bound to the workflow that has to contain it.
+  - id: DOSSIER-BAZEL-SCOPE
+    doc: docs/qualification-dossier-v1.md
+    text: "`bazel test //proofs/rocq/... //proofs/verus/...`"
+    evidence:
+      - kind: count-min
+        pattern: 'run: bazel test //proofs/rocq/'
+        glob: ['.github/workflows/*.yml']
+        min: 1
+      - kind: count-min
+        pattern: 'run: bazel test //proofs/verus/'
+        glob: ['.github/workflows/*.yml']
+        min: 1
+      # And the claim that CI runs NO OTHER bazel test tree: if a third appears,
+      # the dossier row naming exactly two becomes stale and must be updated.
+      # Matched on the INVOCATION form: a comment mentioning a bazel target is
+      # not a gate, and counting one made this predicate measure prose.
+      - kind: count-max
+        pattern: 'run: bazel test //'
+        glob: ['.github/workflows/*.yml']
+        max: 2
+
   # ── Admit-free proofs ─────────────────────────────────────────────────────
   # The README claims 0 Admitted/admit/Axiom across the Rocq proofs. Re-counted
   # from the actual .v source (not a typed figure); a single admit/axiom → red.

--- a/docs/qualification-dossier-v1.md
+++ b/docs/qualification-dossier-v1.md
@@ -68,11 +68,36 @@ per DO-330 Table T-0/T-1 (tool operational requirements & verification):
 | T-0(1) Tool Operational Requirements defined | §1 above; `artifacts/` rivet REQ-001..017 | scope |
 | T-0(2) TOR correct & complete | `rivet validate` (CI gate); `rivet coverage` traceability report (assessor-run, §8) | gate |
 | T-1(1) Tool operational use verified vs TOR | `crates/scry-host-tests` (host runs the composed `scry.wasm`) + `SCRY_COMPONENT_PATH` release-wasm oracle | test |
-| T-1(3) Robustness of tool operation | γ-sweep tests (interval/octagon/bits/pentagon/float/handle), adversarial clean-room per soundness feature | test |
-| T-1(4) TOR verification complete | `bazel test //...` + `cargo test` + MC/DC gate (all CI) | gate |
+| T-1(3) Robustness of tool operation | γ-sweep tests (interval/octagon/bits/pentagon/float/handle), adversarial clean-room per soundness feature — see the scope note below for which of these CI executes | test |
+| T-1(4) TOR verification complete | `bazel test //proofs/rocq/... //proofs/verus/...` + per-package `cargo test` (enumerated in `ci.yml`, claim-gated) + MC/DC gate — see the scope note below | gate |
 | Soundness of the analysis (credit basis) | admit-free Rocq (§4), Verus join proof, MC/DC truth tables | **proof** |
 | Configuration management | git + version-pinned deps (`Cargo.lock`, Bazel `MODULE.bazel`); release artifacts **cosign-signed (sigstore keyless OIDC) + SLSA-v1 build-provenance-attested** (`release.yml`) | gate |
 | Tool operational environment defined | `MODULE.bazel` (Bazel+Nix pins: Rocq 9.0, wasmparser 0.252), `rust-toolchain` | scope |
+
+> **Scope note on the CI-gate citations (corrected 2026-08-26, scry#141).**
+> Two of the rows above previously cited evidence materially broader than what
+> CI executed, and an assessor would have read them as stronger than they were.
+>
+> * **`bazel test //...` was never run by CI.** The only Bazel test invocations
+>   are `//proofs/rocq/...` and `//proofs/verus/...`. The crate-level target
+>   `rust_test(scry_analyze_core_test)` exists in `crates/scry-analyze-core/BUILD.bazel`
+>   but no workflow invokes it. The row now names the targets that actually run.
+> * **`cargo test` was per-package, not workspace-wide.** At the time this
+>   dossier was written CI ran four packages — `scry-host-tests`,
+>   `scry-sai-provenance`, `scry-sai-taint`, `scry-sai-octagon` — which is **51
+>   of 273 workspace tests**. The analyzer core (`scry-sai-core`, 106 tests) was
+>   not among them. Of the six γ-swept domains cited under T-1(3), only
+>   **octagon** was executed by CI; the other five ran locally only.
+> * **The MC/DC gate measures a population that is largely not scry's code.**
+>   In the sampled report, **zero of twelve** full-MC/DC decisions were in
+>   first-party source — the rest were Rust core/alloc, `wasmparser` and
+>   `dlmalloc` (scry#117). The gate is real; what it is a gate *on* is narrower
+>   than "scry's decisions".
+>
+> The package list is now enumerated in `ci.yml` and bound by the `claim-check`
+> gate (`claims.yaml`), so this specific drift cannot recur silently: adding a
+> crate without adding it to CI fails the build, and changing the CI scope
+> without updating this note fails `claim-check`.
 
 ## 4. Mechanized-soundness inventory (the credit basis)
 


### PR DESCRIPTION
Honouring a commitment I made in #141: *"claims made elsewhere on the strength of 'CI is green' … including the qualification dossier's CI-gate citations, want re-reading against what CI actually ran."*

Two rows cited evidence materially broader than reality — on an **assessor-facing** document.

## T-1(4) "TOR verification complete" — kind: **gate**

| claimed | reality |
|---|---|
| `bazel test //...` | CI runs bazel test **only** on `//proofs/rocq/...` and `//proofs/verus/...`. `rust_test(scry_analyze_core_test)` exists in `crates/scry-analyze-core/BUILD.bazel` and **no workflow invokes it**. |
| `cargo test` | Per-package: **four** packages, **51 of 273** tests. The analyzer core was not among them. |
| MC/DC gate | Real, but **zero of twelve** full-MC/DC decisions were first-party in the sampled report (#117). |

## T-1(3) "Robustness of tool operation" — kind: **test**

Cites γ-sweeps across `interval/octagon/bits/pentagon/float/handle`. **Only octagon was executed by CI**; the other five ran locally only.

## Bound, not merely corrected

A prose fix would drift again. New claim `DOSSIER-BAZEL-SCOPE` ties the corrected row to the workflows: two `count-min` predicates for the trees that must be present, plus a `count-max` asserting **no third bazel test tree** appears without this row being updated.

**The count-max fired at 3 against a recorded max of 2 on its first run.** The third occurrence was a *comment* mentioning a bazel target — so my predicate was counting **prose rather than gates**, which is exactly the error this ledger exists to catch. I fixed the pattern to the `run:` form rather than raising the number.

Mutation-checked:
```
+ run: bazel test //crates/...   →  ✗ DOSSIER-BAZEL-SCOPE, 5/6
  (removed)                      →  6/6
```

## Notes

- **No new rivet FEAT** — `claims.yaml` *is* the tracking mechanism for doc claims; a parallel artifact would duplicate it.
- **Touches no roadmap file**, deliberately: four PRs are in flight against `roadmap-3.0.yaml` (#143).
- The scope note says plainly that the gate is real and *what it gates* is narrower than "scry's decisions" — the point is calibration, not retraction.

claim-check **6/6** · `rivet validate` **0**.