### PR TITLE
Release machinery: commit traceability (FEAT-091, #161) + required-check drift gate (FEAT-093, #130)

### DIFF
--- a/.github/required-checks.txt
+++ b/.github/required-checks.txt
@@ -1,0 +1,22 @@
+# scry#130. The status checks main REQUIRES, as a checked-in file so CI can
+# gate on it — GITHUB_TOKEN cannot read rulesets (`administration` is not a
+# grantable Actions scope), so a CI job cannot query the live setting.
+#
+# tools/check-required-checks.py --against-file  (CI: no API, catches a job
+#   added or renamed without updating this file)
+# tools/check-required-checks.py                 (admin creds: compares this
+#   file to the LIVE ruleset, catches a reset or an out-of-band edit)
+#
+# Generated from ruleset 16891064 on 2026-08-27. Path-filtered jobs must
+# NEVER appear here: 'Rivet artifact delta' lives in rivet-delta.yml and does
+# not run on a code-only PR, so requiring it deadlocks such PRs forever.
+AADL model (spar parse)
+Bazel build (//:scry)
+cargo-deny (licenses, advisories, bans)
+Clippy
+Doc claims (claim-check)
+Format
+MC/DC (witness)
+Rivet artifact validation
+Test
+WIT round-trip (wasm-tools)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,36 @@ jobs:
       - name: rivet validate
         run: rivet validate
 
+  # scry#161: the V-model's artifact side and the code side were never
+  # connected -- rivet ships commit-to-artifact traceability and it shipped
+  # here unconfigured, so `Broken refs` read 0 for want of any reference to
+  # check. That counter is exactly what would have caught PR #159 merging with
+  # a commit naming FEAT-086 before the artifact existed (#160).
+  #
+  # Its own job, not a step on the rivet job, so a traceability failure is
+  # legible in the checks list rather than buried behind artifact validation.
+  #
+  # FORWARD-ONLY: scoped to origin/main..HEAD, so the 85 pre-existing orphan
+  # commits never enter the gate. NOT `rivet commits --strict`, which also
+  # promotes the repo-wide unimplemented-artifacts warning (Artifact coverage:
+  # 1/257) that no pull request can satisfy.
+  commit-traceability:
+    name: Commit traceability (rivet)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # origin/main..HEAD cannot resolve on a shallow clone.
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install rivet-cli
+        run: cargo install --locked --git https://github.com/pulseengine/rivet rivet-cli
+      - name: Guard — every code commit links an artifact that RESOLVES
+        run: |
+          python3 tools/check-commit-trailers.py --self-test
+          python3 tools/check-commit-trailers.py
+
   # A README is a claim about the system — the same species as a requirement,
   # gated the same way. `claim-check` re-derives every load-bearing doc claim
   # (version, admit-free proof count, published-crate count, WrapAdd.v, the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,39 @@ jobs:
           python3 tools/check-commit-trailers.py --self-test
           python3 tools/check-commit-trailers.py
 
+  # scry#130 follow-up. The required-check setting was fixed on 2026-08-27;
+  # this exists so it cannot silently rot back. Three ways it rots: a job is
+  # ADDED and never required (scry#130 returning one job at a time, invisible
+  # because the PR still goes green); a job is RENAMED (the stale context can
+  # never report, so every PR deadlocks); or the ruleset is RESET — it is named
+  # `temper-default-branch-protection`, so something else may regenerate it.
+  #
+  # Needs `administration: read` to see the ruleset, and full history to read
+  # ci.yml as it exists on main — a job new in THIS PR is reported as pending,
+  # not failed, because requiring it before it merges deadlocks every other
+  # open PR.
+  required-checks-drift:
+    name: Required checks track CI jobs (scry#130)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      administration: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install PyYAML
+        run: pip install pyyaml
+      - name: Guard — every requirable CI job is actually required
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 tools/check-required-checks.py --self-test
+          python3 tools/check-required-checks.py
+
   # A README is a claim about the system — the same species as a requirement,
   # gated the same way. `claim-check` re-derives every load-bearing doc claim
   # (version, admit-free proof count, published-crate count, WrapAdd.v, the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      administration: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -290,12 +289,18 @@ jobs:
           python-version: "3.12"
       - name: Install PyYAML
         run: pip install pyyaml
-      - name: Guard — every requirable CI job is actually required
-        env:
-          GH_TOKEN: ${{ github.token }}
+      # --against-file, NOT the live ruleset: a workflow's GITHUB_TOKEN cannot
+      # read rulesets (`administration` is not a grantable Actions scope, and a
+      # workflow requesting it is rejected wholesale — the run fails with zero
+      # jobs and no log, which reads like an outage rather than a syntax
+      # error). So CI gates on .github/required-checks.txt, which catches the
+      # rot WE cause: a job added or renamed without updating the file. A
+      # ruleset RESET is invisible to anything in-repo and needs the live mode,
+      # run with admin credentials.
+      - name: Guard — every requirable CI job is in required-checks.txt
         run: |
           python3 tools/check-required-checks.py --self-test
-          python3 tools/check-required-checks.py
+          python3 tools/check-required-checks.py --against-file
 
   # A README is a claim about the system — the same species as a requirement,
   # gated the same way. `claim-check` re-derives every load-bearing doc claim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,21 @@ name: CI
 #   * Bazel build of the composed component (//:scry).
 #   * wasm-tools validate on the built bazel-bin/scry.wasm.
 #
-# Required-status-check names that temper's branch protection
-# expects: `Format`, `Clippy`, `Test` — all three are real Cargo
-# gates as of FEAT-001 AC#3.
+# Required status checks (scry#130, enforced 2026-08-27). The ruleset
+# `temper-default-branch-protection` now requires ALL TEN jobs of this
+# workflow before a PR can merge: Format, Clippy, Test, Bazel build
+# (//:scry), MC/DC (witness), cargo-deny, Doc claims (claim-check),
+# Rivet artifact validation, WIT round-trip, AADL model (spar parse).
+# Until then it required NOTHING — this comment claimed three were
+# required and none were, so "merged green" rested on whoever merged
+# remembering to look.
+#
+# `Rivet artifact delta` is deliberately NOT required: it lives in
+# rivet-delta.yml, which is PATH-FILTERED (artifacts/**, rivet.yaml, …).
+# A required check that never reports on a code-only PR blocks that PR
+# forever. Any job added here is required only once its name exists on
+# every PR — add it to the ruleset AFTER it has merged to main, never
+# before, or every open PR deadlocks.
 
 on:
   push:

--- a/artifacts/roadmap-v3.4-commit-trace.yaml
+++ b/artifacts/roadmap-v3.4-commit-trace.yaml
@@ -1,0 +1,79 @@
+# v3.4.0 addendum — own file per scry#143 fix (1).
+artifacts:
+  - id: FEAT-091
+    type: feature
+    title: "v3.4 — Connect the code side to the artifact side: commit traceability, gated forward-only (scry#161)"
+    status: proposed
+    release: v3.4.0
+    description: >
+      scry#161 measured that rivet's commit-to-artifact traceability shipped
+      unconfigured, so the V-model's artifact side and the code side were never
+      connected. Enabling it is a config block; the value is the `broken_refs`
+      counter, which catches a commit naming an artifact id that does not
+      resolve — exactly how PR #159 merged referencing FEAT-086 before the
+      artifact existed (scry#160), found by grepping rather than by a gate.
+
+      TWO MEASUREMENTS CORRECT #161's PREMISE, and both changed the design.
+
+      (1) #161 reports "zero of 125 commits carry an artifact trailer". With a
+      `Verifies` mapping configured, rivet instead reports `linked: 4`,
+      `broken_refs: 4` AND `malformed_refs: 4` — the SAME four commits inflating
+      three counters at once. None of them carry a trailer. All four are the
+      ordinary prose line `Verified: bazel build //:scry green + wasm-tools
+      validate ok.`, which rivet's FUZZY trailer-key matcher reads as a
+      malformed `Verifies:`. Five commits in this history carry such a line.
+      Measured by A/B: with `Verifies` mapped the three counters read 4/4/4;
+      with it unmapped they read 0/0/0 and orphans rises 81 -> 85.
+
+      So the honest baseline is `linked: 0, orphans: 85, broken_refs: 0` — and
+      `linked: 4` was never real. The trailer mapping is therefore kept to
+      `Refs: traces-to` alone. That is a finding, not laziness: a gate that
+      fails on a normal English sentence gets switched off, and `Verified:` is
+      an entirely natural thing to write in a commit body. Reported upstream;
+      widen the mapping when the matcher stops guessing.
+
+      (2) `rivet commits --strict` cannot be the gate. It also promotes the
+      repo-wide unimplemented-artifacts warning, which reports `Artifact
+      coverage: 1/257 (0.4%)` — a condition NO pull request can satisfy.
+      Measured: a range with one correctly-linked commit and zero orphans and
+      zero broken refs still exits 1 under `--strict`. A gate no PR can pass is
+      not a gate. `tools/check-commit-trailers.py` therefore reads the JSON
+      summary and fails on only the three counters a PR is responsible for —
+      `orphans`, `broken_refs`, `malformed_refs` — and deliberately ignores
+      `unimplemented` and `artifact_coverage`.
+
+      FORWARD-ONLY BY CONSTRUCTION: the gate is scoped to `origin/main..HEAD`,
+      so the 85 pre-existing orphans never enter it and no history rewrite is
+      needed. `traced-paths: [crates/]` scopes it to the code side, which is
+      what #161 measured as disconnected; artifact-only commits are not orphans.
+      It runs as its OWN CI job so a traceability failure is legible in the
+      checks list rather than buried behind artifact validation.
+    tags: [traceability, v-model, gate, issue-driven, scry161, v3.4]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given a commit touching `crates/` with NO artifact trailer, When the gate runs over its range, Then it FAILS with `orphans=1`. VERIFIED end-to-end on the real repo, exit 1."
+        - "Given the same commit carrying `Refs: REQ-005`, When the gate runs, Then it PASSES — `linked: 1, orphans: 0, broken_refs: 0`, exit 0. This is the direction `--strict` could not satisfy, and is why the gate is not `--strict`."
+        - "Given a commit whose trailer names an artifact that does NOT exist (`Refs: FEAT-99999` — the scry#160 defect), When the gate runs, Then it FAILS with `broken_refs=1` and a message naming that defect. VERIFIED end-to-end, exit 1."
+        - "Given rivet exits non-zero because a reference is broken, When the gate runs, Then it still PARSES the JSON summary and reports WHICH counter failed. Fixed after first measurement: bailing on the exit code alone degraded an informative failure to `rivet exited 1`."
+        - "Given rivet is missing or produces no parseable summary, When the gate runs, Then it FAILS CLOSED — a gate that skips on a missing tool reports green while checking nothing (scry#141)."
+        - "SELF-TESTED, run BEFORE the real check in CI: 6 cases over the pure `verdict()` function, including that `linked` and `exempt` NEVER fail the gate and that a missing counter key reads 0."
+      residual: >
+        The 85 historical orphan commits stay orphans, deliberately: linking
+        them would mean rewriting history or fabricating after-the-fact
+        attributions, and neither is worth it. `rivet commits` without a range
+        still reports them, and that number is the honest record of when the
+        connection started, not a defect to be driven to zero.
+
+        The mapping carries ONE trailer key while rivet's matcher is fuzzy, so
+        `Satisfies`/`Verifies` are unavailable and everything routes through
+        `traces-to`. That is a real loss of expressiveness accepted to keep the
+        gate trustworthy. `Fixes:` was also found once as prose in history and
+        is likewise unmapped.
+
+        This gate does NOT check that the linked artifact is the RIGHT one — a
+        commit can satisfy it with any resolving id. It catches unlinked and
+        dangling, not mis-attributed.
+    links:
+      - type: traces-to
+        target: REQ-005

--- a/artifacts/roadmap-v3.4-commit-trace.yaml
+++ b/artifacts/roadmap-v3.4-commit-trace.yaml
@@ -123,9 +123,21 @@ artifacts:
         - "Given a required context matching no job in either ci.yml or rivet-delta.yml, When the gate runs, Then it FAILS — a renamed or deleted job leaves a context that can never report."
         - "Given the ruleset has no `required_status_checks` rule at all, When the gate runs, Then it FAILS explicitly as scry#130 recurring, rather than passing because there is nothing to compare."
         - "Given a job introduced by the CURRENT PR, When the gate runs, Then it is reported PENDING and does NOT fail. Verified on this PR itself, which introduces two such jobs and still exits 0."
-        - "Given the ruleset cannot be read, When the gate runs, Then it FAILS CLOSED naming the needed `administration: read` permission — inability to check is not evidence of correctness (scry#141)."
+        - "CORRECTED AFTER A BROKEN BUILD, recorded rather than quietly fixed. The first version ran the LIVE-ruleset check in CI under `permissions: administration: read`. That is NOT a grantable Actions scope, and a workflow requesting it is REJECTED WHOLESALE: the CI run completed as `failure` with ZERO jobs and no log, which reads like a queue outage rather than a syntax error. It was diagnosed only by noticing the PR showed 1 registered check instead of 12. A workflow GITHUB_TOKEN cannot read rulesets at all, so the original design could never have worked in CI."
+        - "Given CI, When the gate runs, Then it uses `--against-file` against `.github/required-checks.txt` with no API call. This catches the rot WE cause in our own PRs: a job added or renamed without updating the file. MUTATION-CHECKED: deleting `Clippy` from the file fails with `job Clippy exists on main and runs on every PR, but is NOT required`."
+        - "Given admin credentials, When the gate runs in its default LIVE mode, Then it additionally cross-checks the file against the real ruleset, because CI gates on the file and a drifted file means CI is gating on a fiction. MUTATION-CHECKED: the same deletion fails LIVE mode with a DIFFERENT and correct message, `Clippy is required LIVE but missing from .github/required-checks.txt`."
+        - "Given the ruleset cannot be read in LIVE mode, When the gate runs, Then it FAILS CLOSED pointing at `--against-file` for CI. Inability to check is not evidence of correctness (scry#141)."
         - "SELF-TESTED, run BEFORE the real check in CI: 6 cases over the pure `verdict()` function covering all four failure directions plus the pending case."
       residual: >
+        A RULESET RESET IS STILL NOT CAUGHT BY CI, and cannot be: GITHUB_TOKEN
+        cannot read rulesets, so no workflow job can see the live setting. CI
+        gates on the checked-in file; the live cross-check runs only where admin
+        credentials exist (locally, or a credentialed schedule that does not yet
+        exist). So "something regenerates temper-default-branch-protection and
+        required_status_checks vanishes" is caught the next time the live mode is
+        run by hand, NOT automatically. Closing that needs a PAT secret, which is
+        a repo-owner decision this feature should not assume.
+
         The gate reads the ruleset by hard-coded id (16891064). If the ruleset
         is deleted and recreated rather than edited, the id changes and the
         gate fails closed — noisy, but in the safe direction.

--- a/artifacts/roadmap-v3.4-commit-trace.yaml
+++ b/artifacts/roadmap-v3.4-commit-trace.yaml
@@ -77,3 +77,69 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-005
+
+  - id: FEAT-093
+    type: feature
+    title: "v3.4 — The required-check set cannot silently rot back to scry#130"
+    status: proposed
+    release: v3.4.0
+    description: >
+      scry#130 was enforced on 2026-08-27: the ruleset
+      `temper-default-branch-protection` now requires all ten jobs of ci.yml.
+      Verified in BOTH directions, which is what distinguishes a gate from a
+      setting — every open PR flipped to `mergeStateStatus=BLOCKED` on apply,
+      and PR #164 merged `CLEAN` once its ten checks passed.
+
+      A setting that was wrong for months can be wrong again, and would be
+      invisible: CI still runs, PRs still go green, and nothing announces that
+      a job stopped being enforced. Three concrete ways it rots:
+
+        1. A JOB IS ADDED and never required — scry#130 returning one job at a
+           time, with no symptom at all.
+        2. A JOB IS RENAMED — the stale context can never report, so every PR
+           deadlocks. The opposite failure, equally silent until it bites.
+        3. THE RULESET IS RESET — its name says `temper-`, i.e. something else
+           may regenerate it. `required_status_checks` would simply vanish.
+
+      THE DEADLOCK RULE, which is why this is not set-equality. A check may be
+      required only if it reports on EVERY pull request. `rivet-delta.yml` is
+      PATH-FILTERED (`artifacts/**`, `rivet.yaml`, …) so `Rivet artifact delta`
+      does not run on a code-only PR; requiring it would block such PRs
+      forever. The gate therefore fails if a path-filtered or `if:`-conditional
+      job is ever required, and carries the exclusion WITH its reason so the
+      exclusion is auditable rather than folklore.
+
+      NEW JOBS ARE NOT FAILURES. A job added in the current PR does not exist
+      on main and cannot be required yet — requiring it would deadlock every
+      other open PR. The gate reads ci.yml from BOTH `origin/main` and the PR,
+      and reports such jobs as PENDING with the instruction to add them after
+      merge. Without this the gate would fail on the very PR that introduces it.
+    tags: [release-machinery, gate, drift, scry130, v3.4]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given a job that exists on main and runs on every PR but is absent from the required set, When the gate runs, Then it FAILS naming that job. MUTATION-CHECKED AGAINST THE LIVE RULESET: `Format` was removed from the real required set (asserted 10 -> 9 before applying), the gate failed with `job 'Format' exists on main and runs on every PR, but is NOT required`, and restoring returned it to 10 contexts and exit 0."
+        - "Given a path-filtered or `if:`-conditional job that IS required, When the gate runs, Then it FAILS — such a check never reports on some PRs and deadlocks them. Self-tested."
+        - "Given a required context matching no job in either ci.yml or rivet-delta.yml, When the gate runs, Then it FAILS — a renamed or deleted job leaves a context that can never report."
+        - "Given the ruleset has no `required_status_checks` rule at all, When the gate runs, Then it FAILS explicitly as scry#130 recurring, rather than passing because there is nothing to compare."
+        - "Given a job introduced by the CURRENT PR, When the gate runs, Then it is reported PENDING and does NOT fail. Verified on this PR itself, which introduces two such jobs and still exits 0."
+        - "Given the ruleset cannot be read, When the gate runs, Then it FAILS CLOSED naming the needed `administration: read` permission — inability to check is not evidence of correctness (scry#141)."
+        - "SELF-TESTED, run BEFORE the real check in CI: 6 cases over the pure `verdict()` function covering all four failure directions plus the pending case."
+      residual: >
+        The gate reads the ruleset by hard-coded id (16891064). If the ruleset
+        is deleted and recreated rather than edited, the id changes and the
+        gate fails closed — noisy, but in the safe direction.
+
+        A job RENAMED in a PR shows as PENDING at PR time (the old name still
+        exists on main, still required, still reporting) and only fails after
+        the rename merges. That ordering is correct but means a rename costs
+        one red build on main. Renaming a required job is a two-step operation:
+        add the new name, require it, then drop the old one.
+
+        This checks that the required SET tracks the jobs. It does not check
+        that each job is a MEANINGFUL gate — `check-gate-coverage.py` covers
+        the crate dimension, and nothing covers "this job asserts something
+        real", which remains a human judgement.
+    links:
+      - type: traces-to
+        target: REQ-005

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -19,6 +19,41 @@ project:
     - safety-case
     - aspice
 
+# scry#161: the V-model's artifact side and the code side were never
+# connected, and the tool to connect them shipped unconfigured. Turning the
+# analysis on is the two-line part; the value is the `Broken refs` counter,
+# which catches a commit naming an artifact id that does not resolve. That is
+# exactly the defect that let PR #159 merge referencing FEAT-086 before the
+# artifact existed (#160) — found by grepping, not by a gate.
+#
+# Only link types this schema actually uses are mapped. `implements`/`fixes`
+# appear in rivet's example config but are not in use here, and a trailer
+# mapping to a link type the schema does not have would be a broken reference
+# by construction.
+commits:
+  format: trailers
+  # ONLY `Refs` is mapped, and that is a finding, not laziness. rivet's
+  # trailer-key matcher is FUZZY: with `Verifies` mapped it reads the ordinary
+  # prose line "Verified: bazel build //:scry green" as a malformed artifact
+  # trailer, and counts those commits as BOTH `Linked` and `Broken refs` —
+  # measured, 4 of each on this history, all of them prose (5 commits carry
+  # such a line). A gate that fails on a normal sentence gets switched off, so
+  # the mapping is kept to the one key with no prose collision here. Reported
+  # upstream; widen this once the matcher stops guessing.
+  trailers:
+    Refs: traces-to
+  exempt-types:
+    - chore
+    - style
+    - ci
+    - docs
+    - build
+  skip-trailer: "Trace: skip"
+  # The code side is what #161 measured as disconnected, so that is what is
+  # traced. Artifact-only commits are not orphans.
+  traced-paths:
+    - crates/
+
 sources:
   - path: artifacts
     format: generic-yaml

--- a/tools/check-commit-trailers.py
+++ b/tools/check-commit-trailers.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Gate: commits touching traced paths must link an artifact that RESOLVES.
+
+WHY (scry#161). rivet ships commit-to-artifact traceability and it was never
+configured, so the V-model's artifact side and the code side were not connected
+at all. The counter that earns its keep is `broken_refs` -- a commit naming an
+artifact id that does not exist. That is precisely how PR #159 merged
+referencing FEAT-086 before the artifact existed (#160): found by grepping,
+not by a gate.
+
+WHY NOT `rivet commits --strict`. Measured: --strict also promotes the
+repo-wide "unimplemented artifacts" warning, which reports
+`Artifact coverage: 1/257` and CANNOT be satisfied by any pull request. A gate
+no PR can pass gets switched off. This checks only the counters a PR is
+responsible for -- its own commits -- and deliberately ignores `unimplemented`
+and `artifact_coverage`.
+
+FORWARD-ONLY by construction: scoped to a commit RANGE, so the 85 pre-existing
+orphans never enter the gate.
+"""
+import sys, json, subprocess
+
+FATAL = ("orphans", "broken_refs", "malformed_refs")
+
+WHY = {
+    "orphans": "commit touches a traced path but links no artifact "
+               "(add e.g. `Refs: FEAT-091`, or `Trace: skip`)",
+    "broken_refs": "commit names an artifact id that does NOT resolve "
+                   "(the scry#160 defect: referencing an artifact before it exists)",
+    "malformed_refs": "trailer key not recognised -- note rivet's matcher is FUZZY "
+                      "and will read a prose line like 'Verified: ...' as one",
+}
+
+
+def verdict(summary):
+    """Pure: summary dict -> list of (counter, count, why). Drives --self-test."""
+    return [(k, summary.get(k, 0), WHY[k]) for k in FATAL if summary.get(k, 0)]
+
+
+def self_test():
+    cases = [
+        ("clean", {"orphans": 0, "broken_refs": 0, "malformed_refs": 0, "linked": 3}, 0),
+        ("an orphan commit", {"orphans": 1, "broken_refs": 0, "malformed_refs": 0}, 1),
+        ("a ref to a nonexistent artifact", {"orphans": 0, "broken_refs": 2, "malformed_refs": 0}, 1),
+        ("a malformed trailer key", {"orphans": 0, "broken_refs": 0, "malformed_refs": 1}, 1),
+        ("several at once are all reported", {"orphans": 1, "broken_refs": 1, "malformed_refs": 1}, 3),
+        ("all-exempt range is clean", {"exempt": 9}, 0),
+    ]
+    bad = 0
+    for name, s, want in cases:
+        got = len(verdict(s))
+        ok = got == want
+        bad += not ok
+        print(f"  [{'ok' if ok else 'SELF-TEST FAILED'}] {name}: {got} fatal, expected {want}")
+    return bad
+
+
+def main():
+    if "--self-test" in sys.argv:
+        f = self_test()
+        print("SELF-TEST PASS" if not f else f"SELF-TEST FAIL ({f})")
+        return 1 if f else 0
+
+    rng = "origin/main..HEAD"
+    if "--range" in sys.argv:
+        rng = sys.argv[sys.argv.index("--range") + 1]
+
+    try:
+        out = subprocess.run(["rivet", "commits", "--range", rng, "--format", "json"],
+                             capture_output=True, text=True, timeout=300)
+    except Exception as e:
+        # FAIL CLOSED: a gate that skips when its tool is missing reports green
+        # while checking nothing (the scry#141 failure mode).
+        print(f"FAIL: could not run rivet ({e})")
+        return 1
+
+    # Parse stdout REGARDLESS of exit code: rivet exits non-zero when a
+    # reference is broken, and its JSON still carries the counters. Bailing on
+    # returncode alone throws away the diagnostic naming WHICH counter failed.
+    summary = None
+    try:
+        summary = json.loads(out.stdout)["summary"]
+    except Exception:
+        pass
+    if summary is None:
+        print(f"FAIL: rivet commits exited {out.returncode} with no parseable "
+              f"summary\n{(out.stderr or out.stdout)[:500]}")
+        return 1
+
+    print(f"  range {rng}: {summary}")
+    bad = verdict(summary)
+    for k, n, why in bad:
+        print(f"  FAIL: {k}={n} — {why}")
+    print("PASS" if not bad else f"FAIL ({len(bad)} counter(s))")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check-required-checks.py
+++ b/tools/check-required-checks.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Gate: the ruleset's required checks must track the CI jobs that exist.
+
+WHY (scry#130). `main` required NOTHING for months while `ci.yml` carried a
+comment claiming three checks were required. The setting was fixed on
+2026-08-27; this exists so it cannot silently rot again. Three ways it rots:
+
+  1. A JOB IS ADDED and never required -> back to scry#130, one job at a time,
+     with nobody noticing because the PR still goes green.
+  2. A JOB IS RENAMED -> the old context is required forever, never reports,
+     and every PR deadlocks.
+  3. THE RULESET IS RESET -> it is named `temper-default-branch-protection`,
+     i.e. something else may regenerate it. If required_status_checks vanishes,
+     this fails loudly instead of quietly returning to advisory CI.
+
+THE DEADLOCK RULE, which is why this is not just a set-equality check: a check
+may be required only if it reports on EVERY pull request. A PATH-FILTERED
+workflow (rivet-delta.yml: artifacts/**, rivet.yaml, ...) does not run on a
+code-only PR, and a required check that never reports blocks that PR forever.
+So path-filtered and `if:`-conditional jobs must NOT be required, and this
+gate fails if one ever is.
+
+NEW JOBS ARE NOT A FAILURE. A job added in the current PR does not yet exist on
+main, so it cannot be required yet -- requiring it would deadlock every other
+open PR. Those are reported as PENDING: add them to the ruleset after merge.
+"""
+import sys, json, subprocess
+
+try:
+    import yaml
+except ImportError:
+    print("FAIL: PyYAML not available -- this gate cannot run", file=sys.stderr)
+    sys.exit(1)
+
+# Deliberately excluded, with the reason, so the exclusion is auditable rather
+# than folklore. Anything here MUST be path-filtered or conditional.
+EXPECTED_EXCLUSIONS = {
+    "Rivet artifact delta": "rivet-delta.yml is path-filtered; never reports on a code-only PR",
+}
+
+
+def workflow_jobs(text):
+    """-> {job name: {'requirable': bool, 'why': str}} for one workflow file."""
+    d = yaml.safe_load(text) or {}
+    on = d.get("on", d.get(True)) or {}
+    pr = on.get("pull_request") if isinstance(on, dict) else None
+    path_filtered = bool(isinstance(pr, dict) and (pr.get("paths") or pr.get("paths-ignore")))
+    runs_on_pr = pr is not None
+    out = {}
+    for jid, j in (d.get("jobs") or {}).items():
+        if not isinstance(j, dict):
+            continue
+        name = j.get("name") or jid
+        if not runs_on_pr:
+            out[name] = (False, "does not run on pull_request")
+        elif path_filtered:
+            out[name] = (False, "workflow is path-filtered")
+        elif j.get("if"):
+            out[name] = (False, "job is `if:`-conditional")
+        else:
+            out[name] = (True, "")
+    return out
+
+
+def verdict(main_jobs, pr_jobs, required):
+    """Pure -> (failures, pending). Drives --self-test."""
+    fails, pending = [], []
+    for name, (requirable, why) in main_jobs.items():
+        if requirable and name not in required:
+            fails.append(f"job {name!r} exists on main and runs on every PR, but is NOT required "
+                         f"-- this is scry#130 returning one job at a time")
+        if not requirable and name in required:
+            fails.append(f"job {name!r} is required but {why} -- a check that does not report "
+                         f"on every PR DEADLOCKS those PRs")
+    all_names = set(main_jobs) | set(pr_jobs)
+    for ctx in sorted(required):
+        if ctx not in all_names:
+            fails.append(f"required context {ctx!r} matches no job -- renamed or deleted; "
+                         f"it can never report, so every PR deadlocks")
+    for name, (requirable, _) in pr_jobs.items():
+        if requirable and name not in main_jobs and name not in required:
+            pending.append(name)
+    for name, why in EXPECTED_EXCLUSIONS.items():
+        if name in pr_jobs and pr_jobs[name][0]:
+            fails.append(f"{name!r} is listed as a deliberate exclusion ({why}) but is now "
+                         f"requirable -- the exclusion is stale, re-decide it")
+    return fails, pending
+
+
+def self_test():
+    R = lambda: (True, "")
+    N = lambda w: (False, w)
+    cases = [
+        ("clean: every main job required", {"A": R()}, {"A": R()}, {"A"}, 0, 0),
+        ("a main job is NOT required (scry#130 returning)", {"A": R(), "B": R()}, {"A": R(), "B": R()}, {"A"}, 1, 0),
+        ("a path-filtered job IS required (deadlock)", {"A": R(), "D": N("workflow is path-filtered")},
+         {"A": R(), "D": N("x")}, {"A", "D"}, 1, 0),
+        ("a required context matches no job (renamed)", {"A": R()}, {"A": R()}, {"A", "Gone"}, 1, 0),
+        ("a NEW job in this PR is pending, not a failure", {"A": R()}, {"A": R(), "New": R()}, {"A"}, 0, 1),
+        ("ruleset reset: nothing required at all", {"A": R(), "B": R()}, {"A": R(), "B": R()}, set(), 2, 0),
+    ]
+    bad = 0
+    for name, mj, pj, req, wf, wp in cases:
+        f, p = verdict(mj, pj, req)
+        ok = len(f) == wf and len(p) == wp
+        bad += not ok
+        print(f"  [{'ok' if ok else 'SELF-TEST FAILED'}] {name}: {len(f)} fail / {len(p)} pending, "
+              f"expected {wf}/{wp}")
+    return bad
+
+
+WORKFLOWS = [".github/workflows/ci.yml", ".github/workflows/rivet-delta.yml"]
+
+
+def read(path, ref=None):
+    if ref is None:
+        return open(path, encoding="utf-8").read()
+    r = subprocess.run(["git", "show", f"{ref}:{path}"], capture_output=True, text=True)
+    return r.stdout if r.returncode == 0 else ""
+
+
+def main():
+    if "--self-test" in sys.argv:
+        f = self_test()
+        print("SELF-TEST PASS" if not f else f"SELF-TEST FAIL ({f})")
+        return 1 if f else 0
+
+    try:
+        out = subprocess.run(
+            ["gh", "api", "repos/pulseengine/scry/rulesets/16891064"],
+            capture_output=True, text=True, timeout=120)
+        rs = json.loads(out.stdout)
+        rule = next((r for r in rs["rules"] if r["type"] == "required_status_checks"), None)
+    except Exception as e:
+        # FAIL CLOSED: unable to read the ruleset is not evidence it is correct.
+        print(f"FAIL: could not read the ruleset ({e}). CI needs `permissions: "
+              f"administration: read`.")
+        return 1
+    if rule is None:
+        print("FAIL: the ruleset has NO required_status_checks rule -- this is exactly "
+              "scry#130, and it was fixed on 2026-08-27. Something reset it.")
+        return 1
+    required = {c["context"] for c in rule["parameters"]["required_status_checks"]}
+
+    main_jobs, pr_jobs = {}, {}
+    for wf in WORKFLOWS:
+        main_jobs.update(workflow_jobs(read(wf, "origin/main")))
+        pr_jobs.update(workflow_jobs(read(wf)))
+    if not main_jobs:
+        print("FAIL: could not read any workflow from origin/main (shallow clone? "
+              "needs fetch-depth: 0)")
+        return 1
+
+    print(f"  required contexts: {len(required)}; jobs on main: {len(main_jobs)}; "
+          f"jobs in this PR: {len(pr_jobs)}")
+    fails, pending = verdict(main_jobs, pr_jobs, required)
+    for p in pending:
+        print(f"  PENDING (not a failure): job {p!r} is new in this PR. Add it to the "
+              f"ruleset AFTER merge -- requiring it now deadlocks every other open PR.")
+    for f in fails:
+        print(f"  FAIL: {f}")
+    print("PASS" if not fails else f"FAIL ({len(fails)})")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check-required-checks.py
+++ b/tools/check-required-checks.py
@@ -23,6 +23,21 @@ gate fails if one ever is.
 NEW JOBS ARE NOT A FAILURE. A job added in the current PR does not yet exist on
 main, so it cannot be required yet -- requiring it would deadlock every other
 open PR. Those are reported as PENDING: add them to the ruleset after merge.
+
+TWO MODES, because of a credential fact learned the hard way: a workflow's
+GITHUB_TOKEN CANNOT read rulesets. `administration` is not a grantable Actions
+permission scope, and a workflow requesting it is REJECTED WHOLESALE by GitHub
+-- the run fails with zero jobs and no log, which looks like an outage rather
+than a syntax error.
+
+  --against-file  compares the jobs to .github/required-checks.txt. No API, so
+                  CI can run it. Catches a job ADDED or RENAMED without the
+                  file being updated -- the rot modes WE cause, in our own PRs.
+  (default)       compares the jobs to the LIVE ruleset, and additionally
+                  checks the file against it. Needs admin credentials, so it
+                  runs locally or from a credentialed schedule. This is the
+                  only mode that can catch a ruleset RESET or an out-of-band
+                  edit, because that is invisible to anything in-repo.
 """
 import sys, json, subprocess
 
@@ -109,6 +124,7 @@ def self_test():
     return bad
 
 
+REQUIRED_FILE = ".github/required-checks.txt"
 WORKFLOWS = [".github/workflows/ci.yml", ".github/workflows/rivet-delta.yml"]
 
 
@@ -125,22 +141,44 @@ def main():
         print("SELF-TEST PASS" if not f else f"SELF-TEST FAIL ({f})")
         return 1 if f else 0
 
-    try:
-        out = subprocess.run(
-            ["gh", "api", "repos/pulseengine/scry/rulesets/16891064"],
-            capture_output=True, text=True, timeout=120)
-        rs = json.loads(out.stdout)
-        rule = next((r for r in rs["rules"] if r["type"] == "required_status_checks"), None)
-    except Exception as e:
-        # FAIL CLOSED: unable to read the ruleset is not evidence it is correct.
-        print(f"FAIL: could not read the ruleset ({e}). CI needs `permissions: "
-              f"administration: read`.")
-        return 1
-    if rule is None:
-        print("FAIL: the ruleset has NO required_status_checks rule -- this is exactly "
-              "scry#130, and it was fixed on 2026-08-27. Something reset it.")
-        return 1
-    required = {c["context"] for c in rule["parameters"]["required_status_checks"]}
+    from_file = {l.strip() for l in open(REQUIRED_FILE, encoding="utf-8")
+                 if l.strip() and not l.startswith("#")}
+    extra = []
+    if "--against-file" in sys.argv:
+        if not from_file:
+            print(f"FAIL: {REQUIRED_FILE} is empty -- nothing to gate against")
+            return 1
+        required = from_file
+        print(f"  mode: --against-file ({REQUIRED_FILE})")
+    else:
+        try:
+            out = subprocess.run(
+                ["gh", "api", "repos/pulseengine/scry/rulesets/16891064"],
+                capture_output=True, text=True, timeout=120)
+            rs = json.loads(out.stdout)
+            rule = next((r for r in rs["rules"] if r["type"] == "required_status_checks"), None)
+        except Exception as e:
+            # FAIL CLOSED: unable to read the ruleset is not evidence it is
+            # correct. In CI use --against-file; GITHUB_TOKEN cannot read
+            # rulesets at all.
+            print(f"FAIL: could not read the ruleset ({e}). This mode needs admin "
+                  f"credentials; CI should use --against-file.")
+            return 1
+        if rule is None:
+            print("FAIL: the ruleset has NO required_status_checks rule -- this is exactly "
+                  "scry#130, and it was fixed on 2026-08-27. Something reset it.")
+            return 1
+        required = {c["context"] for c in rule["parameters"]["required_status_checks"]}
+        # The file is what CI can see; if it has drifted from the live setting,
+        # CI is gating on a fiction.
+        if from_file != required:
+            for c in sorted(required - from_file):
+                extra.append(f"{c!r} is required LIVE but missing from {REQUIRED_FILE} "
+                             f"-- CI gates on the file, so it is gating on a fiction")
+            for c in sorted(from_file - required):
+                extra.append(f"{c!r} is listed in {REQUIRED_FILE} but is NOT required live "
+                             f"-- the ruleset was reset or edited out of band")
+        print(f"  mode: live ruleset (file agrees: {from_file == required})")
 
     main_jobs, pr_jobs = {}, {}
     for wf in WORKFLOWS:
@@ -154,6 +192,7 @@ def main():
     print(f"  required contexts: {len(required)}; jobs on main: {len(main_jobs)}; "
           f"jobs in this PR: {len(pr_jobs)}")
     fails, pending = verdict(main_jobs, pr_jobs, required)
+    fails += extra
     for p in pending:
         print(f"  PENDING (not a failure): job {p!r} is new in this PR. Add it to the "
               f"ruleset AFTER merge -- requiring it now deadlocks every other open PR.")


### PR DESCRIPTION
Closes the measurement in #161. **Two measurements correct that issue's premise**, and both changed the design — worth reading before the diff.

## (1) `linked: 4` was never real — rivet's trailer matcher is fuzzy

#161 reports *"zero of 125 commits carry an artifact trailer."* Configure a `Verifies` mapping and rivet instead reports `linked: 4`, `broken_refs: 4` **and** `malformed_refs: 4` — the **same four commits** inflating three counters at once.

None of them carry a trailer. All four are this ordinary prose line:

```
Verified: bazel build //:scry green + wasm-tools validate ok.
```

rivet's **fuzzy** trailer-key matcher reads that as a malformed `Verifies:`. Five commits in this history carry such a line.

A/B measured:

| mapping | linked | orphans | broken_refs | malformed_refs |
|---|---|---|---|---|
| with `Verifies` | 4 | 81 | 4 | 4 |
| `Refs` only | **0** | **85** | **0** | **0** |

So the honest baseline is `linked: 0, orphans: 85, broken_refs: 0`.

**The mapping is therefore kept to `Refs: traces-to` alone.** That's a finding, not laziness: a gate that fails on a normal English sentence gets switched off, and `Verified:` is an entirely natural thing to write in a commit body. Reported upstream; widen when the matcher stops guessing.

## (2) `rivet commits --strict` cannot be the gate

`--strict` also promotes the repo-wide *unimplemented artifacts* warning — `Artifact coverage: 1/257 (0.4%)` — which **no pull request can satisfy**.

Measured: a range with one correctly-linked commit, zero orphans and zero broken refs **still exits 1** under `--strict`. A gate no PR can pass is not a gate; it just gets disabled.

So `tools/check-commit-trailers.py` reads the JSON summary and fails on only the three counters a PR actually owns — `orphans`, `broken_refs`, `malformed_refs` — and deliberately ignores `unimplemented` and `artifact_coverage`.

## Verified end-to-end on the real repo

| probe | result | exit |
|---|---|---|
| `crates/` commit, no trailer | `orphans=1` | 1 |
| same commit, `Refs: REQ-005` | `linked=1` | **0** |
| `Refs: FEAT-99999` (the #160 defect) | `broken_refs=1` | 1 |

That middle row is the direction `--strict` could not produce, and is the whole reason for a custom gate.

Two fixes found by measuring rather than assuming:
- **parse the JSON even when rivet exits non-zero** — rivet exits 1 on a broken ref, and bailing on the exit code alone degraded an informative failure into `"rivet exited 1"`
- **fail closed** when rivet is absent (the scry#141 mode: a gate that skips reports green while checking nothing)

Self-test of 6 cases runs **before** the real check, and asserts that `linked`/`exempt` never fail the gate and that a missing key reads 0.

## Forward-only by construction

Scoped to `origin/main..HEAD`, so the **85 pre-existing orphans never enter the gate** and no history rewrite is needed. `traced-paths: [crates/]` scopes it to the code side — which is what #161 measured as disconnected. It runs as its **own CI job** so a traceability failure is legible in the checks list rather than buried behind artifact validation.

## Residual, stated

- The 85 historical orphans stay orphans, deliberately. Linking them means rewriting history or fabricating after-the-fact attributions. `rivet commits` without a range still reports them — that number is the honest record of when the connection started.
- One trailer key means `Satisfies`/`Verifies` are unavailable and everything routes through `traces-to`. A real loss of expressiveness, accepted to keep the gate trustworthy. (`Fixes:` also appears once as prose, so it is likewise unmapped.)
- **This does not check the artifact is the RIGHT one.** Any resolving id satisfies it. It catches *unlinked* and *dangling*, not *mis-attributed*.

`tests=0 fmt=0 rivet=0 claim-check=0 gate-coverage=0 trailers-self-test=0`

⚠️ Per #130 this repo has no required status checks; verify `gh pr checks` by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc