### PR TITLE
FEAT-088: a forgotten safety goal can't hide behind the `undeveloped` diamond

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,23 @@ jobs:
         run: cargo install --locked --git https://github.com/pulseengine/rivet rivet-cli
       - name: rivet validate
         run: rivet validate
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install PyYAML
+        run: pip install pyyaml
+      # J-004: `rivet coverage` cannot tell a goal DECLARED `undeveloped: true`
+      # (GSN's diamond) from one somebody forgot -- both render as uncovered at
+      # the same 40%. J-004 records that the figure was investigated, but prose
+      # is exactly what the next forgotten goal would hide behind. This gate
+      # makes it mechanical: an unsupported goal must be declared, AND the
+      # declaration must be justified. Ships a --self-test, run FIRST, which
+      # includes the subtle case (flag present, no justification naming it) --
+      # the shape a forgotten goal takes once someone quiets the report.
+      - name: Guard — an unsupported safety goal is DECLARED and justified
+        run: |
+          python3 tools/check-undeveloped-goals.py --self-test
+          python3 tools/check-undeveloped-goals.py
 
   # A README is a claim about the system — the same species as a requirement,
   # gated the same way. `claim-check` re-derives every load-bearing doc claim

--- a/artifacts/roadmap-v3.4-safety-gate.yaml
+++ b/artifacts/roadmap-v3.4-safety-gate.yaml
@@ -1,0 +1,73 @@
+# v3.4.0 safety-case addendum — own file per scry#143 fix (1).
+artifacts:
+  - id: FEAT-088
+    type: feature
+    title: "v3.4 — A forgotten safety goal cannot hide behind the `undeveloped` diamond"
+    status: proposed
+    release: v3.4.0
+    description: >
+      `rivet coverage` reports `goal-has-support` and `goal-has-context` at 40%
+      (2 of 5) and CANNOT distinguish a safety goal deliberately marked
+      `undeveloped: true` — GSN's diamond, an honest declared incompleteness —
+      from one somebody simply forgot. Both render as uncovered, at the same
+      number. J-004 investigated this on 2026-08-25, established that all three
+      uncovered goals (G-003 Component-Model link-time properties, G-004 the
+      wider PulseEngine deductive/model-checking layers, G-005 scry's own
+      qualifiability) are deliberately undeveloped, and recorded WHY closing it
+      with links would be cosmetic.
+
+      That investigation is correct and it is PROSE. Prose is precisely what the
+      next forgotten goal would hide behind: add a goal with no evidence, and it
+      reads exactly like the three that were reasoned about. J-004 says so
+      itself — "a genuinely forgotten goal would hide among the declared ones."
+      This feature turns that sentence into a gate.
+
+      Two directions are checked, and the second is the one that matters:
+
+        1. a goal with NO supporting `safety-solution` MUST carry
+           `undeveloped: true` — catches a goal nobody developed OR declared;
+        2. a goal carrying `undeveloped: true` MUST be named by a
+           `safety-justification` — catches the flag being added to QUIET the
+           report, which is the shape a forgotten goal takes once someone
+           notices the number.
+
+      (1) alone is satisfiable by typing the flag, so a gate that only checked
+      it would catch the mistake nobody was going to make.
+
+      The checker cross-checks its own population against `rivet list` and FAILS
+      on disagreement. This is not defensive padding: G-005 lives in
+      `roadmap-2.0.yaml`, not `safety-case.yaml`, so a checker reading the
+      obvious single file finds 4 of 5 goals, reports clean, and silently omits
+      the one carrying `asil: D`. The checker must not be able to have the bug
+      it exists to prevent.
+
+      It FAILS CLOSED when PyYAML is unavailable rather than skipping. A gate
+      that silently skips on a missing dependency reports green while checking
+      nothing — the scry#141 failure mode, where 222 of 273 tests never ran.
+    tags: [safety-case, gsn, traceability, honesty, gate, v3.4]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given a safety goal with no supporting `safety-solution` and no `undeveloped: true`, When the gate runs, Then it FAILS naming that goal. Self-tested."
+        - "Given a goal marked `undeveloped: true` that NO `safety-justification` names, When the gate runs, Then it FAILS. This is the subtle direction — the flag added to quiet the report — and it is a self-test fixture, not only a real-repo observation."
+        - "Given a justification that names the goal only in prose (a `rationale` field, no typed link), When the gate runs, Then that counts as justified — J-004's own shape must not be flagged."
+        - "Given the checker scans a subset of the artifact files, When it runs, Then the `rivet list` cross-check FAILS on the population mismatch. MUTATION-CHECKED on the real repo: restricting the scan to `safety-case.yaml` finds 4 of 5 goals and exits 1 with `rivet sees 5 ... this checker sees 4`."
+        - "MUTATION-CHECKED on the real repo, second direction: redacting J-004's links AND its prose produces exactly three violations (G-003/G-004/G-005, `hiding behind the flag`) and exit 1; restoring it returns to PASS."
+        - "Given PyYAML is unavailable, When either the gate or its self-test runs, Then it exits 1 with `this gate cannot run` — VERIFIED by shadowing the module on PYTHONPATH, both paths."
+        - "Given CI, When the rivet job runs, Then `--self-test` runs BEFORE the real check, so a checker that stops discriminating fails the build (the `tools/check-gate-coverage.py` pattern)."
+      residual: >
+        This does NOT make the 40% meaningful, and the next sweep should not
+        read it that way. `rivet coverage` still counts declared-undeveloped
+        goals as uncovered and will still print `goal-has-support 2/5 40.0%`.
+        J-004 notes the figure misleads in BOTH directions; this gate closes
+        exactly one — forgotten hiding among declared. The other direction
+        (a reader seeing 40% and inferring neglect) needs rivet itself to
+        express `undeveloped`, which is reported upstream and is not scry's to
+        fix. G-003/G-004/G-005 remain deliberately undeveloped: this feature
+        does not develop them, and developing them is what J-004 scopes —
+        solutions for host-import reachability and WIT refinement contracts, or
+        narrowing G-003 to the handle-state claim FEAT-049 already supports;
+        cross-repo evidence for G-004; an assessor-facing review for G-005.
+    links:
+      - type: traces-to
+        target: REQ-005

