### PR TITLE
REQ-021 is NOT satisfied by FEAT-065 alone — record why, before it looks it

### DIFF
--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -302,11 +302,33 @@ artifacts:
       EVIDENCE BEFORE REWORK: FEAT-073 runs the refuted adjudicator over scry's
       OWN commit history in observation mode, so which of the nine scry#122 work
       items actually fire on real code is a measurement rather than a guess.
+
+      NOT SATISFIED BY FEAT-065 ALONE, recorded 2026-08-27 because with
+      FEAT-065 now `accepted` this requirement READS satisfiable and is not.
+      The adjudication MACHINERY exists and is verified; the LOOP it promises
+      cannot converge. Measured by FEAT-065's own AC13 run over scry's history
+      (4 commit pairs, ~13,800 obligations each):
+        * `discharged` = 0 on every real pair
+        * the gate FAILS on every real pair
+        * ~47% `uncertain`, matching scry#123's measured 43-45% identity churn
+        * on a STRIPPED module `discharged` is UNREACHABLE by construction
+          (FEAT-087: `ident_survives_own_edit` false for 10,520 of 10,520), and
+          stripping is standard in release builds
+      The obstacle is PRECISION, not adjudication. FEAT-089 is the unblocker: a
+      correct div-by-zero repair guards with `br_if` on `i32.eqz`, which
+      establishes a disequality, and an interval cannot represent one (scry#165)
+      — so the fix is invisible and the agent is told the obligation still
+      stands. An agent gated on that re-fixes working code.
+      DO NOT promote this requirement on FEAT-065's acceptance. What would
+      discharge it: FEAT-089 landing, then a re-measurement showing a genuine
+      fix reaching `discharged` on a shape an agent would actually write.
     tags: [ai-agent, oracle, fix-verify-loop, gate, adversarial, v3.4]
     fields:
       priority: must
       category: functional
     links:
+      - type: depends-on
+        target: FEAT-089
       - type: traces-to
         target: REQ-020
       - type: traces-to


### PR DESCRIPTION
With FEAT-065 now `accepted`, **REQ-021 reads satisfiable and is not.** The adjudication
*machinery* exists and is verified; the *loop* it promises cannot converge. Nothing on
the requirement said so — which is exactly how a future sweep promotes it.

## Measured, by FEAT-065's own AC13 run

Four commit pairs of scry's history, ~13,800 obligations each:

| | |
|---|---|
| `discharged` | **0** on every real pair |
| gate | **FAILS** on every real pair |
| `uncertain` | ~47%, matching #123's measured 43–45% identity churn |
| stripped modules | `discharged` **unreachable by construction** — FEAT-087 measured `ident_survives_own_edit` false for 10,520 of 10,520, and stripping is standard in release builds |

## The obstacle is precision, not adjudication

A correct div-by-zero repair guards with `br_if` on `i32.eqz`, establishing a
**disequality** — and an interval cannot represent one (#165). So the fix is invisible,
the agent is told the obligation still stands, and **an agent gated on that re-fixes
working code.** That is the failure REQ-021 exists to prevent, reproduced by the thing
meant to prevent it.

## What changes

- the convergence limit is recorded **on the requirement**, not just in FEAT-065's ACs
- **FEAT-089 is now a typed `depends-on`** rather than implicit in prose — the graph says
  what blocks what
- explicit instruction not to promote REQ-021 on FEAT-065's acceptance

**What would discharge it:** FEAT-089 landing, then a re-measurement showing a genuine
fix reaching `discharged` on a shape an agent would actually write.

`rivet=0 claim-check=0 drift-gate=0 fmt=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc