### PR TITLE
release: v3.2.7 — bump workspace + inter-crate pins, CHANGELOG, README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.2.7] — 2026-08-27
+
+Two fixes. Both were found by looking at what the project actually did rather
+than at what it claimed, and one was found by running the artifact shipped
+minutes earlier.
+
+### Fixed — the shipped artifact now tells the truth about itself
+
+- **The shipped component announced `scry 0.0.0`** (#152, FEAT-083). Found by
+  running the SHIPPED v3.2.6 artifact minutes after cutting it — not 3.2.6, and
+  not the 3.2.4 that #133 had been about.
+
+  The mechanism is worth recording because the previous fix caused it. FEAT-076
+  replaced a hand-maintained literal with `env!("CARGO_PKG_VERSION")`, which is
+  correct under cargo. The shipped component is built by **Bazel**, and
+  `rules_rust` populates `CARGO_PKG_VERSION` from the target's `version`
+  attribute — which was absent, so it defaulted to `0.0.0`. A fix that is right
+  for one build system and silently wrong for the one that ships.
+
+  Fixed in three layers, because the source-level assertion had become
+  tautological (`SCRY_VERSION == env!("CARGO_PKG_VERSION")` where the constant
+  IS that env): the Bazel target now carries `version`, `claims.yaml` pins the
+  literal, and CI byte-checks the **built artifact** with `grep -qaF` — the `-a`
+  matters, since without it the check passed on both the fixed and the broken
+  wasm.
+
+### Fixed — CI
+
+- **Clippy ran on 4 of 12 crates** (#157, FEAT-086), the same defect as #141's
+  Test job one gate over. Two live clippy errors existed on main that the job
+  could not see. Both gates are now widened, and the coverage guard checks
+  **both** rather than one.
+
+  The guard's first version scraped the workflow with `awk` ranges that chained
+  across the whole file, so its two lists came out identical — it could not
+  detect the drift it existed for, and printed `FIRES` under mutation with the
+  wrong attribution. Replaced with a YAML-parsing checker shipping a
+  `--self-test` that CI runs BEFORE the real check.
+
+  Recorded plainly: **the implementation merged as PR #159 titled
+  "FEAT-086 (#157)" while no such artifact existed.** It was filed after the
+  fact (#160). `rivet validate` cannot catch that — it validates artifacts that
+  exist, not references to ones that do not. That gap is what #161's commit
+  traceability now closes.
+
+
 ## [3.2.6] — 2026-08-26
 
 Five fixes, three of which were things quietly WRONG rather than missing. All

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "3.2.6"
+version = "3.2.7"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1785,18 +1785,18 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "3.2.6"
+version = "3.2.7"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-bits"
-version = "3.2.6"
+version = "3.2.7"
 
 [[package]]
 name = "scry-sai-core"
-version = "3.2.6"
+version = "3.2.7"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-float",
@@ -1814,19 +1814,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-float"
-version = "3.2.6"
+version = "3.2.7"
 
 [[package]]
 name = "scry-sai-handle"
-version = "3.2.6"
+version = "3.2.7"
 
 [[package]]
 name = "scry-sai-interval"
-version = "3.2.6"
+version = "3.2.7"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "3.2.6"
+version = "3.2.7"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1835,34 +1835,34 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "3.2.6"
+version = "3.2.7"
 
 [[package]]
 name = "scry-sai-pentagon"
-version = "3.2.6"
+version = "3.2.7"
 
 [[package]]
 name = "scry-sai-poly"
-version = "3.2.6"
+version = "3.2.7"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "3.2.6"
+version = "3.2.7"
 
 [[package]]
 name = "scry-sai-segment"
-version = "3.2.6"
+version = "3.2.7"
 dependencies = [
  "scry-sai-interval",
 ]
 
 [[package]]
 name = "scry-sai-taint"
-version = "3.2.6"
+version = "3.2.7"
 
 [[package]]
 name = "scry-sai-viz"
-version = "3.2.6"
+version = "3.2.7"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "3.2.6"
+version = "3.2.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ deductive-proof and bounded-model-checking layers do not staff.
 <!-- claim id=version: "scry-sai-core" crates.io max_version == workspace version -->
 <!-- claim id=crates: publish.rs lists 12 scry-sai-* crates -->
 <!-- claim id=admit-free: 0 Admitted/admit/Axiom across proofs/rocq/*.v -->
-**v3.2.6 shipped** — the full v0.1 → v3.2 arc is done; scry is a working **sound
+**v3.2.7 shipped** — the full v0.1 → v3.2 arc is done; scry is a working **sound
 abstract interpreter**, not a scaffold. Shipped and on crates.io: **12 pure
 `scry-sai-*` crates** (10 abstract domains — interval, region-memory, call-graph
 + reachability, octagon, pentagon, known-bits/congruence, IEEE-754 float,

--- a/claims.yaml
+++ b/claims.yaml
@@ -21,10 +21,10 @@ claims:
   # Cargo.toml + this pattern together — exactly the point.)
   - id: STATUS-VERSION
     doc: README.md
-    text: "**v3.2.6 shipped**"
+    text: "**v3.2.7 shipped**"
     evidence:
       - kind: count-min
-        pattern: 'version = "3\.2\.6"'
+        pattern: 'version = "3\.2\.7"'
         glob: ['Cargo.toml']
         min: 1
 
@@ -32,14 +32,14 @@ claims:
   # rules_rust populates CARGO_PKG_VERSION from the target's `version` attr and
   # defaults it to "0.0.0". Bazel builds the SHIPPED component, so a missing or
   # stale pin means the artifact announces the wrong version — which is exactly
-  # what v3.2.6 did. The literal cannot be derived (Bazel cannot read
+  # what v3.2.7 did. The literal cannot be derived (Bazel cannot read
   # Cargo.toml), so it is pinned to the workspace version here instead.
   - id: BAZEL-VERSION-PIN
     doc: crates/scry-analyze-core/BUILD.bazel
-    text: 'version = "3.2.6",'
+    text: 'version = "3.2.7",'
     evidence:
       - kind: count-min
-        pattern: 'version = "3\.2\.6"'
+        pattern: 'version = "3\.2\.7"'
         glob: ['Cargo.toml']
         min: 1
       # And the default must never come back.

--- a/crates/scry-analyze-core/BUILD.bazel
+++ b/crates/scry-analyze-core/BUILD.bazel
@@ -28,7 +28,7 @@ rust_library(
     # literal to the workspace version, and claim-check goes red if they part.
     # A number that must be maintained by hand is acceptable only when
     # something mechanical notices when it is not.
-    version = "3.2.6",
+    version = "3.2.7",
     visibility = ["//visibility:public"],
     tags = ["feat-014"],
     deps = [

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "3.2.6" }
+scry-sai-interval = { path = "../scry-interval", version = "3.2.7" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,44 +43,44 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "3.2.6" }
-scry-sai-provenance = { path = "../scry-provenance", version = "3.2.6" }
+scry-sai-taint = { path = "../scry-taint", version = "3.2.7" }
+scry-sai-provenance = { path = "../scry-provenance", version = "3.2.7" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "3.2.6" }
+scry-sai-octagon = { path = "../scry-octagon", version = "3.2.7" }
 
 # Known-bits × interval-guarded congruence reduced product (FEAT-037 / DD-017):
 # an additive bit/alignment/stride companion computed in a straight-line-sound
 # pass, surfaced library-only on `AnalysisResult.bit_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-bits = { path = "../scry-bits", version = "3.2.6" }
+scry-sai-bits = { path = "../scry-bits", version = "3.2.7" }
 
 # Pentagons weakly-relational domain (FEAT-044 / AC-014): intervals + strict
 # `x < y` facts, the cheap relational layer behind sound out-of-bounds-trap
 # detection (FEAT-046). An additive guard-recording pass surfaces proven
 # strict relations library-only on `AnalysisResult.pentagon_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-pentagon = { path = "../scry-pentagon", version = "3.2.6" }
+scry-sai-pentagon = { path = "../scry-pentagon", version = "3.2.7" }
 
 # IEEE-754 float-interval domain (FEAT-047 / AC-022): sound f32/f64 abstraction
 # with NaN/±inf tracking + round-to-nearest-aware widening. An additive
 # straight-line pass surfaces sound float intervals library-only on
 # `AnalysisResult.float_facts`. Same pure `#![no_std]` dual-compile crate.
-scry-sai-float = { path = "../scry-float", version = "3.2.6" }
+scry-sai-float = { path = "../scry-float", version = "3.2.7" }
 
 # Affine Component-Model handle-state lattice (FEAT-049 / MF-007): tracks
 # own/borrow resource-handle state to flag use-after-drop / double-drop. A
 # straight-line pass over the canonical-ABI `[resource-drop]` call sites
 # surfaces findings library-only on `AnalysisResult.handle_findings`.
-scry-sai-handle = { path = "../scry-handle", version = "3.2.6" }
+scry-sai-handle = { path = "../scry-handle", version = "3.2.7" }
 
 # FEAT-058: the linear-memory segmentation domain (content-sensitive memory).
 # The interpreter tracks per-offset interval content for i32 loads/stores
 # instead of degrading every load to ⊤.
-scry-sai-segment = { path = "../scry-segment", version = "3.2.6" }
+scry-sai-segment = { path = "../scry-segment", version = "3.2.7" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-segment/Cargo.toml
+++ b/crates/scry-segment/Cargo.toml
@@ -20,4 +20,4 @@ path = "src/lib.rs"
 # The per-segment content domain. Path dep carries `version` so `cargo publish`
 # rewrites it to the crates.io coordinate; the version equals the workspace
 # version and is bumped in lockstep.
-scry-sai-interval = { path = "../scry-interval", version = "3.2.6" }
+scry-sai-interval = { path = "../scry-interval", version = "3.2.7" }

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "3.2.6" }
+scry-sai-core = { path = "../scry-analyze-core", version = "3.2.7" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }


### PR DESCRIPTION
Cuts **v3.2.7**. Two artifacts, both `accepted` and CI-verified:

- **FEAT-083** (#152) — the shipped component reports its real version
- **FEAT-086** (#157) — clippy covers every crate, and the guard covers *both* gates

## Version surfaces bumped 3.2.6 → 3.2.7

workspace `Cargo.toml` · README status line · two `claims.yaml` `text` pins **and** two
`pattern` regexes · the Bazel target's `version` attribute · 11 inter-crate path pins
across three crates · `Cargo.lock`

## The claim gate caught this bump half-done

I updated the `text:` fields and not the `pattern:` regexes. `claim-check` failed with
both `STATUS-VERSION` and `BAZEL-VERSION-PIN` reporting *"the doc asserts it but the
source no longer shows it."*

That is the gate working exactly as intended **on the release it exists because of** —
FEAT-083 is in this release precisely because v3.2.6 shipped announcing `scry 0.0.0`.

Re-verified after the fix: **7/7 claims hold**, and mutating both patterns to `9.9.9`
turns it red — so the green isn't vacuous.

## Local gates

`tests=0 clippy=0 fmt=0 rivet=0 claim-check=0 gate-coverage=0 drift-gate=0 undeveloped-goals=0`

## After merge

The tag goes on main **only once main's own CI is green** — a tag triggers the crates.io
publish workflow, and that is the irreversible step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc