### PR TITLE
Promote FEAT-067 to accepted — v3.3.0 not-ready 5 → 4

### DIFF
--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -1240,7 +1240,7 @@ artifacts:
   - id: FEAT-067
     type: feature
     title: "v3.3 — Query filters over AnalysisResult (FEAT-056 lite)"
-    status: proposed
+    status: accepted
     release: v3.3.0
     description: >
       A filter/selection surface so a consumer asks instead of scrapes —


### PR DESCRIPTION
Merged in #188 with 13/13 CI green; its two oracles re-run on `main`.

**AC1 is met:** filtering by class / code / function / operator / gap-kind returns only
matching records, each carrying its stable obligation id.

Mutation-checked three ways, each asserted to apply to exactly one site **and** to
compile. One mutant had to be redone after producing invalid Rust and no test output —
an *unmeasured* mutant, not a surviving one.

## Why this promotion is safe now and wasn't before

FEAT-067 `traces-to` REQ-020. Before #186 recorded REQ-020's **measured NOT-SATISFIED**
state, promoting a feature that traces to it would have left REQ-020 looking closer to
satisfied than it is — the exact asymmetry that produced four drifted claims this
session: evidence lives in the feature's ACs, the claim lives on the requirement, and
nothing links them.

Recording the limit *first*, then promoting, is the ordering that keeps both honest.

```
v3.3.0: accepted 6 / proposed 4
```

`rivet=0 claim-check=0 fmt=0 drift-gate=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc