### PR TITLE
Declare `residual` in a local schema so a typo stops reading as the real field

### DIFF
--- a/rivet.yaml
+++ b/rivet.yaml
@@ -16,6 +16,7 @@ project:
     - dev
     - research
     - research-ext     # local — adds references-paper / addresses-finding / evaluates-tech
+    - dev-ext          # local — declares `residual` on feature (scry#197)
     - safety-case
     - aspice
 

--- a/schemas/dev-ext.yaml
+++ b/schemas/dev-ext.yaml
@@ -1,0 +1,58 @@
+# Local extension to the built-in `dev` schema.
+#
+# Declares ONE field: `residual` on `feature`.
+#
+# WHY. `residual` is where this repo puts every honesty disclosure — what a
+# feature does NOT do, what was measured and found wanting, what an assessor
+# must not conclude from a green. FEAT-091's trailer limits, FEAT-093's
+# ruleset-reset gap, FEAT-096's undetected asymmetric case, FEAT-097's four
+# vacuous 100%s all live in it. The `dev` schema does not declare it, so all
+# 18 uses were reported as possibly-a-typo (scry#197). Measured: INFO
+# diagnostics drop 32 -> 14 with this schema; WARN is unchanged at 188, so it
+# removes exactly these and nothing else.
+#
+# THE POINT IS NOT THE 17 SUPPRESSED INFOs. It is that an UNDECLARED field
+# makes a TYPO INDISTINGUISHABLE FROM THE CORRECT SPELLING. Measured on an
+# isolated probe with three artifacts — `residual`, `residuals`,
+# `residual_notes`:
+#
+#   without this schema : all THREE reported identically
+#   with this schema    : only the two typos reported
+#
+# A misspelled disclosure is silently a different field, i.e. silently absent,
+# which is the exact failure mode `residual` exists to prevent.
+#
+# DELIBERATELY NOT `required: true`, even for `status: accepted`. A required
+# field is satisfiable with the word "none", so it would gate on the presence
+# of a string rather than on disclosure — a checkbox that reads as rigour and
+# enforces nothing, which is this repo's documented dominant failure class.
+# FEAT-088's rule 2 shape (declared AND justified) is what would be worth
+# having, and it is not expressible as a schema field constraint.
+#
+# Field merge behaviour, VERIFIED before writing this (not assumed): naming an
+# existing artifact-type here MERGES fields rather than replacing them —
+# `rivet schema show feature` afterwards lists phase, acceptance-criteria,
+# baseline AND residual. Confirmed in both directions on an isolated project:
+# disabling this schema brings the INFO back, enabling it removes it.
+
+schema:
+  name: dev-ext
+  version: "0.1.0"
+  namespace: "http://pulseengine.dev/ns/dev-ext#"
+  extends: [dev, common]
+  description: >
+    Local extension to `dev` declaring the `residual` honesty-disclosure
+    field on `feature`, so a misspelling is distinguishable from the
+    correct spelling.
+
+artifact-types:
+  - name: feature
+    description: A user-visible capability or feature
+    fields:
+      - name: residual
+        type: string
+        required: false
+        description: >
+          What this feature does NOT do, and what an assessor must not
+          conclude from it being green. Optional by design — see the file
+          header for why it is not required.


### PR DESCRIPTION
`residual` is where this repo puts **every honesty disclosure** — what a feature does not do, what an assessor must not conclude from a green. FEAT-091's trailer limits, FEAT-093's ruleset-reset gap, FEAT-096's undetected asymmetric case, FEAT-097's four vacuous 100%s all live in it.

The `dev` schema never declared it, so all 18 uses were reported as possibly-a-typo (#197).

## The point is not the suppressed diagnostics

An undeclared field makes a **typo indistinguishable from the correct spelling**. Measured on an isolated probe carrying three artifacts — `residual`, `residuals`, `residual_notes`:

| | reported |
|---|---|
| without this schema | **all three**, identically |
| with this schema | only the two typos |

A misspelled disclosure is silently a different field — i.e. silently absent — which is precisely the failure `residual` exists to prevent.

## Field merge verified, not assumed

#197 flagged the open question: does naming an existing `artifact-type` in a local schema **add** to it or **replace** it? Replacing would drop `acceptance-criteria` from every feature in the repo.

Probed on an isolated project: **it merges.** `rivet schema show feature` afterwards lists `phase`, `acceptance-criteria`, `baseline` **and** `residual`. Controlled both directions — disabling the schema brings the INFO back, enabling it removes it.

On this repo: **INFO 32 → 14, WARN unchanged at 188.** It removes exactly these diagnostics and nothing else.

## Deliberately not `required: true`

Even for `status: accepted`. A required field is satisfiable with the word `"none"`, so it would gate on the *presence of a string* rather than on disclosure — a checkbox that reads as rigour and enforces nothing, which is this repo's documented dominant failure class. FEAT-088's rule 2 shape (declared **and** justified) is what would be worth having, and it is not expressible as a field constraint.

## Unrelated, pre-existing, and being investigated separately

`rivet schema validate` reports two errors on the **safety-case** preset:

```
ERROR: rule 'goal-has-support': required-backlink 'supported-by' not a known link type
ERROR: rule 'goal-has-context': required-backlink 'scoped-by'  not a known link type
```

Verified identical with this schema disabled, so not introduced here. Noting it because those are **the two rules sitting at 40%** — the ones the standing brief points at.

Refs: FEAT-088 · scry#197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc