### PR TITLE
Sync required-checks.txt to the ruleset: 10 → 12 (scry#130)

### DIFF
--- a/.github/required-checks.txt
+++ b/.github/required-checks.txt
@@ -7,16 +7,19 @@
 # tools/check-required-checks.py                 (admin creds: compares this
 #   file to the LIVE ruleset, catches a reset or an out-of-band edit)
 #
-# Generated from ruleset 16891064 on 2026-08-27. Path-filtered jobs must
+# Generated from ruleset 16891064 on 2026-08-27; extended to 12 when Path-filtered jobs must
 # NEVER appear here: 'Rivet artifact delta' lives in rivet-delta.yml and does
 # not run on a code-only PR, so requiring it deadlocks such PRs forever.
+# FEAT-091/FEAT-093 landed (#167) and their jobs became requirable.
 AADL model (spar parse)
 Bazel build (//:scry)
-cargo-deny (licenses, advisories, bans)
 Clippy
+Commit traceability (rivet)
 Doc claims (claim-check)
 Format
 MC/DC (witness)
+Required checks track CI jobs (scry#130)
 Rivet artifact validation
 Test
 WIT round-trip (wasm-tools)
+cargo-deny (licenses, advisories, bans)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,17 @@ name: CI
 # forever. Any job added here is required only once its name exists on
 # every PR — add it to the ruleset AFTER it has merged to main, never
 # before, or every open PR deadlocks.
+#
+# AND THAT IS NOT SUFFICIENT, learned by doing it: a PR opened BEFORE
+# the job existed still does not have it, so it can never report and is
+# blocked forever. When #167 added two jobs and they were required, PRs
+# #168 and #169 each showed 11 checks with 0 of the 2 new ones -- both
+# would have deadlocked. The complete procedure is:
+#   1. merge the PR that adds the job
+#   2. add the context to the ruleset AND to required-checks.txt,
+#      ruleset FIRST (CI gates on the file, so a file ahead of the
+#      ruleset means CI is gating on a fiction)
+#   3. REBASE EVERY OPEN PR, or it can never satisfy the new check
 
 on:
   push:


### PR DESCRIPTION
#167 landed FEAT-091 and FEAT-093, so `Commit traceability (rivet)` and `Required checks
track CI jobs (scry#130)` now exist on main and run on every PR. The drift gate
immediately moved them **PENDING → FAIL** — which is precisely the transition it was
built to make: a requirable job that isn't required is #130 recurring one job at a time.

Both were added to ruleset `16891064` (**10 → 12** contexts); this syncs the checked-in
file so the two agree.

**Order matters.** The ruleset was updated *first* and the file *second*, because CI
gates on the file — a file listing checks the ruleset doesn't require would mean CI
gating on a fiction, which is what the live-mode cross-check says in those words. Being
briefly red on main is the honest state during that window, rather than making CI green
against a claim that wasn't yet true.

Verified: file mode **PASS**, live mode **PASS** with `file agrees: True`.

## A refinement this exposed

`ci.yml` records the rule *"require a job only after its name exists on every PR, i.e.
after it merges to main."* That turns out to be necessary but **not sufficient**: PRs
opened *before* the check was added still don't have the job, so they can never report
it. #168 and #169 both showed 11 checks with 0 of the 2 new ones — they would have
deadlocked. Both have been rebased.

The complete rule is: **add the required check, then rebase every open PR.** I'll fold
that into the `ci.yml` note.

`rivet=0 claim-check=0 drift-self-test=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc