### PR TITLE
FEAT-092 (scry#126): one operator, one name

### DIFF
--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1197,6 +1197,23 @@ artifacts:
       list means "not proven", never "unsafe".
       Interop note: the same shape as the output contract in WasmBounds (Sudo &
       Winstein, Stanford), which is a cleaner interface than our full feed.
+
+      MEASURED BEFORE BUILDING (2026-08-27, scry's own scry_mcdc.wasm,
+      identical stripped and unstripped): scry proves **55** memory accesses
+      safe against **8,162** it cannot — a **0.67%** proven rate. The export
+      this feature describes would therefore carry 55 sites out of 8,217. synth
+      measures software bounds checks at ~25-40% overhead, so eliding 0.67% of
+      them recovers on the order of 0.2% of runtime.
+
+      That does not kill the feature, but it relocates the work: the blocker is
+      NOT the export format, it is PRECISION. The same module shows 1,639
+      `unmodeled-control-flow` and 623 `unsupported-op` advisories — an
+      `if`/`else` havocs its region (by design, with an honest gap record), and
+      FEAT-089 measured that a disequality guard cannot refine an interval at
+      all. Shipping the channel before the payload exists would hand synth a
+      correct and nearly empty file. Precision work (FEAT-089 and the
+      region-havoc family) should land first, and this AC should be re-measured
+      after it, not before.
     tags: [bounds-elision, synth, interop, embedded, v3.3]
     fields:
       phase: phase-3

--- a/artifacts/roadmap-v3.4-op-names.yaml
+++ b/artifacts/roadmap-v3.4-op-names.yaml
@@ -1,0 +1,55 @@
+# v3.4.0 addendum — own file per scry#143 fix (1).
+artifacts:
+  - id: FEAT-092
+    type: feature
+    title: "v3.4 — One operator, one name: stop leaking Rust identifiers into the operator ranking (scry#126)"
+    status: proposed
+    release: v3.4.0
+    description: >
+      `TrapCheck::op` is documented as "the operator name (e.g. `i32.div_s`)" —
+      wasm text format. MEASURED on scry's own scry_mcdc.wasm: 2,800 of 10,520
+      advisories instead carried a RUST ENUM IDENTIFIER — `I64Store`,
+      `I32Load8U`, `I32Store8`, `MemoryCopy`, `F64Load` … The numbers are
+      IDENTICAL on the stripped and unstripped module, so this is not an
+      artifact of how the module was built.
+
+      MECHANISM. `op_report_name` falls back to `format!("{op:?}")` for any
+      operator `op_name` has no arm for, and among memory operators `op_name`
+      covered exactly two: `I32Load` and `I32Store`. Every other load/store
+      therefore rendered as its Rust variant name.
+
+      WHY THIS IS WORSE THAN UNIFORMLY WRONG, and why it belongs to scry#126's
+      operator ranking rather than to cosmetics: the SAME operator carried TWO
+      names at once. The non-degraded path labels the access from a literal
+      (`i64.store`, 287 sites); the degraded path calls `op_report_name`
+      (`I64Store`, 1,008 sites). Both are `out-of-bounds` advisories. A
+      consumer ranking operators by frequency sees ONE operator as TWO rows and
+      under-counts the top entry by ~4.5x — `i64.store` is really 1,295 sites.
+
+      THE FIX IS NAMING ONLY, and that is pinned rather than asserted: after
+      the change every advisory-code count on the real module is byte-identical
+      — `out-of-bounds` 8,162 -> 8,162, proven-safe OOB 55 -> 55, every code
+      equal across all 10,520 advisories — while leaked identifiers drop
+      2,800 -> 71.
+    tags: [consumer, naming, operator-ranking, issue-driven, scry126, v3.4]
+    fields:
+      phase: phase-3
+      acceptance-criteria:
+        - "Given a module using `i64.store`, `i32.load8_u` and `i32.store8`, When trap checks are stamped, Then no `TrapCheck::op` begins with an ASCII uppercase letter and each contains a `.`. RED FIRST: failed with `leaked: [\"I32Load8U\", \"I32Store8\"]`, after the non-vacuity assertion (>= 3 trap checks) had already passed — so the red was the contract, not an empty fixture."
+        - "Given the same fixture, When the fix is applied, Then the VERDICTS are unchanged — every trap check remains PotentialTrap. Pinned in the test so a future edit cannot alter what scry proves while claiming to rename."
+        - "MEASURED end-to-end on scry_mcdc.wasm: leaked Rust identifiers 2,800 -> 71, AND every advisory-code count identical (out-of-bounds 8,162 -> 8,162; proven-safe OOB 55 -> 55; all codes equal). The naming-only claim is a measurement, not an argument."
+        - "MUTATION-CHECKED: deleting the `i32.load8_u` arm (asserted to match exactly one site before applying) turns the test red naming exactly `I32Load8U`; restoring it is green."
+        - "NOT COVERED, stated rather than implied: 71 advisories still render a Rust identifier. All 71 are `unsupported-op` on i64/i32 arithmetic and comparison operators (`I64GtS`, `I64Add`, `I32Rotl`, …) that scry genuinely does not model, and each carries a SINGLE name — so the ranking-splitting defect does not apply to them. Naming that family is a separate mechanical slice that would also serve scry#126's fallback ranking."
+      residual: >
+        This fixes the NAME, not the coverage. The reason `i64.store` appeared
+        1,008 times via the degraded path is that those functions had already
+        been scrubbed by an unsupported operator upstream — the fix makes the
+        ranking countable, it does not make those accesses analysable. What the
+        corrected ranking now shows honestly is how much of the out-of-bounds
+        population comes from degraded functions.
+
+        The 71 remaining Rust identifiers are listed above and are deliberately
+        out of scope for this slice.
+    links:
+      - type: traces-to
+        target: REQ-017

--- a/crates/scry-analyze-core/src/lib.rs
+++ b/crates/scry-analyze-core/src/lib.rs
@@ -7480,6 +7480,41 @@ fn op_name(op: &Operator<'_>) -> &'static str {
         Operator::GlobalSet { .. } => "global.set",
         Operator::I32Load { .. } => "i32.load",
         Operator::I32Store { .. } => "i32.store",
+        // FEAT-092 (scry#126): `op_name` covered only i32.load/i32.store among
+        // memory ops, so `op_report_name` fell through to the `{:?}` Debug
+        // fallback for every other one and leaked a RUST ENUM IDENTIFIER into
+        // consumer-facing text — measured 2,800 of 10,520 advisories on
+        // scry_mcdc.wasm. The same operator then carried TWO names (the
+        // non-degraded path said `i64.store`, the degraded path `I64Store`),
+        // splitting one operator into two rows in an operator ranking.
+        Operator::I64Load { .. } => "i64.load",
+        Operator::I64Store { .. } => "i64.store",
+        Operator::F32Load { .. } => "f32.load",
+        Operator::F32Store { .. } => "f32.store",
+        Operator::F64Load { .. } => "f64.load",
+        Operator::F64Store { .. } => "f64.store",
+        Operator::I32Load8S { .. } => "i32.load8_s",
+        Operator::I32Load8U { .. } => "i32.load8_u",
+        Operator::I32Load16S { .. } => "i32.load16_s",
+        Operator::I32Load16U { .. } => "i32.load16_u",
+        Operator::I32Store8 { .. } => "i32.store8",
+        Operator::I32Store16 { .. } => "i32.store16",
+        Operator::I64Load8S { .. } => "i64.load8_s",
+        Operator::I64Load8U { .. } => "i64.load8_u",
+        Operator::I64Load16S { .. } => "i64.load16_s",
+        Operator::I64Load16U { .. } => "i64.load16_u",
+        Operator::I64Load32S { .. } => "i64.load32_s",
+        Operator::I64Load32U { .. } => "i64.load32_u",
+        Operator::I64Store8 { .. } => "i64.store8",
+        Operator::I64Store16 { .. } => "i64.store16",
+        Operator::I64Store32 { .. } => "i64.store32",
+        Operator::MemoryCopy { .. } => "memory.copy",
+        Operator::MemoryFill { .. } => "memory.fill",
+        Operator::MemoryInit { .. } => "memory.init",
+        Operator::DataDrop { .. } => "data.drop",
+        Operator::I32WrapI64 => "i32.wrap_i64",
+        Operator::I64ExtendI32S => "i64.extend_i32_s",
+        Operator::I64ExtendI32U => "i64.extend_i32_u",
         Operator::MemorySize { .. } => "memory.size",
         Operator::MemoryGrow { .. } => "memory.grow",
         Operator::I32DivS => "i32.div_s",
@@ -10974,6 +11009,72 @@ mod tests {
             !ids_before.is_empty() && ids_before.is_subset(&ids_after),
             "every pre-fix obligation id must still be addressable after the fix \
              (before={ids_before:?} after={ids_after:?})"
+        );
+    }
+
+    /// FEAT-092 (scry#126): `TrapCheck::op` is documented as "the operator name
+    /// (e.g. `i32.div_s`)" — wasm text format. MEASURED on a real module
+    /// (scry's own scry_mcdc.wasm, identical stripped and unstripped): 2,800 of
+    /// 10,520 advisories instead carried a RUST ENUM IDENTIFIER — `I64Store`,
+    /// `I32Load8U`, `I32Store8`, `MemoryCopy`, … — because `op_report_name`
+    /// falls back to `{:?}` for any operator `op_name` has no arm for, and
+    /// among memory ops `op_name` covered only `I32Load` and `I32Store`.
+    ///
+    /// Worse than uniformly wrong: the SAME operator got BOTH names. The
+    /// non-degraded path labels it `i64.store` (287 sites) while the degraded
+    /// path produced `I64Store` (1,008). A consumer ranking operators by
+    /// frequency (scry#126) sees one operator as two and under-counts the top
+    /// entry by ~4.5x.
+    ///
+    /// This is a NAMING fix only — the verdict multiset is pinned below so a
+    /// future edit cannot change what scry proves while claiming to rename.
+    #[test]
+    fn feat092_a_memory_operator_is_never_reported_by_its_rust_identifier() {
+        let r = analyze_default(
+            "(module (memory 1) (func $f (export \"f\") (param i32) \
+               local.get 0 i64.const 7 i64.store \
+               local.get 0 i32.load8_u drop \
+               local.get 0 i32.const 3 i32.store8))",
+        );
+        // Non-vacuity: the fixture must actually reach the operators in
+        // question, or "no Rust identifiers" is a claim about an empty set.
+        assert!(
+            r.trap_checks.len() >= 3,
+            "fixture must raise trap checks for the three memory ops; got {:?}",
+            r.trap_checks
+                .iter()
+                .map(|t| &t.op)
+                .collect::<alloc::vec::Vec<_>>()
+        );
+        let leaked: alloc::vec::Vec<&str> = r
+            .trap_checks
+            .iter()
+            .map(|t| t.op.as_str())
+            .filter(|n| n.starts_with(|c: char| c.is_ascii_uppercase()))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "TrapCheck::op must be the wasm text-format name, never a Rust \
+             enum identifier; leaked: {leaked:?}"
+        );
+        for t in &r.trap_checks {
+            assert!(
+                t.op.contains('.') && t.op.chars().all(|c| !c.is_ascii_uppercase()),
+                "not a wasm text-format operator name: {:?}",
+                t.op
+            );
+        }
+        // NAMING ONLY: pin the verdicts so a rename cannot quietly move what
+        // scry proves. All three accesses are unproven here.
+        let potential = r
+            .trap_checks
+            .iter()
+            .filter(|t| t.verdict == TrapVerdict::PotentialTrap)
+            .count();
+        assert_eq!(
+            potential,
+            r.trap_checks.len(),
+            "this fixture proves nothing safe; a naming change must not alter that"
         );
     }
 }


### PR DESCRIPTION
## The defect

`TrapCheck::op` is documented as *"the operator name (e.g. `i32.div_s`)"* — wasm text
format. Measured on scry's own `scry_mcdc.wasm`, **2,800 of 10,520 advisories** carried
a **Rust enum identifier** instead: `I64Store`, `I32Load8U`, `I32Store8`, `MemoryCopy`,
`F64Load`…

Counts are **identical on the stripped and unstripped module**, so this isn't an
artifact of how the module was built.

## Mechanism

`op_report_name` falls back to `format!("{op:?}")` for any operator `op_name` has no arm
for — and among memory operators `op_name` covered exactly **two**: `I32Load` and
`I32Store`. Every other load/store rendered as its Rust variant name.

## Why this is #126's operator ranking, not cosmetics

**The same operator carried two names at once.**

| path | name | sites | code |
|---|---|---|---|
| non-degraded (literal label) | `i64.store` | 287 | out-of-bounds |
| degraded (`op_report_name`) | `I64Store` | 1,008 | out-of-bounds |

A consumer ranking operators by frequency sees **one operator as two rows** and
under-counts the top entry by ~4.5× — `i64.store` is really **1,295** sites. Same for
`i64.load` (261 + 669).

## Naming only — measured, not argued

After the change, on the real module:

| | before | after |
|---|---|---|
| leaked Rust identifiers | 2,800 | **71** |
| `out-of-bounds` | 8,162 | **8,162** |
| proven-safe OOB | 55 | **55** |
| every advisory code equal | — | **yes** |

Every code count is identical across all 10,520 advisories. The test also pins the
verdicts, so a later edit can't move what scry proves while claiming to rename.

## Oracles

**Red first**, and the red was the contract rather than an empty fixture — the
non-vacuity assertion (`>= 3` trap checks) passed *before* the failure:

```
TrapCheck::op must be the wasm text-format name, never a Rust enum identifier;
leaked: ["I32Load8U", "I32Store8"]
```

**Mutation-checked**: deleting the `i32.load8_u` arm — asserted to match exactly one
site before applying — turns the test red naming exactly `I32Load8U`; restoring is green.

## Not covered, stated rather than implied

**71 advisories still render a Rust identifier.** All 71 are `unsupported-op` on i64/i32
arithmetic and comparison operators (`I64GtS`, `I64Add`, `I32Rotl`, …) that scry
genuinely does not model — and each carries a **single** name, so the ranking-splitting
defect doesn't apply to them. Naming that family is a separate mechanical slice that
would also serve #126's fallback ranking.

And this fixes the **name, not the coverage**. The reason `i64.store` appeared 1,008
times via the degraded path is that those functions were already scrubbed by an
unsupported operator upstream. The corrected ranking now shows honestly how much of the
out-of-bounds population comes from degraded functions.

`tests=0 clippy=0 fmt=0 rivet=0 claim-check=0 gate-coverage=0`

⚠️ Per #130 this repo has no required status checks; verify `gh pr checks` by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc