### PR TITLE
Promote FEAT-087 / FEAT-088 / FEAT-090 to accepted — v3.4.0 not-ready 7 → 4

### DIFF
--- a/artifacts/roadmap-v3.4-delta-identity.yaml
+++ b/artifacts/roadmap-v3.4-delta-identity.yaml
@@ -4,7 +4,7 @@ artifacts:
   - id: FEAT-090
     type: feature
     title: "v3.4 — The delta view carries the second identity bit: a vanish on the body-shape-hash tier is told apart from evidence (FEAT-087 residual)"
-    status: proposed
+    status: accepted
     release: v3.4.0
     description: >
       FEAT-087 added `Advisory::ident_survives_own_edit` and stated its own

--- a/artifacts/roadmap-v3.4-identity.yaml
+++ b/artifacts/roadmap-v3.4-identity.yaml
@@ -4,7 +4,7 @@ artifacts:
   - id: FEAT-087
     type: feature
     title: "v3.4 — Identity that survives an edit to its OWN body is a second, independent bit (scry#122 item 2)"
-    status: proposed
+    status: accepted
     release: v3.4.0
     description: >
       FEAT-077 made function identity honest about ONE question — "are these

--- a/artifacts/roadmap-v3.4-safety-gate.yaml
+++ b/artifacts/roadmap-v3.4-safety-gate.yaml
@@ -3,7 +3,7 @@ artifacts:
   - id: FEAT-088
     type: feature
     title: "v3.4 — A forgotten safety goal cannot hide behind the `undeveloped` diamond"
-    status: proposed
+    status: accepted
     release: v3.4.0
     description: >
       `rivet coverage` reports `goal-has-support` and `goal-has-context` at 40%


### PR DESCRIPTION
Reopens **#169**, auto-closed when I deleted its base branch during the #170 merge.
Branch unchanged apart from a rebase onto main; #169 has the discussion.

`proposed` counts as **not-yet-verified** in the release gate, so a shipped, green
feature left there blocks its release. Promoting these three is the honest counterpart
to *not* promoting the others.

| feature | shipped | re-verified on main |
|---|---|---|
| **FEAT-087** | #162, 11/11 | 3 oracles pass |
| **FEAT-088** | #163, 11/11 | self-test **and** real check pass; wired in `ci.yml` |
| **FEAT-090** | #166, 11/11 | 5 oracles, incl. the polarity test that dies only under `&=`→`\|=` |

**Deliberately NOT promoted:** FEAT-089 (filed, not built — its AC#1 demands a test
still red by design), FEAT-064 (AC3 closed in #164 but **AC1 remains falsified**, so
REQ-020 stays blocked), FEAT-057 / FEAT-065 / REQ-021 (unbuilt).

Result: `v3.4.0 — accepted 4, proposed 4` (was 1/7). Still not cuttable, and the four
that remain are genuine work rather than bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc