### PR TITLE
CI: move every job to the org self-hosted fleet — scry was the last holdout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,24 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# RUNNERS: every job here targets the pulseengine self-hosted fleet
+# ([self-hosted, linux, x64, light|rust-cpu]), matching rivet / witness / meld.
+# scry was the last repo still on GitHub-hosted `ubuntu-latest`, and on
+# 2026-09-02 that cost it 85 minutes of a completely unstarted queue (0 of 13
+# jobs began, across a cancel + re-run) while 5 runners in the org fleet sat
+# idle. `light` = checks that do no heavy Rust compile; `rust-cpu` = anything
+# that builds or proves.
+#
+# THE RISK THIS CARRIES, stated so a failure is diagnosed rather than
+# re-discovered: `bazel-build` and `test` install Nix via
+# cachix/install-nix-action, because Bazel resolves @rocq_toolchains through
+# rules_nixpkgs and fails with "nix-build not found in PATH" without it. That
+# install needs to work on a self-hosted runner too. If those two jobs fail on
+# a Nix step, the runner class is the cause and the fix is the runner, not the
+# build.
+#
+# Job NAMES are unchanged, so all 12 required contexts (scry#130) keep
+# reporting — `runs-on` does not affect a check's context name.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -69,7 +87,7 @@ jobs:
 
   fmt:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -80,7 +98,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -134,7 +152,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
@@ -239,7 +257,7 @@ jobs:
 
   rivet-validate:
     name: Rivet artifact validation
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -307,7 +325,7 @@ jobs:
   # 1/257) that no pull request can satisfy.
   commit-traceability:
     name: Commit traceability (rivet)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -335,7 +353,7 @@ jobs:
   # open PR.
   required-checks-drift:
     name: Required checks track CI jobs (scry#130)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     permissions:
       contents: read
     steps:
@@ -367,7 +385,7 @@ jobs:
   # so the status section can't silently rot ~40 versions again (issue #97).
   claim-check:
     name: Doc claims (claim-check)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
@@ -380,7 +398,7 @@ jobs:
 
   spar-parse:
     name: AADL model (spar parse)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -395,7 +413,7 @@ jobs:
 
   wit-validate:
     name: WIT round-trip (wasm-tools)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -416,7 +434,7 @@ jobs:
 
   bazel-build:
     name: Bazel build (//:scry)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -487,7 +505,7 @@ jobs:
 
   deny:
     name: cargo-deny (licenses, advisories, bans)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -499,7 +517,7 @@ jobs:
 
   mcdc:
     name: MC/DC (witness)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 30
     # FEAT-014 rollout: the witness MC/DC pipeline runs on every change over
     # the REAL analyzer core (crates/scry-analyze-core, driven by

--- a/.github/workflows/publish-to-crates-io.yml
+++ b/.github/workflows/publish-to-crates-io.yml
@@ -42,7 +42,7 @@ jobs:
   publish:
     name: Publish workspace libraries
     if: github.repository == 'pulseengine/scry'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
   release:
     name: Build, sign, and release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 40
     steps:
 
@@ -252,7 +252,7 @@ jobs:
   mcdc-evidence:
     name: MC/DC evidence bundle
     needs: [release]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     permissions:
       contents: write
     env:
@@ -341,7 +341,7 @@ jobs:
   publish-pages:
     name: Publish verification dashboard to GitHub Pages
     needs: [release]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     timeout-minutes: 30
     environment:
       name: github-pages

--- a/.github/workflows/rivet-delta.yml
+++ b/.github/workflows/rivet-delta.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   delta:
     name: Rivet artifact delta
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/rocq-proofs.yml
+++ b/.github/workflows/rocq-proofs.yml
@@ -36,9 +36,13 @@ jobs:
 
   rocq-proofs:
     name: Rocq Formal Proofs
-    # Stays on ubuntu-latest: requires Nix + Bazel for the hermetic
-    # Rocq 9.0 toolchain. Matches loom's runner choice.
-    runs-on: ubuntu-latest
+    # WAS ubuntu-latest, "requires Nix + Bazel for the hermetic Rocq 9.0
+    # toolchain, matches loom's runner choice". Moved to the org fleet with
+    # every other scry job (see ci.yml's header): the Nix + Bazel requirement
+    # is satisfied by the install steps BELOW, not by the runner image, so it
+    # was never a reason to stay hosted. This job is `continue-on-error`, so
+    # it is also the cheapest place to find out if that reading is wrong.
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     # Informational at v0.2 (FEAT-012). Flips to required at v1.0
     # alongside FEAT-011's six-domain credit dossier.
     continue-on-error: true

--- a/.github/workflows/verus-proofs.yml
+++ b/.github/workflows/verus-proofs.yml
@@ -41,7 +41,7 @@ jobs:
 
   verus-proofs:
     name: Verus Formal Proofs
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     # Informational at v0.2 (FEAT-012); flips to required at v1.0.
     continue-on-error: true
     timeout-minutes: 30


### PR DESCRIPTION
On 2026-09-02 a PR sat **85 minutes with 0 of 13 jobs started**, surviving a full cancel + re-run, while **5 runners in the pulseengine fleet sat idle**. This is not contention:

| | |
|---|---|
| scry | **19 of 19** jobs on GitHub-hosted `ubuntu-latest` |
| rivet / witness / meld | heavy jobs already on `[self-hosted, linux, x64, light\|rust-cpu]` |
| org fleet | 12 runners, **all online**, 7 busy / **5 idle** |

The org migrated to a Hetzner self-hosted fleet and scry never followed, so it is the one repo fully exposed when hosted capacity doesn't materialise. rivet even ships a job named *"Traceability (hosted fallback)"* — that is what engineering around this failure mode looks like.

## Mapping (mirrors rivet's ci.yml)

**`light`** — no heavy Rust compile: Format · WIT round-trip · AADL (spar) · claim-check · Required-checks · Rivet validate / delta / traceability · Pages

**`rust-cpu`** — builds or proves: Clippy · Test · Bazel build · cargo-deny · MC/DC · Rocq · Verus · Publish · Release · MC/DC evidence

## Required contexts are unaffected

Job **names** are unchanged, and `runs-on` does not affect a check's context name. Verified rather than assumed — `check-required-checks.py --against-file`: **12 contexts, 13 jobs, PASS**.

## Corrected a comment this change falsified

`rocq-proofs.yml` said:

> *"Stays on ubuntu-latest: requires Nix + Bazel for the hermetic Rocq 9.0 toolchain."*

The Nix and Bazel requirement is satisfied by the **install steps in that job**, not by the runner image — so it was never a reason to stay hosted. Leaving it would have been the same drift as the *"carry no verifies link by construction"* line repaired in #198.

## The risk, recorded rather than discovered

`bazel-build` and `test` install Nix via `cachix/install-nix-action`, because Bazel resolves `@rocq_toolchains` through `rules_nixpkgs` and fails with `"nix-build not found in PATH"` without it. **That install has to work on self-hosted too.**

`ci.yml`'s header now says so, so a failure on a Nix step points at the runner class rather than sending someone into the build. Rocq and Verus are `continue-on-error`, making them the cheapest early signal.

This PR is its own test: if the jobs start, the diagnosis was right.

Refs: FEAT-093

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc