### PR TITLE
FEAT-086 (#157): clippy covers every crate, and the guard covers both gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,21 @@ jobs:
       # the cargo path (it compiles natively as well as to
       # wasm32-wasip2, where wasm-lattice's WIT octagon-* exports
       # delegate to it).
+      # scry#157: this job ran FOUR packages — the same four the Test job ran
+      # before scry#141 widened it. Nine publishable crates were never linted,
+      # and TWO of them had live errors on main that CI could not see:
+      # scry-sai-bits (a doc line read as an unterminated blockquote) and
+      # scry-sai-pentagon (two needless borrows). Both fixed alongside this.
+      #
+      # The lesson recorded on scry#157: fixing a coverage gap in ONE gate did
+      # not fix the pattern. The clippy list sat three lines from the test list
+      # and drifted independently, so the guard below now checks BOTH.
+      - name: cargo clippy — analyzer core, viz, and the domain crates
+        run: |
+          cargo clippy -p scry-sai-core -p scry-sai-viz -p scry-sai-interval \
+                       -p scry-sai-bits -p scry-sai-float -p scry-sai-handle \
+                       -p scry-sai-pentagon -p scry-sai-segment -p scry-sai-poly \
+                       --all-targets -- -D warnings
       - name: cargo clippy --package scry-sai-octagon
         run: cargo clippy --package scry-sai-octagon --all-targets -- -D warnings
 
@@ -168,31 +183,21 @@ jobs:
       # in a `cargo test` invocation in this workflow, or the job fails with the
       # crate named. Without it the next new domain crate silently joins the 81%
       # that were never tested — which is exactly how this happened.
-      - name: Guard — every publishable crate is actually tested
+      # scry#157: gate the gates. Every publishable crate must appear in BOTH
+      # a `cargo test` and a `cargo clippy` invocation, or this fails naming the
+      # crate AND which gate is missing it.
+      #
+      # Implemented as a YAML-PARSING script rather than inline grep/awk,
+      # because three earlier text-scraping versions were vacuous in ways that
+      # looked like they worked — most recently an awk range that chained across
+      # the whole file, making the "tested" and "clippy" lists IDENTICAL so the
+      # check could not detect the drift it exists for. The script carries a
+      # `--self-test` that proves it distinguishes a good workflow from a bad
+      # one, and is mutation-checked against this file in both directions.
+      - name: Guard — every publishable crate is in BOTH gates
         run: |
-          set -uo pipefail
-          # Extract the tested package names ONCE, then do fixed-string
-          # membership. The first version built a regex per crate name and
-          # failed in CI with `grep: Unmatched ( or \(` — the alternation
-          # survived YAML and BSD grep locally but not GNU grep. It failed
-          # CLOSED (red, naming all 12 crates) rather than open, which is the
-          # right direction, but a guard whose own matching is fragile is not
-          # a guard. No dynamic regex now.
-          tested=$(grep -oE -- '(-p|--package) [A-Za-z0-9_-]+' .github/workflows/ci.yml \
-                   | awk '{print $2}' | sort -u)
-          missing=""
-          for d in crates/*/; do
-            [ -f "$d/Cargo.toml" ] || continue
-            name=$(grep -m1 '^name = ' "$d/Cargo.toml" | cut -d'"' -f2)
-            [ -z "$name" ] && continue
-            grep -q '^publish = false' "$d/Cargo.toml" && continue
-            printf '%s\n' "$tested" | grep -qxF "$name" || missing="$missing $name"
-          done
-          if [ -n "$missing" ]; then
-            echo "::error::publishable crate(s) never run by any cargo test step:$missing"
-            exit 1
-          fi
-          echo "OK — every publishable crate appears in a cargo test invocation"
+          python3 tools/check-gate-coverage.py --self-test
+          python3 tools/check-gate-coverage.py
       - name: cargo test — analyzer core, viz, and the domain crates
         run: |
           cargo test -p scry-sai-core -p scry-sai-viz -p scry-sai-interval \

--- a/artifacts/roadmap-v3.6-b.yaml
+++ b/artifacts/roadmap-v3.6-b.yaml
@@ -6,11 +6,43 @@ artifacts:
     status: proposed
     release: v3.6.0
     description: >
-      scry#113 says the sound analyzer's frontend is unguarded. Measured: 18
-      join/meet functions across 8 domains, exactly ONE domain (octagon) has any
-      lattice-law test at all, and that one checks commutativity and
-      top-absorption on hand-picked values. No proptest/quickcheck/arbitrary/
-      cargo-fuzz anywhere in the workspace.
+      CORRECTED AFTER MERGE — the measurement this feature was justified by was
+      WRONG, and the correction is recorded here rather than quietly dropped.
+
+      I originally wrote: "18 join/meet functions across 8 domains, exactly ONE
+      domain (octagon) has any lattice-law test." That is false. I grepped for
+      `associat|commutat|idempot|absorb|lattice_law` — one house vocabulary —
+      and this repo mostly uses another. Re-measured on actual test names, the
+      soundness-critical law is ALREADY tested in every domain checked:
+      interval `join_is_upper_bound`, float `gamma_sweep_join_is_upper_bound`,
+      handle `join_is_upper_bound`, pentagon `adv_join_upper_bound_dim3`,
+      segment/poly `join_over_approximates_union_and_is_upper_bound`, octagon
+      `join_lattice_laws` — and bits itself already had
+      `join_over_approximates_union`, a few hundred lines above what I added.
+      Several are already gamma-checked, not structural.
+
+      So `join_is_an_upper_bound_up_to_gamma`, which this feature framed as THE
+      missing soundness law, DUPLICATES an existing test in the same file.
+
+      WHAT SURVIVES: commutativity, associativity, idempotence and top/bottom
+      identity for bits, stated up to gamma, were genuinely absent —
+      associativity least likely to be covered incidentally. The mutation-check
+      stands: forcing `meet` to return TOP kills
+      meet_is_a_lower_bound_up_to_gamma and one pre-existing test, so the added
+      tests are live.
+
+      WHAT DOES NOT SURVIVE is the justification. This was not "the frontend is
+      unguarded for the law that matters"; it was "four algebraic laws were
+      missing from one domain that already had the important one". scry#113's
+      premise still holds — no property-based generation anywhere, samples are
+      hand-picked, and `provenance` has ZERO law tests — but the gap is much
+      smaller than reported, and the honest headline for a next slice is
+      "provenance has none", not "eight domains are unguarded".
+
+      THE TRANSFERABLE ERROR: I measured with one vocabulary and reported the
+      absence of the concept. A grep for a NAME is not a measurement of a
+      PROPERTY — the same mistake as counting a comment as a gate (scry#147) and
+      reading a binary without `grep -a` (scry#155).
 
       This is the first slice, on scry-sai-bits — 6 of the 18 functions, the
       most intricate arithmetic (CRT, mod_inverse), and the domain scry#105
@@ -49,7 +81,7 @@ artifacts:
     fields:
       phase: phase-3
       acceptance-criteria:
-        - "Given the bits domain, When the law suite runs, Then join is an upper bound and meet a lower bound of the concretizations, over the exhaustive [0,256) domain — the two laws whose failure would be an UNSOUNDNESS rather than an imprecision."
+        - "Given the bits domain, When the law suite runs, Then join is an upper bound and meet a lower bound of the concretizations over the exhaustive [0,256) domain. NOTE, corrected after merge: the upper-bound half DUPLICATES the pre-existing `join_over_approximates_union` in the same file. It is retained because it states the law explicitly and gamma-checked, but it did not close a gap and this AC should not be read as evidence that one existed."
         - "Given join, Then commutativity, associativity and idempotence hold UP TO gamma, not structurally. Stated this way because the structural version is known-false here (FEAT-012's Verus proof)."
         - "MUTATION-CHECKED surgically: forcing `meet` to return TOP kills exactly `meet_is_a_lower_bound_up_to_gamma` plus one pre-existing test, and nothing else. A broad mutation (join returns self) also fires, but is uninformative because `alpha` is built from join."
         - "NOT COVERED, stated rather than implied: 12 of the 18 join/meet functions, across interval / pentagon / float / handle / segment / poly / viz. This slice does not make scry#113 done."

--- a/crates/scry-pentagon/src/lib.rs
+++ b/crates/scry-pentagon/src/lib.rs
@@ -630,7 +630,7 @@ mod tests {
         let ps = adv_pentagons_dim3();
         for a in ps.iter().step_by(41) {
             for b in ps.iter().step_by(59) {
-                let m = a.meet(&b);
+                let m = a.meet(b);
                 for v in gamma3(&m) {
                     assert!(a.contains(&v) && b.contains(&v), "meet gained {v:?}");
                 }
@@ -651,7 +651,7 @@ mod tests {
         let ps = adv_pentagons_dim3();
         for a in ps.iter().step_by(31) {
             for b in ps.iter().step_by(47) {
-                if a.leq(&b) {
+                if a.leq(b) {
                     for v in gamma3(a) {
                         assert!(b.contains(&v), "leq unsound {v:?}\na={a:?}\nb={b:?}");
                     }

--- a/tools/check-gate-coverage.py
+++ b/tools/check-gate-coverage.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""scry#157: assert every publishable crate is covered by BOTH per-package gates.
+
+Parses the workflow as YAML and inspects each step's `run` block, rather than
+scraping the file with grep/awk ranges. Three earlier attempts at this check
+used text ranges and were vacuous in ways that looked like they worked:
+
+  * a per-crate dynamic regex that survived BSD grep and not GNU grep;
+  * an `awk '/cargo test/,/^      - name:/'` range that chained across the whole
+    file, so the "tested" and "clippy" lists came out IDENTICAL — the check
+    could not detect the very drift it exists for;
+  * (elsewhere) a predicate that counted a comment as a gate.
+
+A gate that cannot distinguish its two inputs is worse than no gate, so this one
+is exercised by `--self-test` against synthetic good and bad inputs.
+"""
+import sys, re, yaml
+
+PKG = re.compile(r'(?:-p|--package)\s+([A-Za-z0-9_-]+)')
+
+
+def packages_by_tool(workflow_text):
+    """-> {"cargo test": {names}, "cargo clippy": {names}} from a workflow's steps."""
+    wf = yaml.safe_load(workflow_text)
+    out = {"cargo test": set(), "cargo clippy": set()}
+    for job in (wf.get("jobs") or {}).values():
+        for step in (job.get("steps") or []):
+            run = step.get("run")
+            if not run:
+                continue
+            # A step's run block may contain several commands; attribute each
+            # LINE (with continuations joined) to the tool it invokes.
+            joined = run.replace("\\\n", " ")
+            for line in joined.splitlines():
+                for tool in out:
+                    if tool in line:
+                        out[tool].update(PKG.findall(line))
+    return out
+
+
+def publishable_crates(root="crates"):
+    import os
+    names = []
+    for d in sorted(os.listdir(root)):
+        p = os.path.join(root, d, "Cargo.toml")
+        if not os.path.isfile(p):
+            continue
+        txt = open(p).read()
+        if re.search(r'^publish\s*=\s*false', txt, re.M):
+            continue
+        m = re.search(r'^name\s*=\s*"([^"]+)"', txt, re.M)
+        if m:
+            names.append(m.group(1))
+    return names
+
+
+def self_test():
+    good = """
+jobs:
+  t:
+    steps:
+      - run: cargo test -p a -p b
+      - run: cargo clippy -p a -p b --all-targets -- -D warnings
+"""
+    bad = """
+jobs:
+  t:
+    steps:
+      - run: cargo test -p a -p b
+      - run: cargo clippy -p a --all-targets -- -D warnings
+"""
+    g = packages_by_tool(good)
+    b = packages_by_tool(bad)
+    ok = True
+    if g["cargo test"] != {"a", "b"} or g["cargo clippy"] != {"a", "b"}:
+        print(f"  SELF-TEST FAIL (good): {g}"); ok = False
+    if b["cargo clippy"] != {"a"}:
+        print(f"  SELF-TEST FAIL (bad, clippy): {b}"); ok = False
+    if b["cargo test"] != {"a", "b"}:
+        print(f"  SELF-TEST FAIL (bad, test): {b}"); ok = False
+    # The property that matters: the two tools must be DISTINGUISHABLE.
+    if b["cargo test"] == b["cargo clippy"]:
+        print("  SELF-TEST FAIL: the two gates are indistinguishable — vacuous"); ok = False
+    print("  self-test:", "OK — good input clean, bad input detected" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+def main():
+    if "--self-test" in sys.argv:
+        return self_test()
+    wf = sys.argv[1] if len(sys.argv) > 1 else ".github/workflows/ci.yml"
+    by = packages_by_tool(open(wf).read())
+    missing = []
+    for name in publishable_crates():
+        for tool in ("cargo test", "cargo clippy"):
+            if name not in by[tool]:
+                missing.append(f"{name}({tool.split()[1]})")
+    if missing:
+        print("::error::publishable crate(s) missing from a gate: " + " ".join(missing))
+        return 1
+    print(f"OK — {len(publishable_crates())} publishable crates in BOTH gates")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
CI's Clippy job ran **four** packages — the same four the Test job ran before #141 widened it. Nine publishable crates were never linted, and **two had live errors on `main` that CI could not see**:

| crate | error |
|---|---|
| `scry-sai-bits` | a doc line beginning `> 2^63`, read as an unterminated Markdown blockquote |
| `scry-sai-pentagon` | two needless borrows — in its *own* meet/leq soundness tests |

Both fixed; clippy now covers all twelve, verified locally across the nine previously-unlinted packages.

## The guard is the real deliverable, and it took four attempts

The version merged in #142 asserted coverage for **`cargo test` only**. When the clippy list stayed narrow, it said nothing. Widening one gate did not fix the pattern — the two per-package lists sit three lines apart in the same file and drifted independently.

Three text-scraping attempts at the extended guard were **vacuous in ways that looked like they worked**:

1. a per-crate **dynamic regex** — survived BSD grep locally, failed on GNU grep in CI, and failed *closed* naming all twelve crates;
2. an `awk '/cargo test/,/^      - name:/'` **range** — the ranges chained across the whole file, so `tested` and `linted` came out **identical**. That guard could not detect the exact drift it exists for. Under mutation it printed `FIRES`, which nearly passed my review — but with the **wrong attribution**: removing a crate from clippy reported it missing from *both*;
3. earlier, in a different check, a predicate that counted a **comment** as a gate (#147).

## What replaced it

`tools/check-gate-coverage.py` parses the workflow as **YAML** and attributes packages per step's `run` block.

It carries a **`--self-test`** asserting it distinguishes a good workflow from a bad one — including the explicit property the awk version failed: *that the two gates are not identical*. CI runs the self-test **before** the real check, so a checker that stops discriminating fails the build instead of silently passing.

Mutation-checked against the real workflow, both directions:

```
drop scry-sai-float from CLIPPY only → scry-sai-float(clippy)   exit 1
drop scry-sai-poly  from TEST   only → scry-sai-poly(test)      exit 1
restored                             → 12 crates in BOTH        exit 0
```

Correct attribution — which the awk version got wrong.

tests **0** · clippy **0** (all 9) · fmt **0** · `rivet validate` **0** · claim-check **0** · gate-coverage **0**.