### PR TITLE
Promote FEAT-089 to accepted — v3.4.0 not-ready 3 → 2

### DIFF
--- a/artifacts/roadmap-v3.4-nonzero.yaml
+++ b/artifacts/roadmap-v3.4-nonzero.yaml
@@ -3,7 +3,7 @@ artifacts:
   - id: FEAT-089
     type: feature
     title: "v3.4 — A div-by-zero fix must be VISIBLE: non-zero facts a disequality guard establishes"
-    status: proposed
+    status: accepted
     release: v3.4.0
     description: >
       Found by closing FEAT-064 AC3. The canonical repair for a div-by-zero —


### PR DESCRIPTION
Merged in #183 with 13/13 CI green; its 10 oracles re-run on `main`. All six ACs met,
including AC1's red-first measured end-to-end (`div-by-zero` 1 → 0 on the AC3 fixture)
and AC3's false-proof mutant killing **20 tests**.

## NOT promoted: REQ-021 — and now for a measured reason

FEAT-089 makes the canonical fix **visible** (`div-by-zero` clears, `proven-safe` 1 → 2)
— but `verify_against` still returns **`uncertain`**, not `discharged`.

Term (5) of FEAT-065's conjunction requires the function's operator **shape** unchanged,
and adding a guard changes it. That term isn't a mistake: without it AC10's
cardinality-preserving delete+insert is a **false discharge** — the defect that withdrew
#120.

So two correct designs, composed, don't close the loop. The tension was invisible until
both existed, which is the case for measuring a chain end-to-end rather than reasoning
about it from its parts.

Both the measurement and what would actually discharge REQ-021 — a shape comparison
finer than a hash, or a term corroborating the open→safe transition by **content** rather
than structure — are recorded on the requirement itself.

`rivet=0 claim-check=0 fmt=0 drift-gate=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc