### PR TITLE
Promote FEAT-087 / FEAT-088 / FEAT-090 to accepted — v3.4.0 not-ready 7 → 4

### DIFF
--- a/artifacts/roadmap-v3.4-delta-identity.yaml
+++ b/artifacts/roadmap-v3.4-delta-identity.yaml
@@ -4,7 +4,7 @@ artifacts:
   - id: FEAT-090
     type: feature
     title: "v3.4 — The delta view carries the second identity bit: a vanish on the body-shape-hash tier is told apart from evidence (FEAT-087 residual)"
-    status: proposed
+    status: accepted
     release: v3.4.0
     description: >
       FEAT-087 added `Advisory::ident_survives_own_edit` and stated its own

--- a/artifacts/roadmap-v3.4-identity.yaml
+++ b/artifacts/roadmap-v3.4-identity.yaml
@@ -4,7 +4,7 @@ artifacts:
   - id: FEAT-087
     type: feature
     title: "v3.4 — Identity that survives an edit to its OWN body is a second, independent bit (scry#122 item 2)"
-    status: proposed
+    status: accepted
     release: v3.4.0
     description: >
       FEAT-077 made function identity honest about ONE question — "are these

--- a/artifacts/roadmap-v3.4-safety-gate.yaml
+++ b/artifacts/roadmap-v3.4-safety-gate.yaml
@@ -3,7 +3,7 @@ artifacts:
   - id: FEAT-088
     type: feature
     title: "v3.4 — A forgotten safety goal cannot hide behind the `undeveloped` diamond"
-    status: proposed
+    status: accepted
     release: v3.4.0
     description: >
       `rivet coverage` reports `goal-has-support` and `goal-has-context` at 40%


### PR DESCRIPTION
`proposed` counts as **not-yet-verified** in the release gate, so a shipped, green
feature left there blocks its release indefinitely — which is what v3.4.0 has been
carrying. Promoting these three is the honest counterpart to *not* promoting the
others.

## Evidence, grounded rather than remembered

| feature | shipped | re-verified on main just now |
|---|---|---|
| **FEAT-087** | #162, 11/11 green | 3 oracles pass — tier discrimination, tier-2 independence, module-scoped decision |
| **FEAT-088** | #163, 11/11 green | `--self-test` PASSES **and** the real check PASSES; wired in `ci.yml` self-test-first |
| **FEAT-090** | #166, 11/11 green | 5 oracles pass, including the polarity test that dies only under `&=`→`\|=` |

Each was mutation-checked in both directions when it landed; this re-runs them against
`main` rather than trusting the merge.

## Deliberately NOT promoted

- **FEAT-089** — *filed, not built.* Its own AC#1 demands a test that is **still red by
  design** (a correct div-by-zero fix must stop raising the obligation; it doesn't yet).
- **FEAT-064** — AC3 was closed by measurement in #164, but **AC1 remains falsified**
  (FEAT-077 repairs it only for uniquely-named functions). Closing one AC doesn't clear
  the artifact, and **REQ-020 stays blocked** behind it.
- **FEAT-057 / FEAT-065 / REQ-021** — unbuilt.

## Result

```
v3.4.0: 8 artifacts — accepted 4, proposed 4   (was accepted 1, proposed 7)
remaining: FEAT-057, FEAT-065, FEAT-089, REQ-021
```

Still **not cuttable**, and the four that remain are genuine work rather than
bookkeeping — which is the point of doing this separately from shipping features.

`rivet=0 claim-check=0 fmt=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc