### PR TITLE
FEAT-057 measured before building: the surface is real and NOT coverage-gated

### DIFF
--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -902,6 +902,51 @@ artifacts:
         - "Given a program with linear inequality invariants the octagon cannot express, When scry analyzes it, Then the polyhedra domain infers them soundly (decomposed) and surfaces them via the relational-invariant output."
         - "Given proofs/rocq/Poly.v, When built, Then the polyhedra LATTICE laws (order/join-upper-bound/meet-glb) are proven with 0 admits; the transfer functions are documented as γ-sweep-validated, NOT mechanized (honest scope)."
         - "Given the precision corpus, When polyhedra is compared to the octagon, Then it is strictly more precise on the targeted inequality cases within a bounded cost budget."
+      residual: >
+        MEASURED BEFORE BUILDING SLICE 2 (2026-09-01, scry's own scry_mcdc.wasm,
+        851 functions / 23,772 program points). Harness committed as
+        `crates/scry-analyze-core/examples/poly_surface.rs` so the number can be
+        re-derived rather than trusted; re-run it after FEAT-095 lands.
+
+        THE OPPORTUNITY IS REAL, which is the opposite of what FEAT-069's
+        pre-build measurement found for its own feature. The octagon already
+        emits `ProgramPoint.relational` filtered to constraints NOT implied by
+        the unary intervals, and those carry information at 4,749 of 23,772
+        points (19.98%) across 197 of 851 functions. The octagon is exact for
+        two-variable constraints, so polyhedra can only exceed it where THREE OR
+        MORE locals are mutually constrained: 2,512 points, 10.57% of the
+        module, in 83 functions. The Diff/Sum split is 24,321 / 4,053, so the
+        octagon's non-difference power is genuinely in use — this is not a
+        degenerate difference-bound matrix whose relations are all trivial.
+
+        IT IS NOT GATED ON FEAT-095, and checking that reversed the conclusion.
+        2,165 of the 2,512 wide points sit in functions that degrade SOMEWHERE,
+        which reads like FEAT-069's 92.5%-in-degraded-functions result and is a
+        different claim. Gaps are per-pc and write-set havoc widens only the
+        locals a region writes, so a wide point can sit nowhere near a gap.
+        Measured directly: only 13 of 2,512 wide points have a gap at or before
+        them. NO `depends-on FEAT-095` link was added, because the measurement
+        does not support one — the expectation going in was that it would.
+
+        TWO BOUNDS STATED IN THE DIRECTIONS THEY ACTUALLY RUN. (a) "3+ mutually
+        constrained locals" is OPPORTUNITY, not realized gain: polyhedra beats
+        the octagon only where the true invariant is a general linear inequality
+        the pairwise closure cannot express, so 2,512 bounds the ceiling from
+        ABOVE and shows no point would in fact improve. (b) "no gap at or before
+        it" is an UPPER bound on unaffected points, not a lower one — program
+        order is not dataflow order, and a gap inside a LOOP reaches earlier pcs
+        through the back edge. The loop-induced shortfall is UNQUANTIFIED here:
+        a first attempt to size it counted functions where the fixpoint
+        revisited a pc, and its own vacuity check reported zero duplicate
+        (func, pc) pairs — ProgramPoint is one per pc, so the proxy could only
+        ever return zero. It was removed rather than reported as "no loops".
+
+        SO SLICE 2 REMAINS THE ONLY UNBUILT WORK IN v3.3.0/v3.4.0 and is worth
+        building on its own merits, as a multi-slice arc mirroring the octagon's
+        v1.7-v1.9: a `Poly` on FuncCtx threaded in LOCKSTEP with the octagon,
+        wrap-aware transfers gated on the interval domain's no-wrap result,
+        guard refinement, and `Poly::project`. What this measurement does NOT
+        establish is the SIZE of the win, only that the surface exists.
     links:
       - type: traces-to
         target: REQ-016

--- a/crates/scry-analyze-core/examples/poly_surface.rs
+++ b/crates/scry-analyze-core/examples/poly_surface.rs
@@ -20,10 +20,18 @@ use scry_analyze_core::{AnalysisConfig, GapKind, analyze};
 use std::collections::{BTreeMap, BTreeSet};
 
 fn main() {
-    let path = std::env::args().nth(1).expect("usage: poly_surface <module.wasm>");
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: poly_surface <module.wasm>");
     let bytes = std::fs::read(&path).expect("read module");
-    let r = analyze(bytes, AnalysisConfig { emit_diagnostics: true, ..Default::default() })
-        .expect("analysis");
+    let r = analyze(
+        bytes,
+        AnalysisConfig {
+            emit_diagnostics: true,
+            ..Default::default()
+        },
+    )
+    .expect("analysis");
 
     let pts = &r.invariants.points;
     let total_pts = pts.len();
@@ -45,8 +53,10 @@ fn main() {
         };
         gap_funcs.entry(k).or_default().insert(g.func_index);
     }