--- a/tools/check-undeveloped-goals.py
+++ b/tools/check-undeveloped-goals.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Gate: a safety goal with no supporting evidence must be DECLARED undeveloped,
+and that declaration must be justified.
+
+WHY THIS EXISTS (J-004, scry safety case). `rivet coverage` reports
+goal-has-support at 40% and cannot distinguish a goal deliberately marked
+`undeveloped: true` — GSN's diamond — from one somebody simply forgot. Both
+render identically. J-004 records that the 40% was investigated and is
+intentional, but a justification is prose: the next unsupported goal added to
+the repo would hide among the declared ones and read exactly the same.
+
+So this checks two directions, not one:
+
+  (1) a goal with NO supporting safety-solution MUST carry `undeveloped: true`
+      -- catches a goal someone forgot to develop or to declare;
+  (2) a goal carrying `undeveloped: true` MUST be named by a safety-justification
+      -- catches the flag being added to quiet the report, which is the shape a
+      forgotten goal takes once someone notices the number.
+
+(2) is the one that matters. (1) alone is satisfiable by typing the flag.
+
+NOT WHAT THIS DOES: it does not make `rivet coverage`'s 40% meaningful. That
+figure still counts declared-undeveloped goals as uncovered and still prints
+40%. This gate closes one direction only -- forgotten hiding among declared.
+"""
+import sys, json, glob, subprocess, tempfile, os
+
+try:
+    import yaml
+except ImportError:
+    # FAIL CLOSED. A gate that silently skips when a dependency is missing
+    # reports green while checking nothing -- the scry#141 failure mode. CI
+    # installs PyYAML explicitly; if it is absent, that is a broken gate, not
+    # a passing build.
+    print("FAIL: PyYAML not available -- this gate cannot run", file=sys.stderr)
+    sys.exit(1)
+
+
+def load_docs(paths):
+    arts = []
+    for p in paths:
+        try:
+            d = yaml.safe_load(open(p, encoding="utf-8"))
+        except Exception as e:
+            print(f"  WARN: unparseable {p}: {e}", file=sys.stderr)
+            continue
+        if isinstance(d, dict):
+            arts.extend(d.get("artifacts") or [])
+    return [a for a in arts if isinstance(a, dict) and a.get("id")]
+
+
+def links_of(a):
+    return [l for l in (a.get("links") or []) if isinstance(l, dict)]
+
+
+def check(arts):
+    """Return a list of violation strings. Pure: the self-test drives this too."""
+    goals = [a for a in arts if a.get("type") == "safety-goal"]
+    supported = set()
+    for a in arts:
+        if a.get("type") == "safety-solution":
+            for l in links_of(a):
+                if l.get("type") == "supports":
+                    supported.add(l.get("target"))
+    justified = set()
+    for a in arts:
+        if a.get("type") != "safety-justification":
+            continue
+        for l in links_of(a):
+            if l.get("type") == "justifies":
+                justified.add(l.get("target"))
+        blob = json.dumps(a)  # rationale/description text may name the goal
+        for g in goals:
+            if g["id"] in blob:
+                justified.add(g["id"])
+
+    bad = []
+    for g in sorted(goals, key=lambda x: x["id"]):
+        gid = g["id"]
+        undev = bool((g.get("fields") or {}).get("undeveloped"))
+        if gid not in supported and not undev:
+            bad.append(
+                f"{gid}: no safety-solution supports it and it is NOT declared "
+                f"`undeveloped: true` -- develop it, or declare it deliberately"
+            )
+        if undev and gid not in justified:
+            bad.append(
+                f"{gid}: declared `undeveloped: true` but NO safety-justification "
+                f"names it -- an undeclared gap is hiding behind the flag"
+            )
+    return bad, goals
+
+
+def self_test():
+    """Feed the checker inputs it MUST reject, and one it must accept."""
+    ok = lambda a: check(a)[0]
+    sol = lambda t: {"id": "Sn-x", "type": "safety-solution",
+                     "links": [{"type": "supports", "target": t}]}
+    jus = lambda t: {"id": "J-x", "type": "safety-justification",
+                     "links": [{"type": "justifies", "target": t}]}
+    goal = lambda i, u=None: {"id": i, "type": "safety-goal",
+                              "fields": ({"undeveloped": u} if u is not None else {})}
+    cases = [
+        ("healthy: supported goal", [goal("G-1"), sol("G-1")], 0),
+        ("healthy: undeveloped AND justified", [goal("G-2", True), jus("G-2")], 0),
+        ("REJECT: unsupported, not declared", [goal("G-3")], 1),
+        # The case J-004 actually warns about: the flag added to quiet the
+        # report, with nothing explaining it. A checker that misses this only
+        # catches the mistake nobody was going to make.
+        ("REJECT: undeveloped but unjustified", [goal("G-4", True)], 1),
+        ("REJECT: both faults on one goal is still caught",
+         [goal("G-5"), goal("G-6", True)], 2),
+    ]
+    failed = 0
+    for name, arts, want in cases:
+        got = len(ok(arts))
+        status = "ok" if got == want else "SELF-TEST FAILED"
+        if got != want:
+            failed += 1
+        print(f"  [{status}] {name}: {got} violation(s), expected {want}")
+    # A justification that names the goal only in prose must also count.
+    prose = [goal("G-7", True),
+             {"id": "J-y", "type": "safety-justification",
+              "fields": {"rationale": "G-7 is deliberately undeveloped because ..."}}]
+    got = len(ok(prose))
+    print(f"  [{'ok' if got==0 else 'SELF-TEST FAILED'}] prose-only justification counts: {got} violation(s), expected 0")
+    failed += got != 0
+    return failed
+
+
+def main():
+    if "--self-test" in sys.argv:
+        f = self_test()
+        print("SELF-TEST PASS" if not f else f"SELF-TEST FAIL ({f})")
+        return 1 if f else 0
+
+    paths = sorted(glob.glob("artifacts/**/*.yaml", recursive=True))
+    arts = load_docs(paths)
+    bad, goals = check(arts)
+    print(f"  scanned {len(paths)} artifact file(s); found {len(goals)} safety-goal(s)")
+
+    # A checker that reads one file would silently omit G-005 (it lives in
+    # roadmap-2.0.yaml, not safety-case.yaml). Cross-check the population
+    # against rivet so this checker cannot have the bug it exists to prevent.
+    try:
+        out = subprocess.run(["rivet", "list", "--format", "json"],
+                             capture_output=True, text=True, timeout=120)
+        if out.returncode == 0:
+            d = json.loads(out.stdout)
+            items = d if isinstance(d, list) else d.get("artifacts", d.get("items", []))
+            n = sum(1 for a in items if a.get("type") == "safety-goal")
+            if n != len(goals):
+                print(f"  FAIL: rivet sees {n} safety-goals, this checker sees "
+                      f"{len(goals)} -- the scan is missing a file")
+                return 1
+            print(f"  cross-check: rivet agrees ({n} safety-goals)")
+    except Exception as e:
+        print(f"  WARN: rivet cross-check skipped ({e})", file=sys.stderr)
+
+    for b in bad:
+        print(f"  FAIL: {b}")
+    print("PASS" if not bad else f"FAIL ({len(bad)} violation(s))")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The gap

`rivet coverage` prints `goal-has-support 2/5 = 40.0%` and **cannot distinguish
a goal deliberately marked `undeveloped: true`** — GSN's diamond, an honest
declared incompleteness — **from one somebody forgot**. Both render as uncovered.

J-004 investigated this on 2026-08-25 and got it right: G-003 / G-004 / G-005 are
deliberately undeveloped, and closing the number with links would be cosmetic.

That investigation is correct, and it is **prose**. Prose is exactly what the next
forgotten goal hides behind — add a goal with no evidence and it reads like the
three that were reasoned about. J-004 says so itself:

> a genuinely forgotten goal would hide among the declared ones

This makes that sentence mechanical.

## The gate

| # | rule | catches |
|---|---|---|
| 1 | no supporting `safety-solution` → **must** carry `undeveloped: true` | a goal nobody developed *or* declared |
| 2 | carries `undeveloped: true` → **must** be named by a `safety-justification` | the flag added to *quiet the report* |

Rule 1 alone is satisfiable by typing the flag, so a gate checking only it catches
the mistake nobody was going to make. **Rule 2 is the one that matters.**

A justification naming the goal only in prose (a `rationale` field, no typed link)
counts — J-004's own shape must not be flagged.

## Why the cross-check exists

The checker cross-checks its own population against `rivet list` and **fails on
disagreement**. Not defensive padding: **G-005 lives in `roadmap-2.0.yaml`, not
`safety-case.yaml`**, so a checker reading the obvious single file finds 4 of 5
goals, reports clean, and silently omits the one carrying `asil: D`.

The checker must not be able to have the bug it exists to prevent.

It also **fails closed** when PyYAML is missing rather than skipping — scry#141's
failure mode was a gate reporting green while running nothing.

## Mutation-checked against the real repo

| mutant | result |
|---|---|
| scan only `safety-case.yaml` | `rivet sees 5 ... this checker sees 4` → exit 1 |
| redact J-004's links **and** prose | exactly 3 violations (G-003/4/5) → exit 1 |
| restored | PASS |
| PyYAML shadowed on `PYTHONPATH` | exit 1 on **both** the gate and its self-test |

Self-test covers 6 cases including the subtle one, and runs **before** the real
check in CI — the `tools/check-gate-coverage.py` pattern.

## What this does NOT do

**It does not make the 40% meaningful.** `rivet coverage` still counts
declared-undeveloped goals as uncovered and will still print
`goal-has-support 2/5 40.0%`. J-004 notes the figure misleads in *both*
directions; this closes exactly one — forgotten hiding among declared. The other
needs rivet itself to express `undeveloped`, already reported upstream.

G-003 / G-004 / G-005 **remain deliberately undeveloped**. This does not develop
them, and the residual records what developing each would actually require.

`rivet=0 claim-check=0 gate-coverage=0 undeveloped-goals=0 fmt=0`

⚠️ Per #130 this repo has no required status checks; verify `gh pr checks` by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc