### PR TITLE
release: v3.3.0 — bump workspace + inter-crate pins, CHANGELOG, README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,83 @@ Versioning: [SemVer 2.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.3.0] — 2026-09-03
+
+**Agent-consumable scry.** Every feature here exists so a machine, not a
+person, can consume a scry verdict: an MCP server, a query surface, a
+versioned feed schema, a capability manifest as data, and citable obligation
+anchors. The one precision fix (`br_if` on a bare value) is here because it is
+what LLVM emits for the loops agents actually ask about.
+
+### Added
+
+- **`scry-sai-mcp` — an MCP server exposing scry to agents directly** (FEAT-066).
+  Agents cannot run `cargo`; consuming scry meant shelling out or scraping a
+  5.7 MB JSON. Tools: `analyze` (module → summary + counts) and `query`
+  (FEAT-067 filters). Structured results, never HTML. **This is a NEW crate and
+  its first publish** — v3.2.7's tree contained no `crates/scry-mcp`.
+- **Query filters over `AnalysisResult`** (FEAT-067). Ask instead of scrape:
+  "every site where kind=Top and op in (call_indirect, memory.grow)". The
+  bounded slice of the FEAT-056 queryable-CPG idea — filtering and projection
+  over the existing result, no new graph substrate.
+- **`guidance.json` as a versioned contract** (FEAT-068). The v3.2.2 feed
+  shipped un-versioned; it now carries an explicit `schema` field, per-class
+  counts, and the module hash binding the feed to one exact module.
+- **A machine-readable capability manifest** (FEAT-071). The dashboard stated
+  scry's scope in prose — what is mechanized vs γ-sweep-validated, and what
+  scry does NOT prove. An agent deciding whether to trust a verdict needs that
+  as data. Rendered from the same constants as the page, so the two cannot
+  drift.
+- **Obligation anchors and the delta view** (FEAT-072). Every obligation in the
+  rendered page carries `id="ob-<obligation_id>"` and a copyable deep link, so
+  a verdict can be cited rather than described.
+- **Self-adjudication harness** (FEAT-073). scry adjudicates scry across N
+  consecutive commits of its own history, in observation mode. Purpose is
+  evidence, not gating — and it earned its keep immediately by finding the
+  identity churn recorded below.
+
+### Improved
+
+- **Guard refinement for `br_if` on a bare value** (FEAT-070). Refinement
+  already handled `local.get X; i32.const c; <cmp>; br_if` and `i32.eqz`, but
+  not `local.tee $x; br_if` — a branch on raw truthiness (implicit `≠ 0`),
+  which is what LLVM emits for count-to-zero loops and therefore common in real
+  bounds-check code.
+
+### What this release does NOT give you
+
+Stated here rather than left to be discovered:
+
+- **Obligation identity is NOT yet stable across builds.** FEAT-073's first run
+  measured **43–45% of function identities churning per build** (#123):
+  `func_ident` inherits Rust's `17h<hex>` symbol disambiguator, so an unrelated
+  edit destroys every obligation in the affected function. The anchors and the
+  feed schema ship; the guarantee behind them does not. FEAT-064 and REQ-020
+  moved to v3.4.0 for exactly this reason (#195) — cross-build citation is not
+  yet reliable, and a consumer should treat an `obligation_id` as stable
+  *within* a build only.
+- **The MCP `verify` tool is structurally absent.** FEAT-065 adjudication was
+  refuted pre-ship with six wrong-verdict paths (#122); exposing it would ship a
+  verdict not worth acting on. Tracked as FEAT-094, gated on REQ-021.
+
+### Falsification
+
+This release is wrong if any of the following holds:
+
+1. A module that analysed successfully under 3.2.7 now returns an error, or a
+   different verdict set, from `analyze`.
+2. An `obligation_id` cited from the dashboard does not resolve to the same site
+   when the *same* module is re-analysed by the same build.
+3. The MCP server returns a summary whose counts disagree with the
+   `AnalysisResult` the same build produces for the same module.
+4. `guidance.json` validates against its declared `schema` version while
+   carrying a field that version does not define.
+
+Limitation of (1), stated because it is the weakest of the four: the
+before/after comparison is not corpus-wide. A consumer with a module set —
+#126's reporter has offered theirs — would falsify it properly.
+
+
 ## [3.2.7] — 2026-08-27
 
 Two fixes. Both were found by looking at what the project actually did rather

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scry-host-tests"
-version = "3.2.7"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1785,18 +1785,18 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-analyzer"
-version = "3.2.7"
+version = "3.3.0"
 dependencies = [
  "scry-sai-core",
 ]
 
 [[package]]
 name = "scry-sai-bits"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-core"
-version = "3.2.7"
+version = "3.3.0"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-float",
@@ -1815,19 +1815,19 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-float"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-handle"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-interval"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-lattice"
-version = "3.2.7"
+version = "3.3.0"
 dependencies = [
  "bitflags",
  "scry-sai-octagon",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-mcp"
-version = "3.2.7"
+version = "3.3.0"
 dependencies = [
  "scry-sai-core",
  "serde_json",
@@ -1845,34 +1845,34 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-octagon"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-pentagon"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-poly"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-segment"
-version = "3.2.7"
+version = "3.3.0"
 dependencies = [
  "scry-sai-interval",
 ]
 
 [[package]]
 name = "scry-sai-taint"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-viz"
-version = "3.2.7"
+version = "3.3.0"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ default-members = [
 # on crates.io matches the release artifacts. The crates.io publish workflow
 # asserts the pushed `v*` tag equals this version, so a release bump must move
 # both in lockstep (and the internal path-dep `version = "..."` fields below).
-version = "3.2.7"
+version = "3.3.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pulseengine/scry"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ deductive-proof and bounded-model-checking layers do not staff.
 <!-- claim id=version: "scry-sai-core" crates.io max_version == workspace version -->
 <!-- claim id=crates: publish.rs lists 13 scry-sai-* crates -->
 <!-- claim id=admit-free: 0 Admitted/admit/Axiom across proofs/rocq/*.v -->
-**v3.2.7 shipped** — the full v0.1 → v3.2 arc is done; scry is a working **sound
+**v3.3.0 shipped** — the full v0.1 → v3.3 arc is done; scry is a working **sound
 abstract interpreter**, not a scaffold. Shipped and on crates.io: **13 pure
 `scry-sai-*` crates** (10 abstract domains — interval, region-memory, call-graph
 + reachability, octagon, pentagon, known-bits/congruence, IEEE-754 float,

--- a/claims.yaml
+++ b/claims.yaml
@@ -21,10 +21,10 @@ claims:
   # Cargo.toml + this pattern together — exactly the point.)
   - id: STATUS-VERSION
     doc: README.md
-    text: "**v3.2.7 shipped**"
+    text: "**v3.3.0 shipped**"
     evidence:
       - kind: count-min
-        pattern: 'version = "3\.2\.7"'
+        pattern: 'version = "3\.3\.0"'
         glob: ['Cargo.toml']
         min: 1
 
@@ -36,10 +36,10 @@ claims:
   # Cargo.toml), so it is pinned to the workspace version here instead.
   - id: BAZEL-VERSION-PIN
     doc: crates/scry-analyze-core/BUILD.bazel
-    text: 'version = "3.2.7",'
+    text: 'version = "3.3.0",'
     evidence:
       - kind: count-min
-        pattern: 'version = "3\.2\.7"'
+        pattern: 'version = "3\.3\.0"'
         glob: ['Cargo.toml']
         min: 1
       # And the default must never come back.

--- a/crates/scry-analyze-core/BUILD.bazel
+++ b/crates/scry-analyze-core/BUILD.bazel
@@ -28,7 +28,7 @@ rust_library(
     # literal to the workspace version, and claim-check goes red if they part.
     # A number that must be maintained by hand is acceptable only when
     # something mechanical notices when it is not.
-    version = "3.2.7",
+    version = "3.3.0",
     visibility = ["//visibility:public"],
     tags = ["feat-014"],
     deps = [

--- a/crates/scry-analyze-core/Cargo.toml
+++ b/crates/scry-analyze-core/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # Path deps carry `version` so `cargo publish` rewrites them to the crates.io
 # coordinate (crates.io rejects path-only deps). The version equals the
 # workspace version and must be bumped in lockstep with it.
-scry-sai-interval = { path = "../scry-interval", version = "3.2.7" }
+scry-sai-interval = { path = "../scry-interval", version = "3.3.0" }
 
 # Step 2 (DD-012): the analyze body + helpers moved here. wasmparser parses
 # the input Wasm Core Model module; sha2 digests the module bytes for
@@ -43,51 +43,51 @@ sha2 = { workspace = true }
 
 # Security-label (taint) lattice for the noninterference analysis (FEAT-009)
 # and the pure meld<->scry provenance boundary crate (FEAT-002 / DD-002).
-scry-sai-taint = { path = "../scry-taint", version = "3.2.7" }
-scry-sai-provenance = { path = "../scry-provenance", version = "3.2.7" }
+scry-sai-taint = { path = "../scry-taint", version = "3.3.0" }
+scry-sai-provenance = { path = "../scry-provenance", version = "3.3.0" }
 
 # Octagon relational domain (FEAT-016 slice-2b-ii): carried alongside the
 # intervals through the structured-CFG fixpoint so a loop counter bounded by a
 # VARIABLE relation (`i < n`) stays bounded where the interval domain alone
 # widens it to ⊤. Same pure `#![no_std]` dual-compile crate as scry-interval.
-scry-sai-octagon = { path = "../scry-octagon", version = "3.2.7" }
+scry-sai-octagon = { path = "../scry-octagon", version = "3.3.0" }
 
 # Known-bits × interval-guarded congruence reduced product (FEAT-037 / DD-017):
 # an additive bit/alignment/stride companion computed in a straight-line-sound
 # pass, surfaced library-only on `AnalysisResult.bit_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-bits = { path = "../scry-bits", version = "3.2.7" }
+scry-sai-bits = { path = "../scry-bits", version = "3.3.0" }
 
 # Pentagons weakly-relational domain (FEAT-044 / AC-014): intervals + strict
 # `x < y` facts, the cheap relational layer behind sound out-of-bounds-trap
 # detection (FEAT-046). An additive guard-recording pass surfaces proven
 # strict relations library-only on `AnalysisResult.pentagon_facts`. Same pure
 # `#![no_std]` dual-compile crate as the other domains.
-scry-sai-pentagon = { path = "../scry-pentagon", version = "3.2.7" }
+scry-sai-pentagon = { path = "../scry-pentagon", version = "3.3.0" }
 
 # IEEE-754 float-interval domain (FEAT-047 / AC-022): sound f32/f64 abstraction
 # with NaN/±inf tracking + round-to-nearest-aware widening. An additive
 # straight-line pass surfaces sound float intervals library-only on
 # `AnalysisResult.float_facts`. Same pure `#![no_std]` dual-compile crate.
-scry-sai-float = { path = "../scry-float", version = "3.2.7" }
+scry-sai-float = { path = "../scry-float", version = "3.3.0" }
 
 # Affine Component-Model handle-state lattice (FEAT-049 / MF-007): tracks
 # own/borrow resource-handle state to flag use-after-drop / double-drop. A
 # straight-line pass over the canonical-ABI `[resource-drop]` call sites
 # surfaces findings library-only on `AnalysisResult.handle_findings`.
-scry-sai-handle = { path = "../scry-handle", version = "3.2.7" }
+scry-sai-handle = { path = "../scry-handle", version = "3.3.0" }
 
 # FEAT-058: the linear-memory segmentation domain (content-sensitive memory).
 # The interpreter tracks per-offset interval content for i32 loads/stores
 # instead of degrading every load to ⊤.
-scry-sai-segment = { path = "../scry-segment", version = "3.2.7" }
+scry-sai-segment = { path = "../scry-segment", version = "3.3.0" }
 
 # FEAT-057 slice 2a: convex-polyhedra domain (general-coefficient linear
 # inequalities above the octagon), carried on FuncCtx in LOCKSTEP with the
 # octagon/segmentation through the structured-CFG fixpoint. Assignment
 # equalities are gated on the interval domain's no-wrap proof (i32_add/i32_sub
 # ≠ ⊤); anything unproven projects (FM-forgets) the assigned variable.
-scry-sai-poly = { path = "../scry-poly", version = "3.2.7" }
+scry-sai-poly = { path = "../scry-poly", version = "3.3.0" }
 
 [dev-dependencies]
 # Test-only (the crate is otherwise dep-light + no_std): assemble the .wat

--- a/crates/scry-mcdc/Cargo.lock
+++ b/crates/scry-mcdc/Cargo.lock
@@ -77,11 +77,11 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-bits"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-core"
-version = "3.2.7"
+version = "3.3.0"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-float",
@@ -99,42 +99,42 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-float"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-handle"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-interval"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-octagon"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-pentagon"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-poly"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "scry-sai-segment"
-version = "3.2.7"
+version = "3.3.0"
 dependencies = [
  "scry-sai-interval",
 ]
 
 [[package]]
 name = "scry-sai-taint"
-version = "3.2.7"
+version = "3.3.0"
 
 [[package]]
 name = "sha2"

--- a/crates/scry-mcp/Cargo.toml
+++ b/crates/scry-mcp/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 # The analyzer library — same single-dependency pattern as scry-viz: a plain
 # `std` host tool consuming the published `AnalysisResult` plain-Rust types.
-scry-sai-core = { path = "../scry-analyze-core", version = "3.2.7" }
+scry-sai-core = { path = "../scry-analyze-core", version = "3.3.0" }
 # Hand-rolled JSON-RPC 2.0 (DELIBERATE — no MCP SDK dependency): MCP's stdio
 # transport is newline-delimited JSON-RPC and the server needs exactly three
 # methods (initialize / tools/list / tools/call). serde_json covers that; an

--- a/crates/scry-segment/Cargo.toml
+++ b/crates/scry-segment/Cargo.toml
@@ -20,4 +20,4 @@ path = "src/lib.rs"
 # The per-segment content domain. Path dep carries `version` so `cargo publish`
 # rewrites it to the crates.io coordinate; the version equals the workspace
 # version and is bumped in lockstep.
-scry-sai-interval = { path = "../scry-interval", version = "3.2.7" }
+scry-sai-interval = { path = "../scry-interval", version = "3.3.0" }

--- a/crates/scry-viz/Cargo.toml
+++ b/crates/scry-viz/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The only dependency: the published analyzer library. scry-viz is a plain
 # `std` host tool, so it can read the `AnalysisResult` plain-Rust types and
 # render them — no WIT, no component, no wasmtime.
-scry-sai-core = { path = "../scry-analyze-core", version = "3.2.7" }
+scry-sai-core = { path = "../scry-analyze-core", version = "3.3.0" }
 # Assemble `.wat` inputs to module bytes (so the CLI accepts both .wat and
 # .wasm); host-only, same dep the test harness uses.
 wat = { workspace = true }


### PR DESCRIPTION
Release prep for **v3.3.0 — "agent-consumable scry"**. `rivet release status v3.3.0` = **cuttable**, 7 accepted / 0 proposed.

## The bump moves 19 sites as one commit

`cargo publish` resolves each leaf from the crates.io index, so a stale `version = "3.2.7"` pin would publish a 3.3.0 core depending on the previous release.

| count | site |
|---|---|
| 1 | workspace version |
| 13 | pinned inter-crate deps (analyze-core ×10, viz, segment, mcp) |
| 1 | Bazel `CARGO_PKG_VERSION` pin — #152, the one that shipped `scry 0.0.0` when missed |
| 1 | README shipped-claim |
| 3 | claims.yaml (2 texts + 2 patterns, minus overlap) |

## The claim-check gate did its job again, unprompted

My bump script failed partway through `claims.yaml` on a regex-escaping bug, leaving Cargo.toml and README moved but claims.yaml stale — and **claim-check immediately went 7/7 → 5/7**. That is exactly the drift it exists for, caught within one command of being introduced. Back to 7/7 after.

The **historical** `"what v3.2.7 did"` note in claims.yaml is deliberately not bumped (it refers to that release's shipped-`0.0.0` bug); a guard in the script asserts it survives.

## Two stale things the bump exposed, fixed rather than shipped

- README said *"the full v0.1 → v3.2 arc is done"* while announcing v3.3.0 — the same tense-of-a-claim drift repaired in #198.
- `crates/scry-mcdc/Cargo.lock` still pinned `scry-sai-core 3.2.7`, and the MC/DC gate builds `scry_mcdc.wasm` from it.

## What the CHANGELOG says this release does NOT give you

Both are things a consumer would otherwise assume:

- **Obligation identity is not stable across builds.** FEAT-073 measured **43–45% of function identities churning per build** (#123). The anchors and the feed schema ship; the guarantee behind them does not. Treat an `obligation_id` as stable *within* a build only. FEAT-064 and REQ-020 moved to v3.4.0 for exactly this reason (#195).
- **The MCP `verify` tool is structurally absent.** FEAT-065 was refuted pre-ship with six wrong-verdict paths (#122); exposing it would put a wrong verdict directly into an agent's tool loop.

## Falsification statement

Four criteria in the CHANGELOG, with **the weakest flagged as such**: the before/after comparison is not corpus-wide, and #126's reporter has offered theirs.

## Note for the release runner

`scry-sai-mcp` is a **first-time publish** — v3.2.7's tree contained no `crates/scry-mcp`. Already wired into `scripts/publish.rs` in leaf-after-core position.

And per FEAT-066's release-machinery note: **`cargo package` is not a valid pre-release check mid-cycle.** It fails for a correct tree, because crates.io's `scry-sai-core` predates the `Query` and `VerifyReport` APIs. A red there means nothing; the publish path handles ordering.

## Verified locally

`cargo test` 160 + 12 pass · fmt clean · `rivet validate` PASS · claim-check **7/7** · release-ordering PASS · required-checks PASS

Refs: FEAT-066

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkNzkNYzPh7366DkNijeNc