### PR TITLE
FEAT-083 (#152): the shipped component reports its real version

### DIFF
--- a/artifacts/roadmap-v3.2.7.yaml
+++ b/artifacts/roadmap-v3.2.7.yaml
@@ -1,0 +1,60 @@
+# v3.2.7 — filed in its own file per scry#143 fix (1).
+artifacts:
+  - id: FEAT-083
+    type: feature
+    title: "v3.2.7 — The shipped component reports its real version (scry#152)"
+    status: proposed
+    release: v3.2.7
+    description: >
+      Found by running the SHIPPED v3.2.6 artifact minutes after cutting it.
+      The component announced `scry 0.0.0` — not 3.2.6, and not the 3.2.4 that
+      scry#133 was about.
+
+      MECHANISM. FEAT-076 replaced a hand-maintained literal with
+      `env!("CARGO_PKG_VERSION")`, which is correct under cargo. The shipped
+      component is built by BAZEL, and rules_rust populates CARGO_PKG_VERSION
+      from the target's `version` attribute, defaulting it to "0.0.0". No
+      `crates/*/BUILD.bazel` set one. So the fix was right in the build nobody
+      ships and wrong in the build everybody consumes.
+
+      THE OTHER HALF, and the more instructive one: the test written for
+      scry#133 could not catch this. It asserted
+      `assert_eq!(SCRY_VERSION, env!("CARGO_PKG_VERSION"))` where SCRY_VERSION
+      IS that expression — tautological, unable to fail under any build.
+
+      It was NOT vacuous when written. Red-first it failed honestly with
+      left "3.2.4" / right "3.2.5", because SCRY_VERSION was still a literal.
+      It became vacuous the moment the fix landed, because the fix makes the
+      asserted identity true by construction. This is a vacuity class the
+      project's mutation-check discipline does not cover: reverting the
+      implementation to a literal makes such a test fail, which looks like a
+      healthy oracle, while the passing state carries no information at all.
+      A test can be meaningful before a change and worthless after it.
+
+      FIX, in two parts that are deliberately separate. (1) Set `version` on the
+      Bazel target so CARGO_PKG_VERSION matches the workspace under both builds.
+      (2) Replace the tautology with `assert_ne!(SCRY_VERSION, "0.0.0")`, which
+      names the rules_rust default explicitly and CAN fail.
+
+      The hard-coded Bazel literal recreates exactly the drift FEAT-076 set out
+      to end — Bazel cannot read Cargo.toml — so it is GATED rather than
+      trusted: claims.yaml pins it to the workspace version and forbids the
+      "0.0.0" default returning in any crate. A number maintained by hand is
+      acceptable only when something mechanical notices when it stops being
+      maintained.
+
+      HONESTY NOTE carried forward: v3.2.6's CHANGELOG says FEAT-076 fixed the
+      component misreporting its version. It did not — it changed HOW it
+      misreports. That is recorded on scry#152 and on the closed scry#133
+      rather than left for a consumer to discover from the artifact.
+    tags: [release-machinery, honesty, vacuous-oracle, bazel, v3.2.7]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given the Bazel-built component, When it emits its version diagnostic, Then the string is the workspace version and never the rules_rust default. RED-FIRST EVIDENCE from the shipped artifact: the v3.2.6 wasm contains the byte string `0.0.0` and does NOT contain `3.2.6`."
+        - "Given the unit test for this, When SCRY_VERSION is forced to the default, Then it FAILS. Verified: `assert_ne!` fires with the rules_rust message. The assertion it replaces could not fail under any build."
+        - "Given claims.yaml, When the Bazel literal drifts from the workspace version OR any crate reverts to the 0.0.0 default, Then claim-check goes red. MUTATION-CHECKED both directions: drift -> red, default -> red, restored -> 7/7."
+        - "NOT YET CLOSED BY THIS FEATURE: the end-to-end check that the BUILT component carries the expected version. The unit test guards the constant; only a byte-check on the produced wasm guards the artifact, and the Bazel-built rust_test target is not invoked by any workflow (scry#141's residual). Stated rather than implied."
+    links:
+      - type: traces-to
+        target: REQ-017

--- a/claims.yaml
+++ b/claims.yaml
@@ -28,6 +28,26 @@ claims:
         glob: ['Cargo.toml']
         min: 1
 
+  # ── Bazel version pin (scry#152) ──────────────────────────────────────────
+  # rules_rust populates CARGO_PKG_VERSION from the target's `version` attr and
+  # defaults it to "0.0.0". Bazel builds the SHIPPED component, so a missing or
+  # stale pin means the artifact announces the wrong version — which is exactly
+  # what v3.2.6 did. The literal cannot be derived (Bazel cannot read
+  # Cargo.toml), so it is pinned to the workspace version here instead.
+  - id: BAZEL-VERSION-PIN
+    doc: crates/scry-analyze-core/BUILD.bazel
+    text: 'version = "3.2.6",'
+    evidence:
+      - kind: count-min
+        pattern: 'version = "3\.2\.6"'
+        glob: ['Cargo.toml']
+        min: 1
+      # And the default must never come back.
+      - kind: count-max
+        pattern: 'version = "0\.0\.0"'
+        glob: ['crates/*/BUILD.bazel']
+        max: 0
+
   # ── Dossier CI-gate scope (scry#141) ──────────────────────────────────────
   # The qualification dossier cited `bazel test //...` as a DO-330 T-1(4) gate.
   # CI never ran that — only the two proof trees. An assessor-facing document

--- a/crates/scry-analyze-core/BUILD.bazel
+++ b/crates/scry-analyze-core/BUILD.bazel
@@ -17,6 +17,18 @@ rust_library(
     srcs = ["src/lib.rs"],
     crate_name = "scry_analyze_core",
     edition = "2024",
+    # scry#152: rules_rust populates CARGO_PKG_VERSION from THIS attribute, and
+    # its default is "0.0.0". Without it, `SCRY_VERSION` — which is
+    # env!("CARGO_PKG_VERSION") — resolves to 3.2.6 under cargo and 0.0.0 under
+    # Bazel. Bazel builds the SHIPPED component, so v3.2.6 went out announcing
+    # itself as "scry 0.0.0".
+    #
+    # Hard-coded here because Bazel cannot read Cargo.toml, which recreates the
+    # drift FEAT-076 was meant to end — so it is GATED: claims.yaml pins this
+    # literal to the workspace version, and claim-check goes red if they part.
+    # A number that must be maintained by hand is acceptable only when
+    # something mechanical notices when it is not.
+    version = "3.2.6",
     visibility = ["//visibility:public"],
     tags = ["feat-014"],
     deps = [

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -9100,11 +9100,28 @@ mod tests {
     /// value is what actually closes it; this test only proves it stays derived.
     #[test]
     fn issue133_scry_version_is_derived_from_the_package_version() {
-        assert_eq!(
-            SCRY_VERSION,
-            env!("CARGO_PKG_VERSION"),
-            "SCRY_VERSION must be derived, not hand-maintained — a literal drifts \
-             silently and ships a component that misidentifies itself"
+        // scry#152: the assertion that USED to be here was
+        //     assert_eq!(SCRY_VERSION, env!("CARGO_PKG_VERSION"))
+        // which is TAUTOLOGICAL, because SCRY_VERSION *is* that expression. It
+        // compared a value to itself and could not fail under any build.
+        //
+        // It was not vacuous when written — red-first it failed honestly with
+        // left "3.2.4" / right "3.2.5", because SCRY_VERSION was still a
+        // literal. It became vacuous the MOMENT the fix landed, since the fix
+        // makes the asserted identity true by construction. A test can be
+        // meaningful before a change and worthless after it, and mutation-
+        // checking the implementation does not reveal that: reverting to a
+        // literal makes it fail, which looks like a healthy oracle.
+        //
+        // What it failed to catch: rules_rust populates CARGO_PKG_VERSION from
+        // the Bazel target's `version` attribute and defaults it to "0.0.0".
+        // Bazel builds the SHIPPED component, so v3.2.6 went out announcing
+        // "scry 0.0.0" with this test green.
+        assert_ne!(
+            SCRY_VERSION, "0.0.0",
+            "SCRY_VERSION is the rules_rust default — the Bazel target is \
+             missing its `version` attribute, and the shipped component will \
+             announce 0.0.0 (scry#152)"
         );
         // Non-vacuity: a bare `assert_eq!(X, X)` would pass on any value, so
         // pin the shape too — the released artifact showed this string verbatim.


### PR DESCRIPTION
Found by running the **shipped v3.2.6 artifact** minutes after cutting it.

## The defect

```
message: "scry 0.0.0 — wasm-lattice cross-component import alive"
```

FEAT-076 replaced a hand-maintained literal with `env!("CARGO_PKG_VERSION")` — correct under **cargo**. The shipped component is built by **Bazel**, where `rules_rust` populates `CARGO_PKG_VERSION` from the target's `version` attribute and defaults it to `0.0.0`. No `crates/*/BUILD.bazel` set one.

**The fix was right in the build nobody ships and wrong in the build everybody consumes.**

Red-first evidence taken from the shipped artifact itself:

| probe | in the v3.2.6 wasm |
|---|---|
| `0.0.0` | **present** |
| `3.2.6` | **absent** |

## The more instructive half — a new vacuity class

The test written for #133 **could not catch this**:

```rust
assert_eq!(SCRY_VERSION, env!("CARGO_PKG_VERSION"))
```

…where `SCRY_VERSION` *is* that expression. Tautological.

**It was not vacuous when written.** Red-first it failed honestly — `left: "3.2.4"`, `right: "3.2.5"` — because `SCRY_VERSION` was still a literal. It became vacuous **the moment the fix landed**, because the fix makes the asserted identity true by construction.

That class isn't covered by mutation-checking: reverting the implementation to a literal makes such a test fail, which *looks* like a healthy oracle — while the passing state carries no information. **A test can be meaningful before a change and worthless after it.**

Replaced with `assert_ne!(SCRY_VERSION, "0.0.0")`, which names the `rules_rust` default and **can** fail — verified by forcing the constant and watching it fire.

## The new literal is gated, not trusted

Hard-coding the version in `BUILD.bazel` recreates precisely the drift FEAT-076 set out to end, because Bazel can't read `Cargo.toml`. So `claims.yaml` pins it to the workspace version **and** forbids the `0.0.0` default in any crate.

Mutation-checked both ways:
```
drift from Cargo.toml  → ✗ BAZEL-VERSION-PIN, 6/7
0.0.0 default returns  → ✗ BAZEL-VERSION-PIN, 6/7
restored               → 7/7
```

A number maintained by hand is acceptable only when something mechanical notices when it stops being maintained.

## What this does not close

An **end-to-end** check that the *built* component carries the expected version. The unit test guards the constant; only a byte-check on the produced wasm guards the artifact — and the Bazel `rust_test` target is still not invoked by any workflow (#141's residual). Stated in the AC rather than implied.

tests **0** · clippy **0** · fmt **0** · `rivet validate` **0** · claim-check **7/7**.