-    let havoc: BTreeSet<u32> =
-        gap_funcs.get("unmodeled-control-flow").cloned().unwrap_or_default();
+    let havoc: BTreeSet<u32> = gap_funcs
+        .get("unmodeled-control-flow")
+        .cloned()
+        .unwrap_or_default();
     let scrub: BTreeSet<u32> = gap_funcs.get("unsupported-op").cloned().unwrap_or_default();
     let any_gap: BTreeSet<u32> = gap_funcs.values().flatten().copied().collect();
     let clean: BTreeSet<u32> = funcs_with_pts.difference(&any_gap).copied().collect();
@@ -58,38 +68,59 @@ fn main() {
     println!();
     println!("--- gap population, by function ---");
     for (k, s) in &gap_funcs {
-        println!("  {k:<24} {:>6} functions, {:>7} gaps", s.len(),
-                 r.gaps.iter().filter(|g| match g.kind {
-                     GapKind::UnsupportedOp => *k == "unsupported-op",
-                     GapKind::UnmodeledBranch => *k == "unmodeled-branch",
-                     GapKind::UnmodeledMemoryAddress => *k == "unmodeled-mem-addr",
-                     GapKind::UnmodeledControlFlow => *k == "unmodeled-control-flow",
-                 }).count());
+        println!(
+            "  {k:<24} {:>6} functions, {:>7} gaps",
+            s.len(),
+            r.gaps
+                .iter()
+                .filter(|g| match g.kind {
+                    GapKind::UnsupportedOp => *k == "unsupported-op",
+                    GapKind::UnmodeledBranch => *k == "unmodeled-branch",
+                    GapKind::UnmodeledMemoryAddress => *k == "unmodeled-mem-addr",
+                    GapKind::UnmodeledControlFlow => *k == "unmodeled-control-flow",
+                })
+                .count()
+        );
     }
     println!("  {:<24} {:>6} functions", "ANY gap", any_gap.len());
-    println!("  {:<24} {:>6} functions", "NO gap (fully modelled)", clean.len());
+    println!(
+        "  {:<24} {:>6} functions",
+        "NO gap (fully modelled)",
+        clean.len()
+    );
     println!();
     println!("--- THE POLYHEDRA CEILING: where a relational domain carries info ---");
-    println!("  points with >=1 relational constraint : {} / {total_pts}  ({:.2}%)",
-             rel_pts.len(), 100.0 * rel_pts.len() as f64 / total_pts.max(1) as f64);
+    println!(
+        "  points with >=1 relational constraint : {} / {total_pts}  ({:.2}%)",
+        rel_pts.len(),
+        100.0 * rel_pts.len() as f64 / total_pts.max(1) as f64
+    );
     println!("  total relational constraints          : {total_rel}");
-    println!("  functions with >=1 relational point   : {} / {}  ({:.2}%)",
-             rel_funcs.len(), funcs_with_pts.len(),
-             100.0 * rel_funcs.len() as f64 / funcs_with_pts.len().max(1) as f64);
+    println!(
+        "  functions with >=1 relational point   : {} / {}  ({:.2}%)",
+        rel_funcs.len(),
+        funcs_with_pts.len(),
+        100.0 * rel_funcs.len() as f64 / funcs_with_pts.len().max(1) as f64
+    );
     println!();
-    println!("  of those functions, ALSO control-flow havoc'd : {}",
-             rel_funcs.intersection(&havoc).count());
-    println!("  of those functions, ALSO unsupported-op scrub : {}",
-             rel_funcs.intersection(&scrub).count());
-    println!("  fully-clean functions that emit relational    : {}",
-             rel_funcs.intersection(&clean).count());
+    println!(
+        "  of those functions, ALSO control-flow havoc'd : {}",
+        rel_funcs.intersection(&havoc).count()
+    );
+    println!(
+        "  of those functions, ALSO unsupported-op scrub : {}",
+        rel_funcs.intersection(&scrub).count()
+    );
+    println!(
+        "  fully-clean functions that emit relational    : {}",
+        rel_funcs.intersection(&clean).count()
+    );
     println!();
     // How wide are the relations? Octagon is 2-variable by construction; the
     // question for polyhedra is how many DISTINCT locals participate per point.
     let mut width_hist: BTreeMap<usize, usize> = BTreeMap::new();
     for p in &rel_pts {
-        let vars: BTreeSet<u32> =
-            p.relational.iter().flat_map(|c| [c.a, c.b]).collect();
+        let vars: BTreeSet<u32> = p.relational.iter().flat_map(|c| [c.a, c.b]).collect();
         *width_hist.entry(vars.len()).or_default() += 1;
     }
     println!("--- distinct locals participating in relations, per point ---");
@@ -107,16 +138,25 @@ fn main() {
         let vars: BTreeSet<u32> = p.relational.iter().flat_map(|c| [c.a, c.b]).collect();
         if vars.len() >= 3 {
             wide_funcs.insert(p.func_index);
-            if clean.contains(&p.func_index) { wide_clean += 1 } else { wide_degraded += 1 }
+            if clean.contains(&p.func_index) {
+                wide_clean += 1
+            } else {
+                wide_degraded += 1
+            }
         }
     }
     println!("--- SHARPENED: points where polyhedra COULD exceed the octagon ---");
-    println!("  points with >=3 mutually-constrained locals : {}  ({:.2}% of all points)",
-             wide_clean + wide_degraded,
-             100.0 * (wide_clean + wide_degraded) as f64 / total_pts.max(1) as f64);
+    println!(
+        "  points with >=3 mutually-constrained locals : {}  ({:.2}% of all points)",
+        wide_clean + wide_degraded,
+        100.0 * (wide_clean + wide_degraded) as f64 / total_pts.max(1) as f64
+    );
     println!("    in a FULLY-CLEAN function                : {wide_clean}");
     println!("    in an already-DEGRADED function          : {wide_degraded}");
-    println!("  distinct functions involved                : {}", wide_funcs.len());
+    println!(
+        "  distinct functions involved                : {}",
+        wide_funcs.len()
+    );
     println!();
 
     // Constraint form split. Diff-only would mean the octagon is operating as a
@@ -138,12 +178,17 @@ fn main() {
     // point, i.e. whether this point's state could have been touched by one.
     let mut first_gap: BTreeMap<u32, u32> = BTreeMap::new();
     for g in &r.gaps {
-        first_gap.entry(g.func_index).and_modify(|e| *e = (*e).min(g.pc)).or_insert(g.pc);
+        first_gap
+            .entry(g.func_index)
+            .and_modify(|e| *e = (*e).min(g.pc))
+            .or_insert(g.pc);
     }
     let (mut upstream_clean, mut downstream_of_gap) = (0usize, 0usize);
     for p in &rel_pts {
         let vars: BTreeSet<u32> = p.relational.iter().flat_map(|c| [c.a, c.b]).collect();
-        if vars.len() < 3 { continue }
+        if vars.len() < 3 {
+            continue;
+        }
         match first_gap.get(&p.func_index) {
             Some(&gpc) if gpc <= p.pc => downstream_of_gap += 1,
             _ => upstream_clean += 1,

--- a/crates/scry-analyze-core/examples/poly_surface.rs
+++ b/crates/scry-analyze-core/examples/poly_surface.rs
@@ -1,0 +1,188 @@
+//! FEAT-057 slice-2 sizing: how much surface would a polyhedra domain actually
+//! have on a real module?
+//!
+//! WHY THIS IS COMMITTED, and it is a narrow reason. The numbers it prints are
+//! cited on FEAT-057 to justify a scheduling decision. A bare number in an
+//! artifact is exactly the drift hazard that left "the dev REQ-* carry no
+//! verifies link by construction" checked in and false for months. RE-RUN THIS
+//! after FEAT-095 (region-havoc coverage) lands, and after any change to the
+//! octagon or the fixpoint, and check whether the answer moved.
+//!
+//!   cargo run --release -p scry-sai-core --example poly_surface -- <module.wasm>
+//!
+//! FEAT-069 taught the lesson — measure the ceiling before building. The
+//! octagon already emits `ProgramPoint.relational`, filtered to constraints
+//! NOT implied by the unary intervals. Those points are where a relational
+//! domain is carrying real information, and they bound what polyhedra can
+//! improve: a point where the octagon is degraded to top is degraded for
+//! polyhedra too, because both ride the same fixpoint and the same havoc.
+use scry_analyze_core::{AnalysisConfig, GapKind, analyze};
+use std::collections::{BTreeMap, BTreeSet};
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: poly_surface <module.wasm>");
+    let bytes = std::fs::read(&path).expect("read module");
+    let r = analyze(bytes, AnalysisConfig { emit_diagnostics: true, ..Default::default() })
+        .expect("analysis");
+
+    let pts = &r.invariants.points;
+    let total_pts = pts.len();
+    let funcs_with_pts: BTreeSet<u32> = pts.iter().map(|p| p.func_index).collect();
+
+    // Points carrying >=1 genuinely-relational octagon constraint.
+    let rel_pts: Vec<_> = pts.iter().filter(|p| !p.relational.is_empty()).collect();
+    let rel_funcs: BTreeSet<u32> = rel_pts.iter().map(|p| p.func_index).collect();
+    let total_rel: usize = pts.iter().map(|p| p.relational.len()).sum();
+
+    // Functions degraded by region havoc / full scrub.
+    let mut gap_funcs: BTreeMap<&'static str, BTreeSet<u32>> = BTreeMap::new();
+    for g in &r.gaps {
+        let k = match g.kind {
+            GapKind::UnsupportedOp => "unsupported-op",
+            GapKind::UnmodeledBranch => "unmodeled-branch",
+            GapKind::UnmodeledMemoryAddress => "unmodeled-mem-addr",
+            GapKind::UnmodeledControlFlow => "unmodeled-control-flow",
+        };
+        gap_funcs.entry(k).or_default().insert(g.func_index);
+    }
+    let havoc: BTreeSet<u32> =
+        gap_funcs.get("unmodeled-control-flow").cloned().unwrap_or_default();
+    let scrub: BTreeSet<u32> = gap_funcs.get("unsupported-op").cloned().unwrap_or_default();
+    let any_gap: BTreeSet<u32> = gap_funcs.values().flatten().copied().collect();
+    let clean: BTreeSet<u32> = funcs_with_pts.difference(&any_gap).copied().collect();
+
+    println!("module            : {path}");
+    println!("functions (meta)  : {}", r.function_meta.len());
+    println!("functions w/ pts  : {}", funcs_with_pts.len());
+    println!("program points    : {total_pts}");
+    println!();
+    println!("--- gap population, by function ---");
+    for (k, s) in &gap_funcs {
+        println!("  {k:<24} {:>6} functions, {:>7} gaps", s.len(),
+                 r.gaps.iter().filter(|g| match g.kind {
+                     GapKind::UnsupportedOp => *k == "unsupported-op",
+                     GapKind::UnmodeledBranch => *k == "unmodeled-branch",
+                     GapKind::UnmodeledMemoryAddress => *k == "unmodeled-mem-addr",
+                     GapKind::UnmodeledControlFlow => *k == "unmodeled-control-flow",
+                 }).count());
+    }
+    println!("  {:<24} {:>6} functions", "ANY gap", any_gap.len());
+    println!("  {:<24} {:>6} functions", "NO gap (fully modelled)", clean.len());
+    println!();
+    println!("--- THE POLYHEDRA CEILING: where a relational domain carries info ---");
+    println!("  points with >=1 relational constraint : {} / {total_pts}  ({:.2}%)",
+             rel_pts.len(), 100.0 * rel_pts.len() as f64 / total_pts.max(1) as f64);
+    println!("  total relational constraints          : {total_rel}");
+    println!("  functions with >=1 relational point   : {} / {}  ({:.2}%)",
+             rel_funcs.len(), funcs_with_pts.len(),
+             100.0 * rel_funcs.len() as f64 / funcs_with_pts.len().max(1) as f64);
+    println!();
+    println!("  of those functions, ALSO control-flow havoc'd : {}",
+             rel_funcs.intersection(&havoc).count());
+    println!("  of those functions, ALSO unsupported-op scrub : {}",
+             rel_funcs.intersection(&scrub).count());
+    println!("  fully-clean functions that emit relational    : {}",
+             rel_funcs.intersection(&clean).count());
+    println!();
+    // How wide are the relations? Octagon is 2-variable by construction; the
+    // question for polyhedra is how many DISTINCT locals participate per point.
+    let mut width_hist: BTreeMap<usize, usize> = BTreeMap::new();
+    for p in &rel_pts {
+        let vars: BTreeSet<u32> =
+            p.relational.iter().flat_map(|c| [c.a, c.b]).collect();
+        *width_hist.entry(vars.len()).or_default() += 1;
+    }
+    println!("--- distinct locals participating in relations, per point ---");
+    for (w, n) in &width_hist {
+        println!("  {w:>3} locals : {n:>6} points");
+    }
+    println!();
+    // SHARPENED: the octagon is exact for 2-variable constraints, so a point
+    // can only benefit from polyhedra if >=3 locals are mutually constrained.
+    // Of THOSE points, how many sit in a function that is not already degraded?
+    let mut wide_clean = 0usize;
+    let mut wide_degraded = 0usize;
+    let mut wide_funcs: BTreeSet<u32> = BTreeSet::new();
+    for p in &rel_pts {
+        let vars: BTreeSet<u32> = p.relational.iter().flat_map(|c| [c.a, c.b]).collect();
+        if vars.len() >= 3 {
+            wide_funcs.insert(p.func_index);
+            if clean.contains(&p.func_index) { wide_clean += 1 } else { wide_degraded += 1 }
+        }
+    }
+    println!("--- SHARPENED: points where polyhedra COULD exceed the octagon ---");
+    println!("  points with >=3 mutually-constrained locals : {}  ({:.2}% of all points)",
+             wide_clean + wide_degraded,
+             100.0 * (wide_clean + wide_degraded) as f64 / total_pts.max(1) as f64);
+    println!("    in a FULLY-CLEAN function                : {wide_clean}");
+    println!("    in an already-DEGRADED function          : {wide_degraded}");
+    println!("  distinct functions involved                : {}", wide_funcs.len());
+    println!();
+
+    // Constraint form split. Diff-only would mean the octagon is operating as a
+    // difference-bound matrix and its Sum power is unused.
+    let mut diff = 0usize;
+    let mut sum = 0usize;
+    for p in pts {
+        for c in &p.relational {
+            match c.kind {
+                scry_analyze_core::RelKind::Diff => diff += 1,
+                scry_analyze_core::RelKind::Sum => sum += 1,
+            }
+        }
+    }
+    // "In a degraded function" is NOT "degraded at this point": gaps are
+    // per-pc and write-set havoc widens only the locals a region writes, so a
+    // wide point can sit nowhere near a gap. Measure the sharper thing --
+    // whether ANY gap in the same function occurs at a pc at or before this
+    // point, i.e. whether this point's state could have been touched by one.
+    let mut first_gap: BTreeMap<u32, u32> = BTreeMap::new();
+    for g in &r.gaps {
+        first_gap.entry(g.func_index).and_modify(|e| *e = (*e).min(g.pc)).or_insert(g.pc);
+    }
+    let (mut upstream_clean, mut downstream_of_gap) = (0usize, 0usize);
+    for p in &rel_pts {
+        let vars: BTreeSet<u32> = p.relational.iter().flat_map(|c| [c.a, c.b]).collect();
+        if vars.len() < 3 { continue }
+        match first_gap.get(&p.func_index) {
+            Some(&gpc) if gpc <= p.pc => downstream_of_gap += 1,
+            _ => upstream_clean += 1,
+        }
+    }
+    println!("--- SHARPER: is the wide point actually downstream of a gap? ---");
+    println!("  wide points with NO gap at or before them : {upstream_clean}");
+    println!("  wide points downstream of a gap in-func   : {downstream_of_gap}");
+    println!("  CAUTION -- these are bounds in the directions you might not expect.");
+    println!("  `no gap at or before` is an UPPER bound on unaffected points, NOT a");
+    println!("  lower bound: program order is not dataflow order. A gap at pc 500");
+    println!("  inside a LOOP does reach a point at pc 100, because the fixpoint");
+    println!("  joins the back edge. So the true reachable set is <= the first");
+    println!("  number and >= (total - second). Straight-line code is exact.");
+    println!();
+    // THE LOOP CAVEAT IS REAL AND UNQUANTIFIED HERE, deliberately.
+    //
+    // A first attempt sized it by counting functions where the fixpoint
+    // revisited a pc -- and the vacuity check built into it reported
+    // `(func,pc) pairs seen more than once: 0`. ProgramPoint is one per pc
+    // (the FINAL fixpoint state), so the proxy could only ever return zero.
+    // Printing "0 functions with loops" would have been a measurement that
+    // discriminates nothing, reported as a fact -- this repo's dominant
+    // documented failure class. It was removed rather than reported.
+    //
+    // Sizing it properly needs the operator stream (back edges), which this
+    // harness does not have. So: `no gap at or before` is an UPPER bound, the
+    // loop-induced shortfall is UNKNOWN, and 13 is the only number here that
+    // is provably lost.
+
+    println!("--- constraint form ---");
+    println!("  Diff (x_a - x_b <= c) : {diff}");
+    println!("  Sum  (x_a + x_b <= c) : {sum}");
+    println!();
+    println!("CAVEAT, stated because the number invites overreach: >=3 mutually");
+    println!("constrained locals is OPPORTUNITY, not realized gain. Polyhedra beats");
+    println!("the octagon only where the true invariant is a general linear");
+    println!("inequality the pairwise closure cannot express. This bounds the");
+    println!("ceiling from ABOVE; it does not show any point would actually improve.");
+    println!("(A point where the octagon is TOP is TOP for polyhedra too: both ride");
+    println!(" the same fixpoint and the same region havoc.)");
+}


### PR DESCRIPTION
FEAT-057 slice 2 (wire polyhedra into the fixpoint) is **the only unbuilt work left in v3.3.0/v3.4.0**. FEAT-069 taught the rule — measure the ceiling before building — so this measures it, on scry's own `scry_mcdc.wasm`: 851 functions, 23,772 program points.

## The opportunity is real — the opposite of what FEAT-069 found

The octagon already emits `ProgramPoint.relational`, filtered to constraints **not implied by the unary intervals**. Those carry information at **4,749 of 23,772 points (19.98%)** across 197 of 851 functions.

The octagon is exact for two-variable constraints, so polyhedra can only exceed it where **three or more locals are mutually constrained**:

| | |
|---|---|
| points with ≥3 mutually-constrained locals | **2,512 (10.57%)** in 83 functions |
| constraint form | Diff 24,321 / Sum 4,053 |

The Sum share means the octagon's non-difference power is genuinely in use — these are not degenerate difference bounds.

## I expected to add `depends-on FEAT-095` and let the ordering gate fire

The measurement says not to.

2,165 of the 2,512 wide points sit in functions that degrade *somewhere* — which reads exactly like FEAT-069's "92.5% of unproven obligations in degraded functions" and is a **different claim**. Gaps are per-pc, and write-set havoc widens only the locals a region writes, so a wide point can sit nowhere near a gap.

Measured directly: **only 13 of 2,512** wide points have a gap at or before them.

So FEAT-057 is not coverage-gated, no link was added, and the gate correctly stays green. Manufacturing the dependency to exercise my own gate would have been backwards.

## Both bounds run in the direction you might not expect

- **"≥3 mutually constrained locals" is opportunity, not realized gain.** Polyhedra beats the octagon only where the true invariant is a general linear inequality the pairwise closure cannot express. 2,512 bounds the ceiling from **above**; it does not show any point would in fact improve.
- **"No gap at or before it" is an UPPER bound on unaffected points**, not a lower one. Program order is not dataflow order — a gap inside a loop reaches earlier pcs through the back edge.

## A vacuous proxy was caught and removed rather than reported

Sizing the loop caveat by counting functions where the fixpoint revisited a pc printed **"0 functions"** — and the vacuity check built into it reported **zero duplicate `(func, pc)` pairs**. `ProgramPoint` is one per pc, so the proxy could only ever return zero. Publishing "0 functions with loops" would have been this repo's dominant documented failure class.

The loop-induced shortfall is left **unquantified**, which is the honest state. Sizing it needs the operator stream (back edges), which this harness does not have.

## Why the harness is committed

Narrow reason: its numbers are cited on FEAT-057 to justify a scheduling decision, and a bare number in an artifact is the drift hazard that left *"the dev REQ-\* carry no verifies link by construction"* checked in and false for months (#198). **Re-run it after FEAT-095 lands** — the docstring says so.

```
cargo run --release -p scry-sai-core --example poly_surface -- <module.wasm>
```

## What this does not establish

The **size** of the win — only that the surface exists. Slice 2 remains a multi-slice arc mirroring the octagon's v1.7–v1.9: a `Poly` on `FuncCtx` threaded in lockstep with the octagon, wrap-aware transfers gated on the interval domain's no-wrap result, guard refinement, and `Poly::project`.

Refs: FEAT-057

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc