### PR TITLE
scry#195: resolve all three release-ordering inversions — v3.3.0 is cuttable

### DIFF
--- a/artifacts/roadmap-3.0.yaml
+++ b/artifacts/roadmap-3.0.yaml
@@ -210,7 +210,7 @@ artifacts:
     type: requirement
     title: "An AI agent can CITE a scry obligation: stable identity that survives the edit"
     status: proposed
-    release: v3.3.0
+    release: v3.4.0
     description: >
       REQ-018 shipped ranked, honesty-classed advisories each carrying a
       VERIFICATION ORACLE — but as PROSE ("re-run scry: this trap_check becomes
@@ -1169,9 +1169,9 @@ artifacts:
 
   - id: FEAT-064
     type: feature
-    title: "v3.3 — Stable obligation identity (survives the edit)"
+    title: "v3.4 — Stable obligation identity (survives the edit)"
     status: proposed
-    release: v3.3.0
+    release: v3.4.0
     description: >
       Replace raw `(func_index, pc)` as the EXTERNAL key for every finding with a
       content-addressed obligation ID (DD-020). Composed of: function identity
@@ -1387,9 +1387,9 @@ artifacts:
 
   - id: FEAT-069
     type: feature
-    title: "v3.3 — safe-accesses.json: proven-safe sites for bounds-check elision"
+    title: "v3.5 — safe-accesses.json: proven-safe sites for bounds-check elision"
     status: proposed
-    release: v3.3.0
+    release: v3.5.0
     description: >
       Export the PROVEN-SAFE OutOfBounds verdicts scry already computes as a flat,
       engine-agnostic list keyed on the wasmparser operator index — the channel

--- a/tools/check-release-ordering.py
+++ b/tools/check-release-ordering.py
@@ -41,9 +41,18 @@ except ImportError:
 
 # (dependent, dependency) pairs that are KNOWN and RECORDED. Each needs a reason.
 KNOWN = {
-    ("FEAT-064", "FEAT-077"): "scry#187 — FEAT-064's AC1 was falsified and repaired in v3.4.0; the plan did not follow the discovery",
-    ("FEAT-064", "FEAT-087"): "scry#187 — same repair, second identity bit",
-    ("FEAT-069", "FEAT-095"): "the OOB proven rate is blocked on region-havoc coverage, measured at 92.5% of unproven obligations",
+    # EMPTY, and that is the point. Three inversions were recorded here from
+    # 2026-08-28 to 2026-09-01. They were resolved on 2026-09-01 by moving the
+    # artifacts rather than by deleting the entries: FEAT-064 and REQ-020 to
+    # v3.4.0 (where FEAT-077 and FEAT-087, the repairs that make them
+    # satisfiable, had already shipped), and FEAT-069 to v3.5.0 (beside
+    # FEAT-095, its measured blocker). See scry#195.
+    #
+    # The gate FAILS on an entry that no longer describes a real inversion, so
+    # emptying this is not a suppression -- it is the record that the condition
+    # is gone. Verified in that order: with the entries removed and the
+    # releases UNCHANGED the gate failed on all three; after the moves it
+    # passes with none.
 }
 
 


### PR DESCRIPTION
Decision taken on #195. The plan moves to match what the work discovered, rather than the work being held to a plan the work falsified.

| artifact | move | why |
|---|---|---|
| FEAT-064 | v3.3.0 → **v3.4.0** | FEAT-077 + FEAT-087, the repairs that make it satisfiable, **already shipped** there |
| REQ-020 | v3.3.0 → **v3.4.0** | follows FEAT-064 |
| FEAT-069 | v3.3.0 → **v3.5.0** | beside FEAT-095, its measured blocker |

## v3.3.0 is now 7 accepted / 0 proposed — cuttable

And what it ships is a coherent release rather than a remainder:

> `scry-mcp` tools · query filters · `guidance.json` · `br_if` guard refinement · capability manifest · obligation delta view · self-adjudication harness

That is *agent-consumable scry*.

## FEAT-069 was worse than #195 first recorded

FEAT-064's blockers had already shipped. **FEAT-069's blocker (FEAT-095) is unbuilt and scheduled two releases later** — so v3.3.0 was waiting on work that had not started. That asymmetry is why all three moved rather than just the identity pair.

## Done in the order that proves the allowlist was load-bearing

1. Removed the three `KNOWN` entries with the releases **unchanged** → gate **failed on all three** real inversions.
2. Then moved the artifacts → gate **passes with an empty allowlist**.

Emptying it is therefore the *record that the condition is gone*, not a suppression. The gate fails on a stale entry precisely so this sequence means something.

## Also fixed: drift I would otherwise have introduced

FEAT-064 and FEAT-069 still read `"v3.3 — …"` in their titles while living in v3.4.0/v3.5.0. Realigned, then checked **every** artifact for the same mismatch — **0 remain**.

## What this does not do

**Moving FEAT-064 does not make it satisfiable.** Its AC1 is falsified in practice (43–45% identity churn, #123) and still needs re-measuring against the FEAT-077/087 repairs. This removes an *ordering* problem, not a *verification* one — and v3.4.0 is not cuttable either (6 proposed).

## One property is lost, and it is worth stating

With `KNOWN` empty, the allowlist no longer doubles as a **live regression test of the detection logic against real artifacts** — the property that made inverting the comparison operator turn the gate red. The 13-case synthetic self-test still covers it, including stale-entry detection, but the live-data check is gone until some future inversion is recorded. A real, if minor, cost of resolving them.

## Not cutting the tag

v3.3.0 being *cuttable* is a fact about the board, not authorisation to publish.

Closes #195. Refs: FEAT-096

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc