### PR TITLE
FEAT-085 (#113): lattice laws for the bits domain, checked up to γ

### DIFF
--- a/artifacts/roadmap-v3.6-b.yaml
+++ b/artifacts/roadmap-v3.6-b.yaml
@@ -1,0 +1,58 @@
+# v3.6.0 addendum — own file per scry#143 fix (1).
+artifacts:
+  - id: FEAT-085
+    type: feature
+    title: "v3.6 — Lattice laws, checked up to gamma, for the bits domain (scry#113 first slice)"
+    status: proposed
+    release: v3.6.0
+    description: >
+      scry#113 says the sound analyzer's frontend is unguarded. Measured: 18
+      join/meet functions across 8 domains, exactly ONE domain (octagon) has any
+      lattice-law test at all, and that one checks commutativity and
+      top-absorption on hand-picked values. No proptest/quickcheck/arbitrary/
+      cargo-fuzz anywhere in the workspace.
+
+      This is the first slice, on scry-sai-bits — 6 of the 18 functions, the
+      most intricate arithmetic (CRT, mod_inverse), and the domain scry#105
+      already flags for machine-checked transfer soundness.
+
+      CHECKED UP TO GAMMA, NEVER STRUCTURALLY, and that choice is the whole
+      point. Two distinct encodings can denote the same set, so `==` on
+      representations is too strong — and this project has already been bitten
+      by exactly that: the Verus join proof (FEAT-012) was FALSE and unverified
+      for months because it asserted `join(a,b) == join(b,a)` structurally,
+      which does not hold for distinct bottom encodings. These tests assert the
+      semantic version over the exhaustive [0,256) concrete domain the crate
+      already sweeps.
+
+      THE SOUNDNESS-CRITICAL LAW is `join_is_an_upper_bound_up_to_gamma`. If a
+      join drops an element, every fixpoint built on it under-approximates and
+      the analyzer can report PROVEN-SAFE for something reachable. Commutativity,
+      associativity and idempotence are hygiene; that one is the product. Its
+      dual, `meet_is_a_lower_bound_up_to_gamma`, catches a meet that INVENTS an
+      element, which would let a refinement claim more than it proved.
+
+      CREDIT: prompted by the Wasm Research Day Q&A, where a Binaryen engineer
+      reported having good luck fuzzing their own abstract domains for exactly
+      this — independent corroboration from a second group doing Wasm abstract
+      interpretation, which is better evidence than an in-house opinion that
+      fuzzing "would be good".
+
+      NO NEW DEPENDENCY. The crate already has an `alpha`/`contains`/`sweep`
+      idiom; these reuse it rather than adding proptest to a published crate.
+
+      HONEST SCOPE: this covers ONE domain. interval, pentagon, float, handle,
+      segment, poly and viz remain unguarded — 12 of the 18 functions. The
+      pattern is now established and mechanical to repeat, but repeating it is
+      not done.
+    tags: [robustness, lattice-laws, gamma, scry113, v3.6]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given the bits domain, When the law suite runs, Then join is an upper bound and meet a lower bound of the concretizations, over the exhaustive [0,256) domain — the two laws whose failure would be an UNSOUNDNESS rather than an imprecision."
+        - "Given join, Then commutativity, associativity and idempotence hold UP TO gamma, not structurally. Stated this way because the structural version is known-false here (FEAT-012's Verus proof)."
+        - "MUTATION-CHECKED surgically: forcing `meet` to return TOP kills exactly `meet_is_a_lower_bound_up_to_gamma` plus one pre-existing test, and nothing else. A broad mutation (join returns self) also fires, but is uninformative because `alpha` is built from join."
+        - "NOT COVERED, stated rather than implied: 12 of the 18 join/meet functions, across interval / pentagon / float / handle / segment / poly / viz. This slice does not make scry#113 done."
+    links:
+      - type: traces-to
+        target: REQ-001

--- a/crates/scry-bits/src/lib.rs
+++ b/crates/scry-bits/src/lib.rs
@@ -1052,6 +1052,125 @@ mod tests {
         }
     }
 
+    // ── lattice laws, checked UP TO γ (scry#113) ──────────────────────────
+    //
+    // The laws are asserted on CONCRETIZATIONS, never on representations. Two
+    // distinct encodings can denote the same set, so structural `==` is too
+    // strong — and this project has already been bitten by exactly that: the
+    // Verus join proof (FEAT-012) was FALSE and unverified for months because
+    // it stated `join(a,b) == join(b,a)` structurally, which does not hold for
+    // distinct bottom encodings. These tests state the semantic version.
+    //
+    // Prompted by the Wasm Research Day Q&A, where a Binaryen engineer reported
+    // having good luck fuzzing their own abstract domains for exactly this.
+
+    /// γ(a) over the exhaustive concrete domain, as a comparable set.
+    fn gamma(a: &BitsCong) -> Vec<u64> {
+        (0u64..256).filter(|&x| a.contains(x, W)).collect()
+    }
+
+    fn law_samples() -> Vec<BitsCong> {
+        vec![
+            BitsCong::bottom(),
+            BitsCong::top(),
+            alpha(&[0]),
+            alpha(&[255]),
+            alpha(&[8, 16, 24]),
+            alpha(&[8, 16, 24, 40]),
+            alpha(&[3, 7]),
+            alpha(&[1, 2, 4, 8, 16, 32, 64, 128]),
+            alpha(&[0, 255]),
+        ]
+    }
+
+    /// THE soundness-critical law. If a join drops an element, every fixpoint
+    /// built on it under-approximates and the analyzer can report PROVEN-SAFE
+    /// for something reachable. Commutativity and associativity are hygiene;
+    /// this one is the product.
+    #[test]
+    fn join_is_an_upper_bound_up_to_gamma() {
+        for a in &law_samples() {
+            for b in &law_samples() {
+                let j = a.join(b, W);
+                for x in 0u64..256 {
+                    if a.contains(x, W) || b.contains(x, W) {
+                        assert!(
+                            j.contains(x, W),
+                            "join DROPPED {x}: it is in γ(a)∪γ(b) but not γ(a⊔b) — \
+                             a={a:?} b={b:?} join={j:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn join_is_commutative_up_to_gamma() {
+        for a in &law_samples() {
+            for b in &law_samples() {
+                assert_eq!(
+                    gamma(&a.join(b, W)),
+                    gamma(&b.join(a, W)),
+                    "γ(a⊔b) ≠ γ(b⊔a) — a={a:?} b={b:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn join_is_associative_up_to_gamma() {
+        let s = law_samples();
+        for a in &s {
+            for b in &s {
+                for c in &s {
+                    assert_eq!(
+                        gamma(&a.join(b, W).join(c, W)),
+                        gamma(&a.join(&b.join(c, W), W)),
+                        "γ((a⊔b)⊔c) ≠ γ(a⊔(b⊔c)) — a={a:?} b={b:?} c={c:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn join_is_idempotent_up_to_gamma() {
+        for a in &law_samples() {
+            assert_eq!(gamma(&a.join(a, W)), gamma(a), "γ(a⊔a) ≠ γ(a) — a={a:?}");
+        }
+    }
+
+    /// Dual direction: meet must not INVENT an element. A meet that grows the
+    /// concretization would let a refinement claim more than it proved.
+    #[test]
+    fn meet_is_a_lower_bound_up_to_gamma() {
+        for a in &law_samples() {
+            for b in &law_samples() {
+                let m = a.meet(b, W);
+                for x in 0u64..256 {
+                    if m.contains(x, W) {
+                        assert!(
+                            a.contains(x, W) && b.contains(x, W),
+                            "meet INVENTED {x}: in γ(a⊓b) but not γ(a)∩γ(b) — \
+                             a={a:?} b={b:?} meet={m:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn top_and_bottom_are_join_identities_up_to_gamma() {
+        let top = BitsCong::top();
+        let bot = BitsCong::bottom();
+        for a in &law_samples() {
+            assert_eq!(gamma(&a.join(&bot, W)), gamma(a), "a⊔⊥ ≠ a — a={a:?}");
+            assert_eq!(gamma(&a.join(&top, W)), gamma(&top), "a⊔⊤ ≠ ⊤ — a={a:?}");
+        }
+    }
+
     // ── transfer soundness: exhaustive γ-sweep over [0,256)² ──
 
     /// For a binary op, assert: for all concrete x∈γ(α(xs)), y∈γ(α(ys)), the
@@ -1415,8 +1534,8 @@ mod tests {
         }
     }
 
-    /// Clean-room regression (u64 overflow): a CRT combine with a modulus
-    /// > 2^63 must not overflow the intermediate `(r2 % m2) + m2` / `r1 + m1·t`
+    /// Clean-room regression (u64 overflow): a CRT combine with a modulus above
+    /// 2^63 must not overflow the intermediate `(r2 % m2) + m2` / `r1 + m1·t`
     /// (done in u128). `Cong::new` can produce such moduli, and the crate is a
     /// published library. Trigger: ≡1 (mod 3) ⊓ ≡1 (mod u64::MAX) — lcm fits
     /// (u64::MAX is divisible by 3), so it enters the CRT arm.


### PR DESCRIPTION
First slice of #113. Also surfaces a second gate-coverage defect — filed as #157.

## The gap, measured

18 `join`/`meet` functions across 8 domains. **Exactly one** domain (octagon) has any lattice-law test, and it checks commutativity + top-absorption on hand-picked values. No `proptest`/`quickcheck`/`arbitrary`/`cargo-fuzz` in the workspace.

This slice takes `scry-sai-bits` — 6 of the 18, the most intricate arithmetic (CRT, `mod_inverse`), already flagged by #105.

## Checked up to γ, never structurally — and that's the point

Two encodings can denote the same set, so `==` on representations is too strong. **This project has already been bitten by exactly that**: the Verus join proof (FEAT-012) was *false and unverified for months* because it asserted `join(a,b) == join(b,a)` structurally, which fails for distinct bottom encodings.

These assert the semantic version over the exhaustive `[0,256)` domain the crate already sweeps.

**The soundness-critical law is `join_is_an_upper_bound_up_to_gamma`.** If a join drops an element, every fixpoint built on it under-approximates and the analyzer can report PROVEN-SAFE for something reachable. Commutativity, associativity, idempotence are hygiene; that one is the product. Its dual catches a `meet` that *invents* an element.

## Mutation-checked surgically

```
meet → TOP    kills exactly meet_is_a_lower_bound_up_to_gamma + 1 pre-existing
join → self   also fires, but uninformative: `alpha` is itself built from join
```

The surgical one is the evidence; I'm reporting the broad one as uninformative rather than counting it.

**No new dependency** — the crate's existing `alpha`/`contains`/`sweep` idiom is reused rather than adding proptest to a published crate.

**Credit**: prompted by the Wasm Research Day Q&A, where a Binaryen engineer reported good luck fuzzing their own abstract domains for exactly this. Independent corroboration from a second group beats an in-house opinion that fuzzing would be good.

## It also unearthed #157

Local verification was blocked by a **pre-existing clippy error on `main`** — a doc line beginning `> 2^63`, read as an unterminated blockquote. Confirmed pre-existing by stashing and re-running clean: main fails identically.

CI never saw it because **the Clippy job covers four packages** — the same four the Test job used before #141. Widening one per-package gate did not fix the pattern; I checked `cargo test` because that was the reported symptom and didn't ask the same question of the gate three lines above it.

Fixed here since it blocks this branch; the scope defect is #157.

## Honest scope

**One domain.** 12 of the 18 functions — interval, pentagon, float, handle, segment, poly, viz — remain unguarded. This does **not** make #113 done.

tests **0** · clippy **0** · fmt **0** · `rivet validate` **0** · claim-check **0**.