### PR TITLE
Promote FEAT-065; record what it does NOT discharge (REQ-005, REQ-021)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -105,6 +105,29 @@ artifacts:
       The attestation shall be linkable from rivet artifacts so that a
       requirement of the form "memory access X is in-bounds" can be
       `verified-by` a specific AI run.
+
+      MEASURED 2026-08-27 - NOT DISCHARGED, and the near-miss is why this is
+      written down. Three things in the repo look like they satisfy this and do
+      not:
+        * the v3.2.7 release carries 36 signature/certificate assets, but those
+          cosign-sign RELEASE ARTIFACTS (wasm, SBOMs, evidence bundles), not AI
+          RUNS. This requirement asks that EVERY AI RUN produce an attestation.
+        * FEAT-091 (scry#161) links COMMITS to artifacts. This asks that an
+          ATTESTATION be linkable so a claim like "memory access X is in-bounds"
+          is verified-by a specific AI run. Different objects, opposite
+          direction.
+        * release.yml requests the `attestations: write` PERMISSION. Grepping
+          crates/, wit/ and .github/ for dsse|in-toto|attestation returns that
+          permission line and NOTHING else: no predicate, no module-hash record,
+          no domain-set or analyzer-version field, no proven-invariant set, no
+          fallback list. None of the six fields enumerated above is emitted.
+      Linking any of them as `verifies` would MANUFACTURE traceability - the
+      same refusal J-004 records for the undeveloped safety goals.
+
+      CONTEXT: REQ-005 is one of SIX requirements with no incoming `verifies`
+      link (REQ-003/004/005/007/020/021), matching rivet's
+      requirement-verification 15/21. ALL SIX are `priority: must`. The
+      uncovered 29% is not a random tail - it is entirely the must-priority set.
     tags: [attestation, sigil, rivet]
     fields:
       priority: must

--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -275,7 +275,7 @@ artifacts:
 
       scry shall compare a fresh analysis against a prior one and classify every
       obligation by its stable identity (REQ-020 / FEAT-064): discharged /
-      still-open / regressed / moved / removed-with-code / uncertain. That turns
+      still-open-untouched / still-open-after-edit / regressed / moved / removed-with-code / uncertain. CORRECTED 2026-08-27: `still-open` was SPLIT by FEAT-065 AC2 because it conflated `the agent did not fix it` with `scry cannot see the fix`; an adjudicator conflating those sends an agent to re-fix working code in a loop, the exact failure this requirement exists to prevent. That turns
       the v3.1 PROSE oracle ("re-run scry; this trap_check becomes ProvenSafe")
       into a machine verdict, so an agent's edit is judged by a SOUND
       over-approximation rather than by whether the tests still pass.
@@ -1054,7 +1054,7 @@ artifacts:
   - id: FEAT-065
     type: feature
     title: "v3.4 — `scry verify --against`: scry adjudicates its own oracle"
-    status: proposed
+    status: accepted
     release: v3.4.0
     description: >
       Turn the v3.1 prose verification oracle into a machine verdict. `scry verify


### PR DESCRIPTION
## FEAT-065 → accepted

Merged in #179 with 13/13 CI green; its 14 oracles re-run on `main` just now.
**v3.4.0 not-ready 4 → 3.**

## REQ-021's verdict list was stale

It still named the six-term set, but FEAT-065's AC2 **split `still-open` in two** —
because it conflated *"the agent didn't fix it"* with *"scry can't see the fix"*. An
adjudicator conflating those sends an agent to re-fix working code in a loop, the exact
failure REQ-021 exists to prevent. Corrected to the seven-term set.

## REQ-005 is NOT discharged — and three things look like it is

This is the finding most likely to become a false claim later, so it's recorded on the
requirement itself:

| looks like evidence | what it actually is |
|---|---|
| 36 signature/cert assets on v3.2.7 | cosign-signs **release artifacts** (wasm, SBOMs, evidence bundles) — not **AI runs** |
| FEAT-091 commit traceability | links **commits** → artifacts. REQ-005 asks an **attestation** be linkable to a claim. Different objects, opposite direction |
| `attestations: write` in `release.yml` | a **permission**. Grepping `crates/`, `wit/`, `.github/` for `dsse\|in-toto\|attestation` returns that line and *nothing else* |

None of the six fields REQ-005 enumerates — module hash, domain set, analyzer version,
lattice version, proven invariants, fallback list — is emitted anywhere. Linking any of
the above as `verifies` would **manufacture traceability**, the same refusal J-004
records for the undeveloped safety goals.

## The measured gap

**Six requirements have no incoming `verifies` link** — REQ-003/004/005/007/020/021 —
matching rivet's `requirement-verification 15/21`.

**All six are `priority: must`.** The uncovered 29% isn't a random tail; it's *entirely*
the must-priority set. That's a sharper statement than the coverage percentage, and it's
what a future sweep should act on.

## Method note

I first measured *"0 of 21 requirements have acceptance criteria"* and nearly reported
it as the gap. That's this repo's **Class-4 vacuous measurement** — requirements here are
verified by incoming `verifies` links, not by ACs, and rivet already scores exactly that.
Caught it before publishing and re-measured in the right vocabulary.

`rivet=0 claim-check=0 drift-gate=0 fmt=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc