### PR TITLE
v3.2.6: promote the last two features — the release is genuinely cuttable

### DIFF
--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1671,7 +1671,7 @@ artifacts:
   - id: FEAT-080
     type: feature
     title: "v3.2.6 — CI actually runs the analyzer's tests, and a guard keeps it that way (scry#141)"
-    status: proposed
+    status: accepted
     release: v3.2.6
     description: >
       The CI Test job ran `cargo test` on FOUR packages. `scry-sai-core` — the
@@ -1714,7 +1714,7 @@ artifacts:
     fields:
       phase: phase-3
       acceptance-criteria:
-        - "Given the CI Test job, When it runs, Then every publishable crate in crates/ is exercised by a `cargo test` invocation — verified locally at 222 tests, exit 0, across the nine previously-missing packages."
+        - "Given the CI Test job, When it runs, Then every publishable crate in crates/ is exercised by a `cargo test` invocation. DISCHARGED IN CI on main d295fd8, not merely locally: the guard step printed `OK — every publishable crate appears in a cargo test invocation`, the new step ran `cargo test -p scry-sai-core -p scry-sai-viz -p scry-sai-interval ...`, and the job executed 322 tests against the 51 it ran before."
         - "Given a publishable crate absent from every `cargo test` step, When the guard runs, Then the job FAILS and names that crate. MUTATION-CHECKED: removing `-p scry-sai-bits` makes it fire with `missing: scry-sai-bits`; restoring it clears. A guard that cannot fail would be the same defect one level up."
         - "Given the explicit package list, Then it is deliberately not `--workspace`: the workspace holds wasm32 cdylib members a host `cargo test` cannot build. The guard is what makes the explicit list safe."
     links:
@@ -1723,7 +1723,7 @@ artifacts:
   - id: FEAT-079
     type: feature
     title: "v3.2.6 — Every havoc'd region records a gap: close the laundering hole (scry#121)"
-    status: proposed
+    status: accepted
     release: v3.2.6
     description: >
       `havoc_region` never interprets the region body, yet it recorded a gap ONLY


### PR DESCRIPTION
FEAT-079 (#121 havoc gap) and FEAT-080 (#141 CI coverage) are merged with CI green and neither carries an AC flagged not-met. Promoting both takes **v3.2.6 to 5/5 and Cuttable**.

Unlike the earlier partial promotion, this one isn't scope-limited — all five features are on `main`, so "cuttable" no longer means *"cuttable as far as main happens to have got"*.

| | |
|---|---|
| FEAT-076 | release machinery stops failing silently (#134) |
| FEAT-078 | wasmtime 45 → 47, advisory ignores 5 → 1 (#138) |
| FEAT-079 | every havoc'd region records a gap (#139) |
| FEAT-080 | CI actually runs the analyzer's tests, plus a guard (#142) |
| FEAT-082 | identity survives v0 Rust mangling (#146) |

## FEAT-080's AC#1 upgraded, because the evidence changed

It read *"verified **locally** at 222 tests, exit 0"*. Main's CI on `d295fd8` now discharges it directly:

```
Guard — every publishable crate is actually tested:
  OK — every publishable crate appears in a cargo test invocation

cargo test — analyzer core, viz, and the domain crates:
  cargo test -p scry-sai-core -p scry-sai-viz -p scry-sai-interval ...

total executed by the Test job: 322 tests    (was 51)
```

That distinction is the entire point of #141 — *"the local oracle passed" was never "the gate passed"* — and this is the **first time the analyzer's own tests can honestly be cited as CI evidence**.

## Not cutting

Tagging publishes to crates.io and is irreversible. That's a decision to surface, not to take.

tests **0** · clippy **0** · fmt **0** · `rivet validate` **0** · claim-check **0**.