### PR TITLE
REQ-020 is not satisfied on the common production shape — record it before it looks it

### DIFF
--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -250,6 +250,29 @@ artifacts:
       the adjudicator (REQ-021) must report it as `removed-with-code`, never as
       `discharged`. This statement is the shared honesty constraint across both
       halves and is why the split does not weaken either.
+
+      NOT SATISFIED ON THE COMMON PRODUCTION SHAPE, recorded 2026-08-27 for the
+      same reason REQ-021 carries its own limit: this requirement will READ
+      satisfiable the moment FEAT-064 is promoted, and it is not.
+      The claim is `stable identity that survives the edit`. MEASURED by
+      FEAT-087 on a STRIPPED build of scry's own binary (`wasm-tools strip -a`,
+      8.2MB -> 484KB, 853 functions / 32 exported): 766 of 766
+      obligation-carrying functions and ALL 10,520 obligations fall to the
+      `body_shape_hash` identity tier, whose id is a hash of the very bytes an
+      edit changes. Stripping is standard in release builds, so on the common
+      production shape NO obligation has an identity that survives an edit to
+      its own function.
+      WHAT IS DELIVERED, and it is real: identity is now HONEST about which
+      tier it used. FEAT-077 gives a stable id for uniquely-named functions
+      (measured 100% survival) and marks the rest `id_build_local`; FEAT-087
+      adds `ident_survives_own_edit` so a consumer can tell a citable id from
+      one that moves. A consumer reading the conjunction
+      `!id_build_local && ident_survives_own_edit` cites soundly. That is
+      HONEST DEGRADATION, not the requirement's stated property.
+      DO NOT promote REQ-020 on FEAT-064's acceptance. What would discharge it:
+      an identity for unnamed functions that does not derive from the body —
+      which needs content corroboration, not another key scheme (DD-022: the
+      keys are a good ADDRESS and a bad PROOF).
     tags: [ai-agent, fix-verify-loop, identity, oracle, precision, v3.3]
     fields:
       priority: must


### PR DESCRIPTION
Recorded **before** FEAT-064 is promoted, not after. REQ-020 will *read* satisfiable the
moment that happens — the same trap REQ-021 already carries a note against.

## The claim vs the measurement

REQ-020: *"stable identity that survives the edit."*

FEAT-087 measured, on a **stripped** build of scry's own binary (`wasm-tools strip -a`,
8.2 MB → 484 KB, 853 functions / 32 exported):

| | |
|---|---|
| obligation-carrying functions on the `body_shape_hash` tier | **766 of 766** |
| obligations whose id is a hash of the bytes an edit changes | **10,520 of 10,520** |

Stripping is standard in release builds. So on the common production shape, **no
obligation has an identity that survives an edit to its own function.**

## What IS delivered — and it's real

Identity is now **honest about which tier it used**. FEAT-077 gives a stable id for
uniquely-named functions (100% measured survival) and marks the rest `id_build_local`;
FEAT-087 adds `ident_survives_own_edit`. A consumer reading the conjunction
`!id_build_local && ident_survives_own_edit` cites soundly.

That is **honest degradation, not satisfaction.** Worth having, worth saying precisely.

## Why record it now

Landing a feature can make a requirement look satisfied **without touching it** — the
evidence lives in the feature's ACs, the claim lives on the requirement, and nothing links
the two. That asymmetry has produced four drifted claims this session, every one found by
*reading* artifacts rather than validating them.

**What would discharge REQ-020:** an identity for unnamed functions that doesn't derive
from the body — which needs **content corroboration**, not another key scheme. That's
DD-022 (*the keys are a good address and a bad proof*) arriving for the third time today,
after FEAT-065's shape term and REQ-021's blocker.

`rivet=0 claim-check=0 fmt=0 drift-gate=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc