### PR TITLE
Repair a claim that was true when written and false for months after

### DIFF
--- a/artifacts/aspice-vmodel.yaml
+++ b/artifacts/aspice-vmodel.yaml
@@ -9,9 +9,21 @@
 # tests / clean-room that discharge each requirement. Mirrors the meld/spar
 # house pattern (dev + aspice schemas side by side). SR-1..SR-13 restate dev
 # REQ-001..REQ-013 as software requirements (one for one, checked by title) and
-# derive structurally from the SYS-* system requirements; the verification
-# mapping is the authoritative one (the dev REQ-* carry no verifies link by
-# construction).
+# derive structurally from the SYS-* system requirements.
+#
+# THE DEV REQ-* DO CARRY VERIFICATION, and an earlier version of this comment
+# said they did not. When FEAT-033 landed (bea3ddf) the parenthetical "the dev
+# REQ-* carry no verifies link by construction" was TRUE -- no artifact type
+# could source a `verifies` link onto them. Commit 6be7359 then added
+# artifacts/verifications.yaml, whose `verification` artifacts link `verifies`
+# straight at the dev REQ-*, and nothing revisited this file. The statement
+# stayed checked in, false, for months.
+#
+# So, structurally and without a count that can drift the same way: dev REQ-*
+# are verified by `verification` artifacts in artifacts/verifications.yaml,
+# and the gaps are named individually in that file's DELIBERATELY UNCOVERED
+# block, each with what evidence would close it. `rivet coverage` reports the
+# current split; this comment deliberately does not restate it.
 #
 # SCOPE, STATED BY EXCLUSION AND NOT ONLY BY ENUMERATION. Three ASPICE levels
 # are DELIBERATELY NOT MODELLED here: SWE.2 (software architectural design),


### PR DESCRIPTION
## The drift

`artifacts/aspice-vmodel.yaml` said:

> the dev REQ-* carry no verifies link **by construction**

**Measured today: 15 of 21 dev requirements carry an incoming `verifies`**, every one from a `verification` artifact (`VER-001..VER-015`). The statement is false.

It was **true when written**. At `bea3ddf` (FEAT-033) no artifact type could source a `verifies` link onto a dev REQ-* — that was precisely the gap FEAT-033 existed to close. Then `6be7359` added `artifacts/verifications.yaml` — *"wire the dev V's right side — 15/21 REQs verified, 6 honestly open"* — whose artifacts link straight at the dev REQ-*. Nothing revisited this comment. It stayed checked in, false, for months.

## The replacement carries no count

Writing "15 of 21" would drift the same way, just more slowly. The comment now states the **structure** — dev REQ-* are verified by `verification` artifacts in `verifications.yaml`, whose `DELIBERATELY UNCOVERED` block names each gap with what evidence would close it — and points at `rivet coverage` for the current split rather than restating it.

## How it survived me yesterday

FEAT-097 (#196) repaired a corrupted sentence **one line above this one**. I was editing for a different defect and treated the surrounding prose as given, so I rewrote its neighbour and propagated this verbatim.

**Proximity to a thing you are fixing is not evidence that a claim is true.** A false statement adjacent to a repair is *likelier* to be re-blessed than one nobody is looking at.

## Checked for other copies first

Fixing only the copy I happened to be reading would be the same failure shape as the one being corrected:

- `carry no verifies link` — appears **exactly once** in the repo
- FEAT-033's description states it in the **past tense** ("requirements *had* no verifies backlinks") — still historically accurate, left alone
- the residuals added yesterday to FEAT-033 and FEAT-097 do not repeat it

## No gate added — and that is a decision, not an omission

The six uncovered requirements (REQ-003/004/005/007/020/021) are **already declared individually** in `verifications.yaml`, each with a "Would verify:" naming the evidence that would close it. That block sits directly above the data it describes.

Binding it mechanically would mean scraping `^#\s+(REQ-\d+)` out of a YAML comment — this repo's **dominant documented failure class** (four instances of text-matching when the question is discrimination) — deployed to guard a block whose own editor is already looking at it. Bad trade.

`rivet coverage --fail-under` was also considered and rejected: set below the current value it is #117's loose floor; set at it, any legitimate artifact addition that shifts the denominator fails.

Refs: FEAT-097

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc