### PR TITLE
release: v3.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,78 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.2.6] — 2026-08-26
+
+Five fixes, three of which were things quietly WRONG rather than missing. All
+five were found by inspecting what the project actually did — running the
+released artifact, reading CI logs, re-measuring a claim — not by the fixture
+suite.
+
+### Fixed — CI (the one that changes what every other green means)
+
+- **CI never ran 81% of the test suite** (#141, FEAT-080). The Test job ran
+  `cargo test` on FOUR packages; `scry-sai-core` — the analyzer itself — was not
+  among them. 222 of 273 workspace tests never executed: nine of twelve
+  published crates, eight of ten abstract domains, all of scry-viz, and every
+  regression oracle recently added. A green Test check meant "host-tests,
+  provenance, taint and octagon pass", not "the analyzer works".
+
+  Fixed in two parts, because fixing it once is not enough: the nine missing
+  packages are added, AND a guard fails the job — naming the crate — if any
+  publishable crate is absent from a `cargo test` invocation. The guard is
+  mutation-checked; a guard that cannot fail is the same defect one level up.
+  It also went red on its own first run (a dynamic regex that survived BSD grep
+  and not GNU grep) and was rewritten without one — it failed CLOSED, which is
+  why that was visible in one run instead of hiding.
+
+  Confirmed in CI on main, not merely locally: the Test job now executes
+  **322 tests** against the 51 it ran before.
+
+### Fixed — release machinery
+
+- **The release machinery stopped failing silently** (#132/#133, FEAT-076).
+  `SCRY_VERSION` was a hand-maintained literal the v3.2.5 bump missed, so the
+  shipped 3.2.5 component reported itself as "scry 3.2.4" — and consumers
+  identify the producing analyzer from that string. Now derived from
+  `env!("CARGO_PKG_VERSION")`.
+
+  The FEAT-072 delta view also never rendered on Pages and said nothing about
+  it: a shallow checkout left no tags, and `grep` returns 1 on empty input under
+  GitHub's default `bash -e`, so the step aborted BEFORE the message it was
+  written to print. Every exit path now prints a `DELTA-STEP:` status line.
+
+### Fixed — analysis honesty
+
+- **Every havoc'd region now records a gap** (#121, FEAT-079). A typed region
+  with an empty write set and no call vanished with no record of any kind — no
+  trap check, no gap, no advisory. That was a hole in REQ-017's invariant (the
+  analyzer was MAXIMALLY conservative and said nothing at all), a one-line
+  laundering vector (wrapping a flagged expression in a typed block removed it
+  from the report entirely), and a source of wrong downstream verdicts.
+
+  Measured on scry's own module: gaps 2046 -> 2100. Those 54 regions were always
+  being havoc'd; they were simply never disclosed. **The number rising is
+  visibility, not regression.**
+
+### Fixed — identity
+
+- **Function identity survives v0 Rust mangling** (#144, FEAT-082). FEAT-077
+  (below) stripped only the LEGACY disambiguator. A downstream consumer reported
+  their target is v0-mangled, where the disambiguator is a crate-level
+  `Cs<base62>_` near the front — so on the module that most needed a stable join
+  key, the fix gave none. Measured: identity churned `217a5de8eb443492` vs
+  `d32b864664215709`. Legacy behaviour is unchanged, regression-pinned.
+
+### Security / dependencies
+
+- **wasmtime 45 -> 47** (#116, FEAT-078), clearing **four of five** standing
+  advisory ignores: RUSTSEC-2026-0182, -0188, -0190, -0222. Measured with a
+  control — at wasmtime 45 zero ignores were stale, so the bump is what cleared
+  them rather than their having been stale already. RUSTSEC-2026-0204 survives
+  (crossbeam-epoch 0.9.18) and its comment now names what would actually clear
+  it. No API churn: the harness compiles unmodified.
+
+
 ### Added — scry-sai-core
 
 - **FEAT-077 (scry#123): two-tier function identity.** `func_ident` — the
@@ -32,6 +104,26 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
   build-local site vanishing/appearing between builds is expected identity
   churn, not evidence a site came or went.
 
+### Falsification
+
+This release is wrong if a module that analysed successfully under 3.2.5 now
+returns an error or a different verdict set, or if the gap-count increase
+reflects anything other than previously-silent havoc'd regions. The gap delta
+was measured on ONE module (scry's own); a corpus-wide before/after would
+falsify it properly.
+
+It is also wrong if the CI guard can be satisfied while a publishable crate goes
+untested — it was mutation-checked against one crate, not all twelve.
+
+### Known issues shipped
+
+- **#130** — `main` has no `required_status_checks`, so the CI gate is advisory.
+  Every merge in this release was verified by hand instead. Needs repo-admin.
+- **#128** — an operand-stack defect in `func.wast`, unmasked by the v3.2.5 panic
+  fix. Cause deliberately recorded as uncharacterised rather than guessed.
+- **#123** — obligation identity still churns ~26% per build, down from ~48%.
+  The residual is the collision population, which is MARKED `id_build_local`
+  rather than hidden.
 
 ## [3.2.5] — 2026-08-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1785,18 +1785,18 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-bits"
-version = "3.2.5"
+version = "3.2.6"
 
 [[package]]
 name = "scry-sai-core"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-float",
@@ -1814,19 +1814,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-float"
-version = "3.2.5"
+version = "3.2.6"
 
 [[package]]
 name = "scry-sai-handle"
-version = "3.2.5"
+version = "3.2.6"
 
 [[package]]
 name = "scry-sai-interval"
-version = "3.2.5"
+version = "3.2.6"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1835,34 +1835,34 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "3.2.5"
+version = "3.2.6"
 
 [[package]]
 name = "scry-sai-pentagon"
-version = "3.2.5"
+version = "3.2.6"
 
 [[package]]
 name = "scry-sai-poly"
-version = "3.2.5"
+version = "3.2.6"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "3.2.5"
+version = "3.2.6"
 
 [[package]]
 name = "scry-sai-segment"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "scry-sai-interval",
 ]
 
 [[package]]
 name = "scry-sai-taint"
-version = "3.2.5"
+version = "3.2.6"
 
 [[package]]
 name = "scry-sai-viz"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "3.2.5"
+version = "3.2.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ deductive-proof and bounded-model-checking layers do not staff.
 <!-- claim id=version: "scry-sai-core" crates.io max_version == workspace version -->
 <!-- claim id=crates: publish.rs lists 12 scry-sai-* crates -->
 <!-- claim id=admit-free: 0 Admitted/admit/Axiom across proofs/rocq/*.v -->
-**v3.2.5 shipped** — the full v0.1 → v3.2 arc is done; scry is a working **sound
+**v3.2.6 shipped** — the full v0.1 → v3.2 arc is done; scry is a working **sound
 abstract interpreter**, not a scaffold. Shipped and on crates.io: **12 pure
 `scry-sai-*` crates** (10 abstract domains — interval, region-memory, call-graph
 + reachability, octagon, pentagon, known-bits/congruence, IEEE-754 float,

--- a/claims.yaml
+++ b/claims.yaml
@@ -21,10 +21,10 @@ claims:
   # Cargo.toml + this pattern together — exactly the point.)
   - id: STATUS-VERSION
     doc: README.md
-    text: "**v3.2.5 shipped**"
+    text: "**v3.2.6 shipped**"
     evidence:
       - kind: count-min
-        pattern: 'version = "3\.2\.5"'
+        pattern: 'version = "3\.2\.6"'
         glob: ['Cargo.toml']
         min: 1
 

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "3.2.5" }
+scry-sai-interval = { path = "../scry-interval", version = "3.2.6" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,44 +43,44 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "3.2.5" }
-scry-sai-provenance = { path = "../scry-provenance", version = "3.2.5" }
+scry-sai-taint = { path = "../scry-taint", version = "3.2.6" }
+scry-sai-provenance = { path = "../scry-provenance", version = "3.2.6" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "3.2.5" }
+scry-sai-octagon = { path = "../scry-octagon", version = "3.2.6" }
 
 # Known-bits × interval-guarded congruence reduced product (FEAT-037 / DD-017):
 # an additive bit/alignment/stride companion computed in a straight-line-sound
 # pass, surfaced library-only on `AnalysisResult.bit_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-bits = { path = "../scry-bits", version = "3.2.5" }
+scry-sai-bits = { path = "../scry-bits", version = "3.2.6" }
 
 # Pentagons weakly-relational domain (FEAT-044 / AC-014): intervals + strict
 # `x < y` facts, the cheap relational layer behind sound out-of-bounds-trap
 # detection (FEAT-046). An additive guard-recording pass surfaces proven
 # strict relations library-only on `AnalysisResult.pentagon_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-pentagon = { path = "../scry-pentagon", version = "3.2.5" }
+scry-sai-pentagon = { path = "../scry-pentagon", version = "3.2.6" }
 
 # IEEE-754 float-interval domain (FEAT-047 / AC-022): sound f32/f64 abstraction
 # with NaN/±inf tracking + round-to-nearest-aware widening. An additive
 # straight-line pass surfaces sound float intervals library-only on
 # `AnalysisResult.float_facts`. Same pure `#![no_std]` dual-compile crate.
-scry-sai-float = { path = "../scry-float", version = "3.2.5" }
+scry-sai-float = { path = "../scry-float", version = "3.2.6" }
 
 # Affine Component-Model handle-state lattice (FEAT-049 / MF-007): tracks
 # own/borrow resource-handle state to flag use-after-drop / double-drop. A
 # straight-line pass over the canonical-ABI `[resource-drop]` call sites
 # surfaces findings library-only on `AnalysisResult.handle_findings`.
-scry-sai-handle = { path = "../scry-handle", version = "3.2.5" }
+scry-sai-handle = { path = "../scry-handle", version = "3.2.6" }
 
 # FEAT-058: the linear-memory segmentation domain (content-sensitive memory).
 # The interpreter tracks per-offset interval content for i32 loads/stores
 # instead of degrading every load to ⊤.
-scry-sai-segment = { path = "../scry-segment", version = "3.2.5" }
+scry-sai-segment = { path = "../scry-segment", version = "3.2.6" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-segment/Cargo.toml
+++ b/crates/scry-segment/Cargo.toml
@@ -20,4 +20,4 @@ path = "src/lib.rs"
 # The per-segment content domain. Path dep carries `version` so `cargo publish`
 # rewrites it to the crates.io coordinate; the version equals the workspace
 # version and is bumped in lockstep.
-scry-sai-interval = { path = "../scry-interval", version = "3.2.5" }
+scry-sai-interval = { path = "../scry-interval", version = "3.2.6" }

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "3.2.5" }
+scry-sai-core = { path = "../scry-analyze-core", version = "3.2.6" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }


### PR DESCRIPTION
Release prep for **v3.2.6** — five fixes, three of which were things quietly *wrong* rather than missing.

## What's here

- **Version bump to 3.2.6** across the workspace *and* all 12 pinned inter-crate dependencies. They must move together: `cargo publish` resolves each leaf from the crates.io index, so a stale `"3.2.5"` pin would publish a 3.2.6 core depending on the previous release.
- **CHANGELOG** with the falsification statement.
- **README / claims.yaml** status line — bumping `Cargo.toml` without them turns `STATUS-VERSION` red immediately, which is #97's drift gate working. claim-check **6/6** after.

The FEAT-077 / schema-v3 entries already under `[Unreleased]` are folded into 3.2.6 rather than duplicated.

## Falsification statement

> This release is wrong if a module that analysed successfully under 3.2.5 now returns an error or a different verdict set, or if the gap-count increase reflects anything other than previously-silent havoc'd regions.

Stated with its limits: the gap delta was measured on **one** module (scry's own) — a corpus-wide before/after would falsify it properly. And it's wrong if the CI guard can be satisfied while a publishable crate goes untested; that was mutation-checked against **one** crate, not twelve.

## Known issues shipped, listed not omitted

- **#130** — `main` has no `required_status_checks`, so the CI gate is advisory. Every merge in this release was verified **by hand** instead. Needs repo-admin.
- **#128** — operand-stack defect in `func.wast`, cause recorded as uncharacterised rather than guessed.
- **#123** — identity still churns **~26%** per build (down from ~48%); the residual is marked `id_build_local`, not hidden.

## Pre-tag invariants

| | |
|---|---|
| traceability gate | **PASS** — `rivet validate` 0, no approved/implemented artifact missing a `verifies` backlink |
| `rivet release status v3.2.6` | **✓ Cuttable** — 5/5 accepted |
| prior tag carries a success run | v3.2.5 ✓ |
| **branch gate enforced** | **✗ — known (#130), compensated by hand-verifying every merge** |

tests **0** · clippy **0** · fmt **0** · `rivet validate` **0** · claim-check **6/6**.