### PR TITLE
v3.3.0: promote the four verified features, name what is actually left

### DIFF
--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1160,8 +1160,8 @@ artifacts:
 
   - id: FEAT-068
     type: feature
-    title: "v3.3 — guidance.json v2: versioned schema carrying obligation IDs"
-    status: proposed
+    title: "v3.3 — guidance.json: a versioned schema carrying obligation IDs (shipped as v2, now v3)"
+    status: accepted
     release: v3.3.0
     description: >
       The v3.2.2 guidance feed shipped un-versioned. v2 adds an explicit
@@ -1172,7 +1172,8 @@ artifacts:
     fields:
       phase: phase-3
       acceptance-criteria:
-        - "Given guidance.json v2, When a consumer reads it, Then every advisory carries a stable obligation ID and the document declares its schema version and module hash."
+        - "Given guidance.json, When a consumer reads it, Then every advisory carries a stable obligation ID and the document declares its schema version and module hash. VERIFIED on a real feed: guidance_schema=3, module_sha256 present, and every advisory carries obligation_id / site_key / group_key / id_build_local."
+        - "VERSION DRIFT, recorded rather than hidden: this feature shipped the feed at schema 2; FEAT-082 then added `id_build_local` and bumped it to 3. The AC requires the document to DECLARE its version, not to be any particular one, so it is satisfied — but the feature title said `v2` while the artifact said `3`, which is exactly the drift claims.yaml exists to catch and which no predicate covered here."
     links:
       - type: traces-to
         target: REQ-018
@@ -1210,7 +1211,7 @@ artifacts:
   - id: FEAT-070
     type: feature
     title: "v3.3 — Guard refinement for `br_if` on a bare value (precision)"
-    status: proposed
+    status: accepted
     release: v3.3.0
     description: >
       Our guard refinement recognises `local.get X; i32.const c; <cmp>; br_if`,
@@ -1269,7 +1270,7 @@ artifacts:
   - id: FEAT-072
     type: feature
     title: "v3.3 — Obligation anchors + the delta view (identity, made visible)"
-    status: proposed
+    status: accepted
     release: v3.3.0
     description: >
       The dashboard renders ONE snapshot. The entire value of a stable obligation
@@ -1327,7 +1328,7 @@ artifacts:
   - id: FEAT-073
     type: feature
     title: "v3.3 — Self-adjudication harness: scry adjudicates scry, in observation mode"
-    status: proposed
+    status: accepted
     release: v3.3.0
     description: >
       Roll the fix-verify loop out ON OURSELVES. FEAT-025 already dogfoods scry


### PR DESCRIPTION
Audited v3.3.0's ten unverified artifacts **against what is on `main`** rather than assuming — after v3.2.6 turned out to hold three features that were done and merely unpromoted.

## The split, checked not inferred

**Implemented and verified → `accepted` (4)**

| | |
|---|---|
| FEAT-068 | guidance.json versioned schema + identity keys |
| FEAT-070 | `br_if`-on-bare-value guard refinement (2 tests) |
| FEAT-072 | obligation anchors + the delta view |
| FEAT-073 | self-adjudication harness, observation mode |

**Genuinely unbuilt (4)** — grepped for code on main:

| | evidence |
|---|---|
| FEAT-066 | no `crates/*mcp*` crate exists |
| FEAT-067 | no query filter surface |
| FEAT-069 | no safe-accesses emitter |
| FEAT-071 | no capability manifest |

**Stays `proposed`, correctly (2)**

- **FEAT-064** — **two of its eight ACs are flagged not met.** AC#1 is recorded as *falsified in practice*: identity survival measured at ~74%, not the 100% the AC states. FEAT-077/082 improved it from ~52% but **did not make the AC true**. The artifact is doing its job by refusing promotion, and I'm not going to soften the AC to move a number.
- **REQ-020** — depends on FEAT-064.

So v3.3.0 goes **10 unverified → 6**, and the 6 are now honestly categorised: four nobody has built, one whose own AC says it isn't met, and the requirement waiting on it.

## Version drift found and recorded

FEAT-068 was titled *"guidance.json **v2**"* while the shipped feed declares **schema 3** — FEAT-082 added `id_build_local` and bumped it.

The AC requires the document to *declare* its version rather than be any particular one, so it is satisfied. But the title was stale, which is exactly the class `claims.yaml` gates for the README and which **no predicate covered here**. Corrected in place, with the drift written into the AC rather than smoothed away.

Verified on a **real feed**, not from source:

```
guidance_schema : 3
module_sha256   : present
advisory.obligation_id / site_key / group_key / id_build_local : all present
```

tests **0** · clippy **0** · fmt **0** · `rivet validate` **0** · claim-check **0**.